### PR TITLE
[WIP] Gebruik JPA entities

### DIFF
--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/entity/Bericht.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/entity/Bericht.java
@@ -3,7 +3,8 @@ package nl.b3p.brmo.loader.entity;
 import java.util.Date;
 
 /**
- *
+ * @deprecated gebruik de JPA versie
+ * @see nl.b3p.brmo.persistence.staging.Bericht
  * @author Boy de Wit
  */
 public class Bericht {

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/entity/LaadProces.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/entity/LaadProces.java
@@ -3,11 +3,11 @@ package nl.b3p.brmo.loader.entity;
 import java.util.Date;
 
 /**
- *
+ * @deprecated gebruik nl.b3p.brmo.persistence.staging.LaadProces
  * @author Boy de Wit
  */
 public class LaadProces {
-    
+
     private Long id;
     private String bestandNaam;
     private Date bestandDatum;
@@ -17,14 +17,14 @@ public class LaadProces {
     private LaadProces.STATUS status;
     private Date statusDatum;
     private String contactEmail;
-    
+
     public static enum STATUS {
         STAGING_OK, STAGING_NOK, ARCHIVE
     };
-    
-    public LaadProces() {        
+
+    public LaadProces() {
     }
-    
+
     public LaadProces(String bestandNaam, String soort) {
         this.bestandNaam = bestandNaam;
         this.soort = soort;

--- a/brmo-persistence/src/main/java/nl/b3p/brmo/persistence/staging/Bericht.java
+++ b/brmo-persistence/src/main/java/nl/b3p/brmo/persistence/staging/Bericht.java
@@ -8,6 +8,8 @@ import java.util.Date;
 import org.hibernate.annotations.ForeignKey;
 import org.hibernate.annotations.Type;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Lob;
@@ -46,7 +48,8 @@ public class Bericht implements Serializable {
     @Type(type = "org.hibernate.type.StringClobType")
     private String opmerking;
 
-    private String status;
+    @Enumerated(EnumType.STRING)
+    private STATUS status;
 
     @Temporal(TemporalType.TIMESTAMP)
     private Date status_datum;
@@ -66,6 +69,18 @@ public class Bericht implements Serializable {
     private String db_xml;
 
     private String xsl_version;
+
+    public static enum STATUS {
+        STAGING_OK, STAGING_NOK, RSGB_WAITING, RSGB_PROCESSING, RSGB_OK, RSGB_OUTDATED, RSGB_NOK, ARCHIVE
+    };
+
+    public Bericht() {
+
+    }
+
+    public Bericht(String br_xml) {
+        this.br_xml = br_xml;
+    }
 
     // <editor-fold defaultstate="collapsed" desc="getters and setters">
     public Long getId() {
@@ -124,11 +139,11 @@ public class Bericht implements Serializable {
         this.opmerking = opmerking;
     }
 
-    public String getStatus() {
+    public STATUS getStatus() {
         return status;
     }
 
-    public void setStatus(String status) {
+    public void setStatus(STATUS status) {
         this.status = status;
     }
 

--- a/brmo-persistence/src/main/java/nl/b3p/brmo/persistence/staging/Bericht.java
+++ b/brmo-persistence/src/main/java/nl/b3p/brmo/persistence/staging/Bericht.java
@@ -70,12 +70,25 @@ public class Bericht implements Serializable {
 
     private String xsl_version;
 
-    public static enum STATUS {
-        STAGING_OK, STAGING_NOK, RSGB_WAITING, RSGB_PROCESSING, RSGB_OK, RSGB_OUTDATED, RSGB_NOK, ARCHIVE
-    };
+    public enum STATUS {
+
+        STAGING_OK("STAGING_OK"),
+        STAGING_NOK("STAGING_NOK"),
+        RSGB_WAITING("RSGB_WAITING"),
+        RSGB_PROCESSING("RSGB_PROCESSING"),
+        RSGB_OK("RSGB_OK"),
+        RSGB_OUTDATED("RSGB_OUTDATED"),
+        RSGB_NOK("RSGB_NOK"),
+        ARCHIVE("ARCHIVE");
+
+        private String status;
+
+        STATUS(String status) {
+            this.status = status;
+        }
+    }
 
     public Bericht() {
-
     }
 
     public Bericht(String br_xml) {

--- a/brmo-persistence/src/main/java/nl/b3p/brmo/persistence/staging/LaadProces.java
+++ b/brmo-persistence/src/main/java/nl/b3p/brmo/persistence/staging/LaadProces.java
@@ -7,6 +7,8 @@ import java.io.Serializable;
 import java.util.Date;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Lob;
@@ -42,12 +44,26 @@ public class LaadProces implements Serializable {
     @Type(type = "org.hibernate.type.StringClobType")
     private String opmerking;
 
-    private String status;
+    @Enumerated(EnumType.STRING)
+    private STATUS status;
 
     @Temporal(TemporalType.TIMESTAMP)
     private Date status_datum;
 
     private String contact_email;
+
+    public static enum STATUS {
+
+        STAGING_OK, STAGING_NOK, ARCHIVE
+    };
+
+    public LaadProces() {
+    }
+
+    public LaadProces(String bestand_naam, String soort) {
+        this.bestand_naam = bestand_naam;
+        this.soort = soort;
+    }
 
     // <editor-fold defaultstate="collapsed" desc="getters and setters">
     public Long getId() {
@@ -98,11 +114,11 @@ public class LaadProces implements Serializable {
         this.opmerking = opmerking;
     }
 
-    public String getStatus() {
+    public STATUS getStatus() {
         return status;
     }
 
-    public void setStatus(String status) {
+    public void setStatus(STATUS status) {
         this.status = status;
     }
 

--- a/brmo-persistence/src/test/java/nl/b3p/brmo/persistence/staging/BerichtTest.java
+++ b/brmo-persistence/src/test/java/nl/b3p/brmo/persistence/staging/BerichtTest.java
@@ -17,6 +17,7 @@ public class BerichtTest extends TestUtil {
     @Test
     public void shouldStoreBericht() {
         Bericht b = new Bericht();
+        b.setStatus(Bericht.STATUS.RSGB_OK);
         entityManager.persist(b);
         entityManager.getTransaction().commit();
     }

--- a/brmo-persistence/src/test/java/nl/b3p/brmo/persistence/staging/BerichtTest.java
+++ b/brmo-persistence/src/test/java/nl/b3p/brmo/persistence/staging/BerichtTest.java
@@ -3,8 +3,19 @@
  */
 package nl.b3p.brmo.persistence.staging;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import javax.persistence.Query;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
 import nl.b3p.brmo.persistence.TestUtil;
+import org.junit.After;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 /**
@@ -15,15 +26,133 @@ import org.junit.Test;
 public class BerichtTest extends TestUtil {
 
     @Test
-    public void shouldStoreBericht() {
+    public void shouldStoreAndRemoveBericht() {
         Bericht b = new Bericht();
         b.setStatus(Bericht.STATUS.RSGB_OK);
         entityManager.persist(b);
+
+        assertTrue(b.getId() > 0);
+        entityManager.remove(b);
         entityManager.getTransaction().commit();
     }
 
+    /**
+     * test {@code select count(*) bericht}.
+     */
     @Test
-    public void shouldDeleteAllBericht() {
+    public void testCount() {
+        final int loopCount = 50;
+        for (int i = 0; i < loopCount; i++) {
+            Bericht b = new Bericht();
+            b.setStatus(Bericht.STATUS.RSGB_OK);
+            entityManager.persist(b);
+        }
+        entityManager.getTransaction().commit();
+
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Long> cq = cb.createQuery(Long.class);
+        cq.select(cb.count(cq.from(Bericht.class)));
+        long count = entityManager.createQuery(cq).getSingleResult();
+        assertEquals("verwacht 50 berichten te tellen.", loopCount, count);
+
+        // opruimen
+        entityManager.getTransaction().begin();
+        Query q = entityManager.createQuery("DELETE FROM Bericht");
+        count = q.executeUpdate();
+        entityManager.getTransaction().commit();
+        assertEquals("verwacht 50 berichten te verwijderen.", loopCount, count);
+    }
+
+    /**
+     * test {@code select from bericht b where b.status in (RSGB_OK, RSGB_NOK);}
+     */
+    @Test
+    public void testCountSubset() {
+        final int loopCount = 50;
+        for (int i = 0; i < loopCount; i++) {
+            Bericht b = new Bericht();
+            if (i % 2 == 0) {
+                b.setStatus(Bericht.STATUS.RSGB_OK);
+            } else {
+                b.setStatus(Bericht.STATUS.RSGB_WAITING);
+            }
+            entityManager.persist(b);
+        }
+        entityManager.getTransaction().commit();
+
+        CriteriaBuilder cb = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Bericht> cqB = cb.createQuery(Bericht.class);
+        Root<Bericht> bericht = cqB.from(Bericht.class);
+
+        List<Bericht.STATUS> ins = new ArrayList<Bericht.STATUS>();
+        ins.add(Bericht.STATUS.RSGB_OK);
+        Expression<String> exp = bericht.get("status");
+        Predicate predicate = exp.in(ins);
+        cqB.where(predicate);
+
+        CriteriaQuery<Long> cq = cb.createQuery(Long.class);
+        cq.select(cb.count(cq.from(Bericht.class)));
+        List<Bericht> results = entityManager.createQuery(cqB).getResultList();
+        long count = results.size();
+        assertEquals("verwacht 25 berichten te tellen in de resultatenlijst.", loopCount / 2, count);
+    }
+
+    /**
+     * test
+     * {@code select count(b) from bericht b where b.status in (RSGB_OK, RSGB_NOK) and b.soort in ('TEST');}.
+     */
+    @Test
+    public void testCountWhereIn() {
+        // 50 + 1 berichten maken en opslaan
+        final int loopCount = 50;
+        for (int i = 0; i < loopCount; i++) {
+            Bericht b = new Bericht();
+            if (i % 2 == 0) {
+                b.setStatus(Bericht.STATUS.RSGB_OK);
+                b.setSoort("TEST");
+            } else {
+                b.setStatus(Bericht.STATUS.RSGB_WAITING);
+                b.setSoort("TEST");
+            }
+            entityManager.persist(b);
+        }
+        Bericht b = new Bericht();
+        b.setStatus(Bericht.STATUS.RSGB_NOK);
+        b.setSoort("TEST");
+        entityManager.persist(b);
+        entityManager.getTransaction().commit();
+
+        CriteriaBuilder builder = entityManager.getCriteriaBuilder();
+        CriteriaQuery<Long> cq = builder.createQuery(Long.class);
+        Root<Bericht> from = cq.from(Bericht.class);
+
+        // status in... predicate
+        List<Bericht.STATUS> berichtStatussen = new ArrayList<Bericht.STATUS>();
+        berichtStatussen.add(Bericht.STATUS.RSGB_OK);
+        berichtStatussen.add(Bericht.STATUS.RSGB_NOK);
+        Expression<String> exp = from.get("status");
+        Predicate predicate = exp.in(berichtStatussen);
+
+        // soort in... predicate
+        List<String> berichtSoorten = Arrays.asList(new String[]{"TEST"});
+        Predicate predicate1 = from.get("soort").in(berichtSoorten);
+
+        Predicate[] p = {predicate, predicate1};
+        // cq.where(builder.and(p));
+
+        // select count...
+        CriteriaQuery<Long> select = cq.select(builder.count(from));
+        select.where(builder.and(p));
+
+        long count = entityManager.createQuery(select).getSingleResult();
+        assertEquals("verwacht 25+1 berichten te tellen.", loopCount / 2 + 1, count);
+    }
+
+    @After
+    public void cleanup() {
+        if (!entityManager.getTransaction().isActive()) {
+            entityManager.getTransaction().begin();
+        }
         Query q = entityManager.createQuery("DELETE FROM Bericht");
         int deleted = q.executeUpdate();
         entityManager.getTransaction().commit();

--- a/brmo-persistence/src/test/java/nl/b3p/brmo/persistence/staging/LaadProcesTest.java
+++ b/brmo-persistence/src/test/java/nl/b3p/brmo/persistence/staging/LaadProcesTest.java
@@ -5,6 +5,9 @@ package nl.b3p.brmo.persistence.staging;
 
 import javax.persistence.Query;
 import nl.b3p.brmo.persistence.TestUtil;
+import nl.b3p.brmo.persistence.staging.LaadProces.STATUS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 /**
@@ -17,12 +20,16 @@ public class LaadProcesTest extends TestUtil {
     @Test
     public void shouldStoreLaadProces() {
         LaadProces p = new LaadProces();
+        p.setStatus(LaadProces.STATUS.STAGING_OK);
         entityManager.persist(p);
+        assertTrue(p.getId() > 0);
+
         Bericht b = new Bericht();
         b.setLaadprocesid(p);
         entityManager.persist(b);
         entityManager.getTransaction().commit();
 
+        assertEquals("Verwacht dezelfde status", STATUS.STAGING_OK, p.getStatus());
     }
 
     @Test

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/BerichtenActionBean.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/BerichtenActionBean.java
@@ -1,8 +1,15 @@
 package nl.b3p.brmo.service.stripes;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
 import javax.servlet.http.HttpServletResponse;
-import javax.sql.DataSource;
 import net.sourceforge.stripes.action.ActionBean;
 import net.sourceforge.stripes.action.ActionBeanContext;
 import net.sourceforge.stripes.action.DefaultHandler;
@@ -10,14 +17,12 @@ import net.sourceforge.stripes.action.ForwardResolution;
 import net.sourceforge.stripes.action.Resolution;
 import net.sourceforge.stripes.action.StreamingResolution;
 import net.sourceforge.stripes.validation.Validate;
-import nl.b3p.brmo.loader.BrmoFramework;
-import nl.b3p.brmo.loader.entity.Bericht;
-import nl.b3p.brmo.loader.util.BrmoException;
-import nl.b3p.brmo.service.util.ConfigUtil;
+import nl.b3p.brmo.persistence.staging.Bericht;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.stripesstuff.stripersist.Stripersist;
 
 /**
  *
@@ -54,7 +59,113 @@ public class BerichtenActionBean implements ActionBean {
         return new ForwardResolution("/WEB-INF/jsp/bericht/list.jsp");
     }
 
-    public Resolution getGridData() throws BrmoException {
+    /**
+     * @todo naar de JPA opvolger van BrmoFramework of StagingProxy overbrengen.
+     * @param sort
+     * @param dir
+     * @param filterSoort
+     * @param filterStatus
+     * @return
+     */
+    private long getCountBerichten(String sort, String dir, String filterSoort, String filterStatus) {
+        // sort en dir worden genegeerd, net als in StagingProxy..
+        final EntityManager em = Stripersist.getEntityManager();
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<Long> cq = cb.createQuery(Long.class);
+        Root<Bericht> from = cq.from(Bericht.class);
+
+        List<Predicate> predicates = new ArrayList<Predicate>();
+        if(!filterSoort.isEmpty()) {
+            List<String> berichtSoorten = new ArrayList<String>();
+            // soort in ...
+            String[] soorten = filterSoort.split(",");
+            berichtSoorten.addAll(Arrays.asList(soorten));
+            Predicate predicate = from.get("soort").in(berichtSoorten);
+            predicates.add(predicate);
+        }
+
+        if(!filterStatus.isEmpty()) {
+            List<Bericht.STATUS> berichtStatussen = new ArrayList<Bericht.STATUS>();
+            // status in...
+            String[] statussen = filterStatus.split(",");
+            for (String s:statussen){
+                berichtStatussen.add(Bericht.STATUS.valueOf(s));
+            }
+            Predicate predicate = from.get("status").in(berichtStatussen);
+            predicates.add(predicate);
+        }
+
+        CriteriaQuery<Long> select = cq.select(cb.count(from));
+        select.where(cb.and(predicates.toArray(new Predicate[predicates.size()])));
+        return em.createQuery(select).getSingleResult();
+    }
+
+    /**
+     * @todo naar de JPA opvolger van BrmoFramework of StagingProxy overbrengen.
+     * @todo ge-dupliceerde code uit this#getCountBerichten uitfilteren
+     * @param page
+     * @param start
+     * @param limit
+     * @param sort
+     * @param dir
+     * @param filterSoort
+     * @param filterStatus
+     * @return
+     */
+    private List<Bericht> getBerichten(int page, int start, int limit, String sort, String dir, String filterSoort, String filterStatus){
+        // page word genegeerd, net als in StagingProxy#buildFilterSql
+        final EntityManager em = Stripersist.getEntityManager();
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<Bericht> cq = cb.createQuery(Bericht.class);
+        Root<Bericht> from = cq.from(Bericht.class);
+
+        // handle filterSoort
+        List<Predicate> predicates = new ArrayList<Predicate>();
+        if(!filterSoort.isEmpty()) {
+            List<String> berichtSoorten = new ArrayList<String>();
+            // soort in ...
+            String[] soorten = filterSoort.split(",");
+            berichtSoorten.addAll(Arrays.asList(soorten));
+            Predicate predicate = from.get("soort").in(berichtSoorten);
+            predicates.add(predicate);
+        }
+        // handle filterStatus
+        if(!filterStatus.isEmpty()) {
+            List<Bericht.STATUS> berichtStatussen = new ArrayList<Bericht.STATUS>();
+            // status in...
+            String[] statussen = filterStatus.split(",");
+            for (String s:statussen){
+                berichtStatussen.add(Bericht.STATUS.valueOf(s));
+            }
+            Predicate predicate = from.get("status").in(berichtStatussen);
+            predicates.add(predicate);
+        }
+        cq.where(cb.and(predicates.toArray(new Predicate[predicates.size()])));
+
+        // handle sort & dir
+        if(sort != null && dir != null){
+            if(dir.equalsIgnoreCase("ASC")){
+                cq.orderBy(cb.asc(from.get(sort)));
+            }else{
+                cq.orderBy(cb.desc(from.get(sort)));
+            }
+
+        }
+
+
+        TypedQuery<Bericht> q = em.createQuery(cq);
+
+        if(start > 0 ){
+            // handle start  & limit
+            q.setFirstResult(start);
+        }
+        if(limit > 0){
+            q.setMaxResults(limit);
+        }
+        return q.getResultList();
+    }
+
+    public Resolution getGridData() {
 
         // ophalen filters
         String filterSoort = "";
@@ -82,23 +193,14 @@ public class BerichtenActionBean implements ActionBean {
              }
         }
 
-        DataSource dataSourceStaging = ConfigUtil.getDataSourceStaging();
         long count = 0l;
         JSONArray jsoNBerichten = new JSONArray();
-        BrmoFramework brmo = null;
-        try {
-            brmo = new BrmoFramework(dataSourceStaging, null);
 
-            count = brmo.getCountBerichten(sort, dir, filterSoort, filterStatus);
+        count = this.getCountBerichten(sort, dir, filterSoort, filterStatus);
 
-            berichten = brmo.getBerichten(page, start, limit, sort, dir, filterSoort,
+        berichten = this.getBerichten(page, start, limit, sort, dir, filterSoort,
                     filterStatus);
 
-        } finally {
-            if (brmo!=null) {
-                brmo.closeBrmoFramework();
-            }
-        }
         for (Bericht b : berichten) {
             JSONObject jsonObject = bericht2Json(b);
             jsoNBerichten.put(jsonObject);
@@ -120,11 +222,11 @@ public class BerichtenActionBean implements ActionBean {
         JSONObject json = new JSONObject();
 
         json.put("id", ber.getId());
-        json.put("object_ref", ber.getObjectRef());
+        json.put("object_ref", ber.getObject_ref());
         json.put("datum", ber.getDatum());
         json.put("soort", ber.getSoort());
         json.put("status", ber.getStatus());
-        json.put("volgordenummer", ber.getVolgordeNummer());
+        json.put("volgordenummer", ber.getVolgordenummer());
 
         return json;
     }
@@ -144,19 +246,13 @@ public class BerichtenActionBean implements ActionBean {
         };
     }
 
-    public Resolution log() throws BrmoException{
-        DataSource dataSourceStaging = ConfigUtil.getDataSourceStaging();
+    public Resolution log() {
         JSONObject jsonObj = new JSONObject();
         jsonObj.put("success", Boolean.FALSE);
-        BrmoFramework brmo = new BrmoFramework(dataSourceStaging, null);
-        try{
-            Bericht bericht = brmo.getBerichtById(selectedIds[0]);
-            jsonObj = bericht2Json(bericht);
-            jsonObj.put("opmerking", bericht.getOpmerking());
-            jsonObj.put("success", Boolean.TRUE);
-        }finally{
-            brmo.closeBrmoFramework();
-        }
+        Bericht bericht = Stripersist.getEntityManager().find(Bericht.class,selectedIds[0]);
+        jsonObj = bericht2Json(bericht);
+        jsonObj.put("opmerking", bericht.getOpmerking());
+        jsonObj.put("success", Boolean.TRUE);
         final String returnValue =  jsonObj.toString();
         return new StreamingResolution("application/json") {
             @Override
@@ -165,6 +261,8 @@ public class BerichtenActionBean implements ActionBean {
             }
         };
     }
+
+    // <editor-fold defaultstate="collapsed" desc="getters and setters">
 
     public ActionBeanContext getContext() {
         return context;
@@ -255,4 +353,6 @@ public class BerichtenActionBean implements ActionBean {
     public void setChangedItem(JSONObject changedItem) {
         this.changedItem = changedItem;
     }
+
+    //</editor-fold>
 }

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/util/ConfigUtil.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/util/ConfigUtil.java
@@ -13,6 +13,9 @@ import nl.b3p.brmo.loader.util.BrmoException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+/**
+ * @deprecated voorkeur gaat uit naar gebruik van JPA interfaces
+ */
 public class ConfigUtil implements Servlet {
 
     private static final Log log = LogFactory.getLog(ConfigUtil.class);
@@ -23,25 +26,25 @@ public class ConfigUtil implements Servlet {
 
     private static DataSource datasourceStaging = null;
     private static DataSource datasourceRsgb = null;
-    
+
     public static Integer MAX_UPLOAD_SIZE;
     public static String TEMP_FOLDER;
 
     public void init(ServletConfig config) throws ServletException {
         String tempSize = config.getInitParameter("max_upload_size");
-        
-        if (tempSize != null && !tempSize.isEmpty()) {          
+
+        if (tempSize != null && !tempSize.isEmpty()) {
             MAX_UPLOAD_SIZE = new Integer(tempSize) * 1024;
         } else {
             MAX_UPLOAD_SIZE = 500 * 1024;
         }
-        
+
         String tempFolder = config.getInitParameter("temp_folder");
-        if (tempFolder != null && !tempFolder.isEmpty()) {          
+        if (tempFolder != null && !tempFolder.isEmpty()) {
             TEMP_FOLDER = tempFolder;
         } else {
             TEMP_FOLDER = "/tmp";
-        }    
+        }
     }
 
     public static DataSource getDataSourceStaging() throws BrmoException {
@@ -59,7 +62,7 @@ public class ConfigUtil implements Servlet {
 
         return ds;
     }
-    
+
     public static DataSource getDataSourceRsgb() throws BrmoException {
         DataSource ds = null;
         try {
@@ -77,11 +80,11 @@ public class ConfigUtil implements Servlet {
     }
 
     public ServletConfig getServletConfig() {
-        throw new UnsupportedOperationException("Not supported yet."); 
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     public void service(ServletRequest sr, ServletResponse sr1) throws ServletException, IOException {
-        throw new UnsupportedOperationException("Not supported yet."); 
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     public String getServletInfo() {


### PR DESCRIPTION
see #4

  - [x] deprecate nl.b3p.brmo.loader.entity.Bericht en  nl.b3p.brmo.loader.entity.LaadProces om de JPA equivalenten te gebruiken
  - [x] maak de STATUS in Bericht en LaadProces een enumerated value ipv String, voeg utility constructors toe
  - [x] markeer ConfigUtil als deprecated
  - [ ] uitfaseren ConfigUtil en BrmoFramework (althans voor staging) in webapp
  - [ ] omzetten BasisregistratieBigFileLoadActionBean naar JPA gebruik
  - [ ] omzetten BasisregistratieFileUploadActionBean naar JPA gebruik
  - [ ] omzetten BasisregistratieServiceActionBean naar JPA gebruik
  - [x] omzetten BerichtenActionBean naar JPA gebruik
  - [ ] omzetten LaadProcesActionBean naar JPA gebruik
  - [ ] omzetten TransformActionBean naar JPA gebruik
