### PR TITLE
work around OOM exception in BerichtDoorsturenProces bij veel Berichten

### DIFF
--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/entity/Bericht.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/entity/Bericht.java
@@ -23,7 +23,7 @@ public class Bericht {
     private String xslVersion;
 
     public static enum STATUS {
-        STAGING_OK, STAGING_NOK, RSGB_WAITING, RSGB_PROCESSING, RSGB_OK, RSGB_OUTDATED, RSGB_NOK, ARCHIVE
+        STAGING_OK, STAGING_NOK, STAGING_FORWARDED, RSGB_WAITING, RSGB_PROCESSING, RSGB_OK, RSGB_OUTDATED, RSGB_NOK, ARCHIVE
     };
 
     public Bericht(String brXml) {

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/BerichtDoorsturenProces.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/BerichtDoorsturenProces.java
@@ -90,6 +90,7 @@ public class BerichtDoorsturenProces extends AbstractExecutableProces {
                         Bericht b = Stripersist.getEntityManager().find(Bericht.class, pkid);
                         if (GDS2OphalenProces.doorsturenBericht(proces, l, b, url)) {
                             doorgestuurd++;
+                            this.l.progress(doorgestuurd);
                         } else {
                             fouten++;
                         }


### PR DESCRIPTION
Niet alle berichten op voorhand in lijst laden, maar alleen IDs, het bericht wordt pas opgehaald als het nodig is.

close #66