### PR TITLE
Accepteer HTTP status 202 als succes bij doorsturen Bericht

### DIFF
--- a/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/GDS2OphalenProces.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/GDS2OphalenProces.java
@@ -548,14 +548,16 @@ public class GDS2OphalenProces extends AbstractExecutableProces {
             conn.setRequestProperty("Content-Type", "application/octet-stream");
             IOUtils.copy(IOUtils.toInputStream(b.getBr_orgineel_xml(), "UTF-8"), conn.getOutputStream());
             conn.disconnect();
-            if (conn.getResponseCode() != 200) {
+            if ((conn.getResponseCode() == HttpURLConnection.HTTP_OK)
+                    || (conn.getResponseCode() == HttpURLConnection.HTTP_CREATED)
+                    || (conn.getResponseCode() == HttpURLConnection.HTTP_ACCEPTED)) {
+                msg = "Bericht " + b.getObject_ref() + " op " + sdf.format(new Date()) + " doorgestuurd naar " + endpoint;
+                b.setStatus(Bericht.STATUS.STAGING_FORWARDED);
+            } else {
                 msg = String.format("HTTP foutcode bij doorsturen bericht %s op %s naar endpoint %s: %s",
                         b.getObject_ref(),
                         sdf.format(new Date()), endpoint, conn.getResponseCode() + ": " + conn.getResponseMessage());
                 b.setStatus(Bericht.STATUS.STAGING_NOK);
-            } else {
-                msg = "Bericht " + b.getObject_ref() + " op " + sdf.format(new Date()) + " doorgestuurd naar " + endpoint;
-                b.setStatus(Bericht.STATUS.STAGING_FORWARDED);
             }
             b.setOpmerking(msg);
             proces.addLogLine(msg);


### PR DESCRIPTION
Thans wordt alleen 200 (OK) geaccepteerd als succesvolle doorstuur actie, 202 (Accepted) niet.

Verzoek vanuit SKP/yenlo verzoek om http 202 bij de valide responses te noteren?  
> Ik krijg nu duizenden regels aan 'HTTP foutcode' berichten voor een succesvolle call en ik kan dus ook niet makkelijk zien of er iets anders mis gaat. Verder verbaast het mij dat hij beweert nog 0 doorgestuurd te hebben terwijl de 'http 202 foutcodes' impliceren dat er wel degelijk al het eea verstuurd is?

de aanpassing is klein, de impact ook denk ik

