### PR TITLE
BRKDirectoryScanner is niet robuust genoeg

### DIFF
--- a/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/AbstractExecutableProces.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/AbstractExecutableProces.java
@@ -126,7 +126,7 @@ public abstract class AbstractExecutableProces implements ProcesExecutable {
      */
     protected boolean isDuplicaatLaadProces(File input, String soort) {
         log.debug("Controle voor duplicaat laadproces, soort: '" + soort + "', bestand: " + input.getName());
-        final String name = input.getAbsolutePath();
+        final String name = getBestandsNaam(input);
         EntityManager em = Stripersist.getEntityManager();
         CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
         CriteriaQuery<LaadProces> criteriaQuery = criteriaBuilder.createQuery(LaadProces.class);
@@ -138,5 +138,16 @@ public abstract class AbstractExecutableProces implements ProcesExecutable {
         TypedQuery<LaadProces> typedQuery = em.createQuery(select);
 
         return !typedQuery.getResultList().isEmpty();
+    }
+
+    /**
+     * bepaal bestandnaam.
+     *
+     * @param f
+     * @return de naam van het bestand tbv oa. duplicaat controle
+     * @see #isDuplicaatLaadProces(java.io.File, java.lang.String)
+     */
+    protected String getBestandsNaam(File f) {
+        return f.getAbsolutePath();
     }
 }

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/BAGDirectoryScanner.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/BAGDirectoryScanner.java
@@ -6,6 +6,7 @@
 package nl.b3p.brmo.service.scanner;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import nl.b3p.brmo.loader.BrmoFramework;
@@ -18,6 +19,7 @@ import static nl.b3p.brmo.persistence.staging.AutomatischProces.ProcessingStatus
 import static nl.b3p.brmo.persistence.staging.AutomatischProces.ProcessingStatus.WAITING;
 import nl.b3p.brmo.persistence.staging.BAGScannerProces;
 import nl.b3p.brmo.service.util.ConfigUtil;
+import org.apache.commons.io.comparator.NameFileComparator;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -87,6 +89,7 @@ public class BAGDirectoryScanner extends AbstractExecutableProces {
                 }
 
                 File files[] = scanDirectory.listFiles();
+                Arrays.sort(files, NameFileComparator.NAME_COMPARATOR);
                 for (File f : files) {
                     if (f.isDirectory()) {
                         continue;
@@ -104,7 +107,7 @@ public class BAGDirectoryScanner extends AbstractExecutableProces {
                         try {
                             // 1: laadt in staging.
                             brmo = new BrmoFramework(ConfigUtil.getDataSourceStaging(), null);
-                            brmo.loadFromFile(BrmoFramework.BR_BAG, f.getAbsolutePath());
+                            brmo.loadFromFile(BrmoFramework.BR_BAG, getBestandsNaam(f));
                             msg = String.format("Bestand %s is geladen.", f);
                             log.info(msg);
                             sb.append(msg).append(AutomatischProces.LOG_NEWLINE);

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/BRKDirectoryScanner.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/BRKDirectoryScanner.java
@@ -3,24 +3,35 @@
  */
 package nl.b3p.brmo.service.scanner;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import nl.b3p.brmo.loader.BrmoFramework;
-import nl.b3p.brmo.loader.util.BrmoDuplicaatLaadprocesException;
+import nl.b3p.brmo.loader.entity.BrkBericht;
 import nl.b3p.brmo.loader.util.BrmoException;
-import nl.b3p.brmo.loader.util.BrmoLeegBestandException;
+import nl.b3p.brmo.loader.xml.BrkSnapshotXMLReader;
 import nl.b3p.brmo.persistence.staging.AutomatischProces;
 import static nl.b3p.brmo.persistence.staging.AutomatischProces.ProcessingStatus.ERROR;
 import static nl.b3p.brmo.persistence.staging.AutomatischProces.ProcessingStatus.PROCESSING;
 import static nl.b3p.brmo.persistence.staging.AutomatischProces.ProcessingStatus.WAITING;
 import nl.b3p.brmo.persistence.staging.BRKScannerProces;
-import nl.b3p.brmo.service.util.ConfigUtil;
+import nl.b3p.brmo.persistence.staging.Bericht;
+import nl.b3p.brmo.persistence.staging.LaadProces;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.comparator.NameFileComparator;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.stripesstuff.stripersist.Stripersist;
 
 /**
- * Directory scanner for BRK berichten.
+ * Directory scanner for BRK berichten in xml formaat.
  *
  * @author Mark Prins
  */
@@ -28,127 +39,230 @@ public class BRKDirectoryScanner extends AbstractExecutableProces {
 
     private static final Log log = LogFactory.getLog(BRKDirectoryScanner.class);
 
-    private BRKScannerProces config;
+    private final BRKScannerProces config;
+
+    private ProgressUpdateListener listener;
 
     public BRKDirectoryScanner(BRKScannerProces config) {
         this.config = config;
     }
 
     /**
+     * Leest de xml berichten uit de directory in in de database, indien
+     * geconfigureerd worden bestanden gearchiveerd.
+     *
      * @throws BrmoException als de directory niet lees/blader/schrijfbaar is
      *
-     * @deprecated deze methode gebruikt nog de
-     * BrmoFramework(ConfigUtil.getDataSourceStaging(), null) methode, maar moet
-     * over op JPA natuurlijk
      */
     @Override
     public void execute() throws BrmoException {
-        switch (config.getStatus()) {
-            case ONBEKEND:
-            case WAITING:
-            case ERROR:
-                StringBuilder sb = new StringBuilder();
-                config.setStatus(PROCESSING);
-                String msg = String.format("De BRK scanner met ID %d is gestart op %tc.", config.getId(), Calendar.getInstance());
-                log.info(msg);
-                sb.append(msg).append(AutomatischProces.LOG_NEWLINE);
-                this.active = true;
+        this.execute(new ProgressUpdateListener() {
+            @Override
+            public void total(long total) {
+            }
 
-                // validatie van de directories, kunnen we lezen/bladeren en evt. schrijven?
-                final File scanDirectory = new File(this.config.getScanDirectory());
-                if (!scanDirectory.isDirectory() || !scanDirectory.canExecute()) {
-                    config.setStatus(ERROR);
-                    config.addLogLine(String.format("FOUT: De scan directory '%s' is geen executable directory", scanDirectory));
-                    config.setSamenvatting("Er is een fout opgetreden, details staan in de logs");
-                    this.active = false;
-                    throw new BrmoException(String.format("De scan directory '%s' is geen executable directory", scanDirectory));
-                }
-                final String aDir = this.config.getArchiefDirectory();
-                final boolean isArchiving = (aDir != null);
-                File archiefDirectory = null;
-                if (isArchiving) {
-                    archiefDirectory = new File(aDir);
-                    archiefDirectory.mkdirs();
-                    if (!archiefDirectory.isDirectory() || !archiefDirectory.canWrite()) {
-                        config.setStatus(ERROR);
-                        config.addLogLine(String.format("FOUT: De archief directory '%s' is geen beschrijfbare directory", archiefDirectory));
-                        config.setSamenvatting("Er is een fout opgetreden, details staan in de logs");
-                        this.active = false;
-                        throw new BrmoException(String.format("De archief directory '%s' is geen beschrijfbare directory", archiefDirectory));
-                    }
-                    if (!scanDirectory.canWrite()) {
-                        config.setStatus(ERROR);
-                        config.addLogLine(String.format("FOUT: De scan directory '%s' is geen beschrijfbare directory", scanDirectory));
-                        config.setSamenvatting("Er is een fout opgetreden, details staan in de logs");
-                        this.active = false;
-                        throw new BrmoException(String.format("De scan directory '%s' is geen beschrijfbare directory", scanDirectory));
-                    }
-                }
+            @Override
+            public void progress(long progress) {
+            }
 
-                File files[] = scanDirectory.listFiles();
-                for (File f : files) {
-                    if (f.isDirectory()) {
-                        continue;
-                    }
-                    msg = String.format("Bestand %s is gevonden in %s.", f, scanDirectory);
-                    log.info(msg);
-                    sb.append(msg).append(AutomatischProces.LOG_NEWLINE);
-                    if (this.isDuplicaatLaadProces(f, BrmoFramework.BR_BRK)) {
-                        msg = String.format("Bestand %s is een duplicaat en wordt overgeslagen.", f);
-                        log.info(msg);
-                        sb.append(msg).append(AutomatischProces.LOG_NEWLINE);
-                    } else {
-                        BrmoFramework brmo = null;
-                        try {
-                            // 1: laadt in staging
-                            // TODO gebruik JPA
-                            brmo = new BrmoFramework(ConfigUtil.getDataSourceStaging(), null);
-                            brmo.loadFromFile(BrmoFramework.BR_BRK, f.getAbsolutePath());
-                            msg = String.format("Bestand %s is geladen.", f);
-                            log.info(msg);
-                            sb.append(msg).append(AutomatischProces.LOG_NEWLINE);
-                        } catch (BrmoDuplicaatLaadprocesException duplicaat) {
-                            log.info(duplicaat.getLocalizedMessage());
-                            sb.append(duplicaat.getLocalizedMessage()).append(AutomatischProces.LOG_NEWLINE);
-                        } catch (BrmoLeegBestandException leegEx) {
-                            // log message maar ga door met verwerking, om een "leeg" bestand bericht/laadproces over te slaan
-                            log.warn(leegEx.getLocalizedMessage());
-                            sb.append(leegEx.getLocalizedMessage()).append(AutomatischProces.LOG_NEWLINE);
-                        } finally {
-                            if (brmo != null) {
-                                brmo.closeBrmoFramework();
-                            }
-                            if (isArchiving) {
-                                // 2: verplaats naar archief (NB mogelijk platform afhankelijk)
-                                f.renameTo(new File(archiefDirectory, f.getName()));
-                                msg = String.format("Bestand %s is naar archief %s verplaatst.", f, archiefDirectory);
-                                log.info(msg);
-                                sb.append(msg).append(AutomatischProces.LOG_NEWLINE);
-                            }
-                        }
-                    }
-                }
-                msg = String.format("Klaar met run op %tc", Calendar.getInstance());
-                log.info(msg);
-                sb.append(msg);
-                this.active = false;
-                config.setStatus(WAITING);
-                config.updateSamenvattingEnLogfile(sb.toString());
-                config.setLastrun(new Date());
+            @Override
+            public void exception(Throwable t) {
+                log.error(t);
+            }
 
-                break;
+            @Override
+            public void updateStatus(String status) {
+            }
 
-            default:
-                log.warn(String.format("De BRK scanner met ID %d is niet gestart vanwege de status %s.", config.getId(), config.getStatus()));
-        }
+            @Override
+            public void addLog(String log) {
+            }
+        });
     }
 
     @Override
     public void execute(ProgressUpdateListener listener) {
-        try {
-            this.execute();
-        } catch (BrmoException ex) {
-            log.error(ex);
+        this.listener = listener;
+        config.setStatus(PROCESSING);
+        String msg = String.format("De BRK scanner met ID %d is gestart op %tc.", config.getId(), Calendar.getInstance());
+        log.info(msg);
+        listener.addLog(msg);
+        config.addLogLine(msg);
+
+        // validatie van de directories, kunnen we lezen/bladeren en evt. schrijven?
+        final File scanDirectory = new File(this.config.getScanDirectory());
+        if (!scanDirectory.isDirectory() || !scanDirectory.canExecute()) {
+            config.setStatus(ERROR);
+            msg = String.format("De scan directory '%s' is geen executable directory", scanDirectory);
+            config.addLogLine(msg);
+            config.setSamenvatting("Er is een fout opgetreden, details staan in de logs");
+            this.listener.exception(new BrmoException(msg));
+            return;
         }
+        // validatie archief directory
+        final String aDir = this.config.getArchiefDirectory();
+        File archiefDirectory = null;
+        if (aDir != null) {
+            archiefDirectory = new File(aDir);
+            archiefDirectory.mkdirs();
+            if (!archiefDirectory.isDirectory() || !archiefDirectory.canWrite()) {
+                archiefDirectory = null;
+                config.setStatus(ERROR);
+                msg = String.format("De archief directory '%s' is geen beschrijfbare directory, er worden geen bestanden gearchiveerd.",
+                        archiefDirectory);
+                config.addLogLine(msg);
+                config.setSamenvatting("Er is een fout opgetreden, details staan in de logs");
+                log.error(msg);
+                this.listener.exception(new BrmoException(msg));
+            }
+            if (!scanDirectory.canWrite()) {
+                archiefDirectory = null;
+                config.setStatus(ERROR);
+                msg = String.format("De scan directory '%s' is geen beschrijfbare directory, er worden geen bestanden gearchiveerd.",
+                        scanDirectory);
+                config.addLogLine(msg);
+                config.setSamenvatting("Er is een fout opgetreden, details staan in de logs");
+                log.error(msg);
+                this.listener.exception(new BrmoException(msg));
+            }
+        }
+
+        File files[] = scanDirectory.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return name.toLowerCase().endsWith(".xml");
+            }
+        });
+        Arrays.sort(files, NameFileComparator.NAME_COMPARATOR);
+
+        processXMLFiles(files, scanDirectory, archiefDirectory);
+
+        Stripersist.getEntityManager().merge(this.config);
+        Stripersist.getEntityManager().flush();
+        Stripersist.getEntityManager().getTransaction().commit();
+        Stripersist.getEntityManager().clear();
+    }
+
+    /**
+     * verwerk een bestandenlijst.
+     *
+     * @param files array met xml bestanden
+     *
+     * @param scanDirectory
+     * @param archiefDirectory
+     */
+    private void processXMLFiles(File[] files, File scanDirectory, File archiefDirectory) {
+        StringBuilder sb = new StringBuilder(AutomatischProces.LOG_NEWLINE + config.getLogfile());
+        String msg;
+        int filterAlVerwerkt = 0;
+        int aantalGeladen = 0;
+        int progress = 0;
+        SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss");
+
+        listener.total(files.length);
+        for (File f : files) {
+            if (f.isDirectory()) {
+                continue;
+            }
+            msg = String.format("Bestand %s is gevonden in %s.", f, scanDirectory);
+            log.info(msg);
+            listener.addLog(msg);
+            sb.append(msg).append(AutomatischProces.LOG_NEWLINE);
+            if (this.isDuplicaatLaadProces(f, BrmoFramework.BR_BRK)) {
+                msg = String.format("  Bestand %s is een duplicaat en wordt overgeslagen.", f);
+                listener.addLog(msg);
+                log.info(msg);
+                sb.append(msg).append(AutomatischProces.LOG_NEWLINE);
+                filterAlVerwerkt++;
+            } else {
+                try {
+                    LaadProces lp = new LaadProces();
+                    lp.setBestand_naam(getBestandsNaam(f));
+                    lp.setSoort(BrmoFramework.BR_BRK);
+                    lp.setStatus(LaadProces.STATUS.STAGING_OK);
+                    lp.setOpmerking(String.format("Bestand geladen van %s op %s", f.getAbsolutePath(), sdf.format(new Date())));
+                    lp.setAutomatischProces(Stripersist.getEntityManager().find(AutomatischProces.class, config.getId()));
+
+                    Bericht b = new Bericht();
+                    b.setLaadprocesid(lp);
+                    b.setDatum(lp.getBestand_datum());
+                    b.setSoort(BrmoFramework.BR_BRK);
+                    b.setStatus_datum(new Date());
+                    b.setBr_orgineel_xml(FileUtils.readFileToString(f, "UTF-8"));
+
+                    try {
+                        BrkSnapshotXMLReader reader = new BrkSnapshotXMLReader(
+                                new ByteArrayInputStream(b.getBr_orgineel_xml().getBytes("UTF-8")));
+                        BrkBericht bericht = reader.next();
+
+                        if (bericht.getDatum() != null) {
+                            b.setDatum(bericht.getDatum());
+                        }
+                        b.setBr_xml(bericht.getBrXml());
+                        b.setVolgordenummer(bericht.getVolgordeNummer());
+
+                        //Als objectRef niet opgehaald kan worden,dan kan het
+                        //  bericht niet verwerkt worden.
+                        String objectRef = bericht.getObjectRef();
+                        if (objectRef != null && !objectRef.isEmpty()) {
+                            b.setObject_ref(bericht.getObjectRef());
+                            b.setStatus(Bericht.STATUS.STAGING_OK);
+                            b.setOpmerking("Klaar voor verwerking.");
+                        } else {
+                            b.setStatus(Bericht.STATUS.STAGING_NOK);
+                            b.setOpmerking("Object Ref niet gevonden in bericht-xml, neem contact op met leverancier.");
+                        }
+                    } catch (Exception e) {
+                        b.setStatus(Bericht.STATUS.STAGING_NOK);
+                        StringWriter sw = new StringWriter();
+                        e.printStackTrace(new PrintWriter(sw));
+                        msg = String.format("Fout bij parsen BRK bericht (bestand %s): %s ", f, sw.toString());
+                        b.setOpmerking(msg);
+                        log.warn(msg);
+                    }
+
+                    Stripersist.getEntityManager().persist(lp);
+                    Stripersist.getEntityManager().persist(b);
+                    Stripersist.getEntityManager().merge(this.config);
+
+                    aantalGeladen++;
+                    msg = String.format("  Bestand %s is geladen. Status: %s", f, b.getStatus());
+                    log.info(msg);
+                    this.listener.addLog(msg);
+                    sb.append(msg).append(AutomatischProces.LOG_NEWLINE);
+                } catch (IOException io) {
+                    // mogelijk bij openen en lezen xml bestand
+                    log.error(io.getLocalizedMessage());
+                    sb.append(io.getLocalizedMessage()).append(AutomatischProces.LOG_NEWLINE);
+                    listener.exception(io);
+                }
+            }
+            listener.progress(++progress);
+
+            if (archiefDirectory != null) {
+                // verplaats naar archief (NB mogelijk platform afhankelijk)
+                f.renameTo(new File(archiefDirectory, f.getName()));
+                msg = String.format("  Bestand %s is naar archief %s verplaatst.", f, archiefDirectory);
+                log.info(msg);
+                this.listener.addLog(msg);
+                sb.append(msg).append(AutomatischProces.LOG_NEWLINE);
+            }
+        }
+        msg = String.format("Klaar met run op %tc", Calendar.getInstance());
+        log.info(msg);
+        listener.updateStatus(msg);
+        listener.addLog(msg);
+        sb.append(msg);
+
+        listener.addLog("\n\n**** resultaat ****");
+        listener.addLog("\nAantal bestanden die al waren geladen: " + filterAlVerwerkt);
+        listener.addLog("\nAantal bestanden geladen: " + aantalGeladen + "\n");
+
+        config.setStatus(WAITING);
+        config.setLogfile(sb.toString());
+        config.setLastrun(new Date());
+        config.updateSamenvattingEnLogfile("Aantal bestanden die al waren verwerkt: "
+                + filterAlVerwerkt + AutomatischProces.LOG_NEWLINE
+                + "Aantal bestanden geladen: " + aantalGeladen + AutomatischProces.LOG_NEWLINE);
     }
 }


### PR DESCRIPTION
In het geval er een misvormd xml bestand aangetroffen wordt crashed het proces.

Beter is: fout opvangen, laadproces aanmaken en een STAGING_NOK bericht met de xml blob erin en de foutmelding/stack trace in laadproces of bericht