### PR TITLE
Build (en test) op Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ before_install:
 
 install:
 # install all dependencies + artifacts without any testing,
-# this will currently fail on missing oracle ojdbc drivers
   - mvn install -Dmaven.test.skip=true -B -V -fae -q -Ptravis-ci
 
 before_script:
@@ -56,13 +55,13 @@ script:
 # run integration tests
   - mvn -e verify -B -Ptravis-ci
 
-after_success:
+# after_success:
 
-after_failure:
+# after_failure:
 
-after_script:
+# after_script:
 
-notifications:
-  email: false
+# notifications:
+#   email: false
   #  on_success: [always|never|change] # default: change
   #  on_failure: [always|never|change] # default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,69 @@
-sudo: false
 language: java
+
+sudo: false
 
 branches:
   only:
     - travis-integration
+
+addons:
+  postgresql: "9.3"
+
+jdk:
+#  - openjdk6
+#  - openjdk7
+  - oraclejdk7
+#  - oraclejdk8
+
+matrix:
+  fast_finish: true
+
+cache:
+  directories:
+  - $HOME/.m2
+
+before_install:
+# STAGING
+  - psql --version
+  - psql -U postgres -c 'create database staging;'
+  - psql -U postgres -c 'create database rsgb;'
+  - psql -U postgres -d rsgb -c 'create extension postgis;'
+#  - psql -U postgres --list
+  - ls -l ./datamodel/generated_scripts/
+# set up RSGB
+  - travis_wait psql -U postgres -w -d rsgb -a -f ./datamodel/generated_scripts/datamodel_postgresql.sql
+  - ls -l ./datamodel/utility_scripts/
+#  - psql -U postgres -d rsgb -a -f ./datamodel/utility_scripts/111a_update_gemeente_geom.sql
+#  - psql -U postgres -d rsgb -a -f ./datamodel/utility_scripts/113a_update_wijk_geom.sql
+
+install:
+# install all dependencies + artifacts without any testing,
+# this will currently fail on missing oracle ojdbc drivers
+  - mvn install -Dmaven.test.skip=true -B -V -fae -q
+
+before_script:
+# dit dient na afloop van de 'install' gedaan te worden omdat de staging DB sql gegenereerd wordt door Hibernate
+  - ls -l ./brmo-persistence/target/ddlscripts/
+  - psql -U postgres -d staging -a -f ./brmo-persistence/target/ddlscripts/create-brmo-persistence-postgresql.sql
+  - ls -l ./brmo-persistence/db/
+  - psql -U postgres -d staging -a -f ./brmo-persistence/db/01_create_indexes.sql
+  - psql -U postgres -d staging -a -f ./brmo-persistence/db/02_insert_default_user.sql
+  - psql -U postgres -d staging -a -f ./brmo-persistence/db/03_update_status_enum_value.sql
+
+# run tests
+script:
+# run unit tests
+  - mvn -e test -B
+# run integration tests
+  - mvn -e verify -B
+
+after_success:
+
+after_failure:
+
+after_script:
+
+notifications:
+  email: false
+  #  on_success: [always|never|change] # default: change
+  #  on_failure: [always|never|change] # default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,13 @@ cache:
   - $HOME/.m2
 
 before_install:
-# STAGING
+# set up STAGING
   - psql --version
+  - psql -U postgres -a -c "CREATE ROLE staging LOGIN PASSWORD 'staging' SUPERUSER CREATEDB;"
+  - psql -U postgres -a -c "CREATE ROLE rsgb LOGIN PASSWORD 'rsgb' SUPERUSER CREATEDB;"
   - psql -U postgres -c 'create database staging;'
   - psql -U postgres -c 'create database rsgb;'
   - psql -U postgres -d rsgb -c 'create extension postgis;'
-#  - psql -U postgres --list
   - ls -l ./datamodel/generated_scripts/
 # set up RSGB
   - travis_wait psql -U postgres -w -d rsgb -a -f ./datamodel/generated_scripts/datamodel_postgresql.sql
@@ -32,7 +33,7 @@ before_install:
 #  - psql -U postgres -d rsgb -a -f ./datamodel/utility_scripts/113a_update_wijk_geom.sql
 
 install:
-# install all dependencies + artifacts without any testing,
+  # install all dependencies + artifacts without any testing, create staging db scripts
   - mvn install -Dmaven.test.skip=true -B -V -fae -q -Ptravis-ci -pl '!brmo-dist'
 
 before_script:
@@ -42,7 +43,6 @@ before_script:
   - ls -l ./brmo-persistence/db/
   - psql -U postgres -d staging -a -f ./brmo-persistence/db/01_create_indexes.sql
   - psql -U postgres -d staging -a -f ./brmo-persistence/db/02_insert_default_user.sql
-  - psql -U postgres -d staging -a -f ./brmo-persistence/db/03_update_status_enum_value.sql
 
 # run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: java
 
 sudo: false
 
-branches:
-  only:
-    - travis-integration
-
 addons:
   postgresql: "9.4"
 
@@ -37,7 +33,7 @@ before_install:
 
 install:
 # install all dependencies + artifacts without any testing,
-  - mvn install -Dmaven.test.skip=true -B -V -fae -q -Ptravis-ci
+  - mvn install -Dmaven.test.skip=true -B -V -fae -q -Ptravis-ci -pl '!brmo-dist'
 
 before_script:
 # dit dient na afloop van de 'install' gedaan te worden omdat de staging DB sql gegenereerd wordt door Hibernate
@@ -51,9 +47,9 @@ before_script:
 # run tests
 script:
 # run unit tests
-  - mvn -e test -B  -Ptravis-ci
+  - mvn -e test -B -Ptravis-ci -pl '!brmo-dist'
 # run integration tests
-  - mvn -e verify -B -Ptravis-ci
+  - mvn -e verify -B -Ptravis-ci -pl '!brmo-dist'
 
 # after_success:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,12 @@ branches:
     - travis-integration
 
 addons:
-  postgresql: "9.3"
+  postgresql: "9.4"
 
 jdk:
-#  - openjdk6
-#  - openjdk7
+  - openjdk7
   - oraclejdk7
-#  - oraclejdk8
+  - oraclejdk8
 
 matrix:
   fast_finish: true
@@ -39,7 +38,7 @@ before_install:
 install:
 # install all dependencies + artifacts without any testing,
 # this will currently fail on missing oracle ojdbc drivers
-  - mvn install -Dmaven.test.skip=true -B -V -fae -q
+  - mvn install -Dmaven.test.skip=true -B -V -fae -q -Ptravis-ci
 
 before_script:
 # dit dient na afloop van de 'install' gedaan te worden omdat de staging DB sql gegenereerd wordt door Hibernate
@@ -53,9 +52,9 @@ before_script:
 # run tests
 script:
 # run unit tests
-  - mvn -e test -B
+  - mvn -e test -B  -Ptravis-ci
 # run integration tests
-  - mvn -e verify -B
+  - mvn -e verify -B -Ptravis-ci
 
 after_success:
 

--- a/brmo-loader/pom.xml
+++ b/brmo-loader/pom.xml
@@ -65,7 +65,7 @@
         -->
         <dependency>
             <groupId>com.oracle</groupId>
-            <artifactId>ojdbc5</artifactId>
+            <artifactId>ojdbc6</artifactId>
             <!-- Bij JNDI db verbinding moeten Oracle jars in tomcat lib staan -->
             <scope>provided</scope>
         </dependency>

--- a/brmo-loader/pom.xml
+++ b/brmo-loader/pom.xml
@@ -65,7 +65,7 @@
         -->
         <dependency>
             <groupId>com.oracle</groupId>
-            <artifactId>ojdbc6</artifactId>
+            <artifactId>${oracle.jdbc.artifactId}</artifactId>
             <!-- Bij JNDI db verbinding moeten Oracle jars in tomcat lib staan -->
             <scope>provided</scope>
         </dependency>

--- a/brmo-loader/src/test/resources/log4j.xml
+++ b/brmo-loader/src/test/resources/log4j.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration PUBLIC "-//APACHE//DTD LOG4J 1.2//EN" "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+    <appender name="consoleAppender" class="org.apache.log4j.ConsoleAppender">
+        <param name="Threshold" value="debug" />
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="BRMO-LOADER-TEST: %5p %d{HH:mm:ss} (%C#%M:%L) - %m%n" />
+        </layout>
+    </appender>
+    <root>
+        <level value="debug" />
+        <appender-ref ref="consoleAppender" />
+    </root>
+</log4j:configuration>

--- a/brmo-persistence/pom.xml
+++ b/brmo-persistence/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle</groupId>
-            <artifactId>ojdbc5</artifactId>
+            <artifactId>ojdbc6</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/brmo-persistence/pom.xml
+++ b/brmo-persistence/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>com.oracle</groupId>
-            <artifactId>ojdbc6</artifactId>
+            <artifactId>${oracle.jdbc.artifactId}</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/brmo-service/pom.xml
+++ b/brmo-service/pom.xml
@@ -98,6 +98,12 @@
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>jaxws-rt</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -179,4 +185,105 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>travis-ci</id>
+            <properties>
+                <test.persistence.unit>brmo.persistence.postgresql</test.persistence.unit>
+                <postgresql.jdbc.version>9.4.1207</postgresql.jdbc.version>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.postgresql</groupId>
+                    <artifactId>postgresql</artifactId>
+                    <version>${postgresql.jdbc.version}</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <filters>
+                    <filter>${project.basedir}/src/test/resources/postgres.properties</filter>
+                </filters>
+                <!--<resources></resources>-->
+                <testResources>
+                    <testResource>
+                        <directory>${project.basedir}/src/test/tomcatconf/</directory>
+                        <filtering>true</filtering>
+                    </testResource>
+                    <testResource>
+                        <directory>${project.basedir}/src/test/resources/</directory>
+                    </testResource>
+                </testResources>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>properties-maven-plugin</artifactId>
+                        <configuration>
+                            <files>
+                                <file>${project.basedir}/src/test/resources/postgres.properties</file>
+                            </files>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>read-project-properties</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.tomcat.maven</groupId>
+                        <artifactId>tomcat7-maven-plugin</artifactId>
+                        <configuration>
+                            <port>9090</port>
+                            <!-- Note: dit bestand wordt neergezet tijdens 'test' phase. 
+                            Om Tomcat standalone te draaien gebruik je
+                            'mvn clean test tomcat7:run -Ptravis-ci' -->
+                            <contextFile>${project.build.directory}/test-classes/testcontext.xml</contextFile>-->
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>tomcat-run</id>
+                                <goals>
+                                    <goal>run-war-only</goal>
+                                </goals>
+                                <phase>pre-integration-test</phase>
+                                <configuration>
+                                    <fork>true</fork>
+                                    <skip>${maven.test.skip}</skip>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>tomcat-shutdown</id>
+                                <goals>
+                                    <goal>shutdown</goal>
+                                </goals>
+                                <phase>post-integration-test</phase>
+                                <configuration>
+                                    <skip>${maven.test.skip}</skip>
+                                    <skipErrorOnShutdown>true</skipErrorOnShutdown>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>javax.mail</groupId>
+                                <artifactId>mail</artifactId>
+                                <version>1.4.7</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.postgresql</groupId>
+                                <artifactId>postgresql</artifactId>
+                                <version>${postgresql.jdbc.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration></configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/brmo-service/src/test/java/nl/b3p/web/IndexPageIntegrationTest.java
+++ b/brmo-service/src/test/java/nl/b3p/web/IndexPageIntegrationTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2016 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.web;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.util.EntityUtils;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+/**
+ * Integration test for the index page.
+ *
+ * @author mprins
+ */
+public class IndexPageIntegrationTest extends TestUtil {
+
+    /**
+     * onze test response.
+     */
+    private HttpResponse response;
+
+    /**
+     * Test of de brmo-service applicatie is gestart en de index pagina
+     * opgehaald kan worden.
+     *
+     *
+     * @throws IOException als die optreedt tijdens ophalen pagina
+     */
+    @Test
+    public void requestIndex() throws IOException {
+        response = client.execute(new HttpGet(BASE_TEST_URL + "/brmo-service/"));
+
+        final String body = EntityUtils.toString(response.getEntity());
+        assertThat("Response status is OK.", response.getStatusLine().getStatusCode(),
+                equalTo(HttpStatus.SC_OK));
+        assertNotNull("Response body mag niet null zijn.", body);
+    }
+
+    /**
+     * Test of de database bestaat en de default admin gebruiker is aangemaakt.
+     * Test of de .travis.yml correct is uitgevoerd.
+     *
+     * @throws SQLException als er iets misgaat met SQL parsen
+     */
+    @Test
+    public void testDefaultUserPresent() throws SQLException {
+        // staat in /brmo-persistence/db/02_insert_default_user.sql
+        String default_gebruikersnaam = "brmo";
+        String default_hash = "6310227872580fec7d1262ab7ab3b4b3902a9f61";
+
+        try {
+            Class.forName(POSTGRESPROPS.getProperty("postgres.driverClassName"));
+        } catch (ClassNotFoundException ex) {
+            fail("Laden van Postgres driver is mislukt.");
+        }
+        Connection connection = DriverManager.getConnection(
+                POSTGRESPROPS.getProperty("staging.url"),
+                POSTGRESPROPS.getProperty("staging.username"),
+                POSTGRESPROPS.getProperty("staging.password")
+        );
+        ResultSet rs = connection.createStatement().executeQuery("SELECT gebruikersnaam, wachtwoord FROM gebruiker_;");
+
+        String actual_gebruikersnaam = "";
+        String actual_hash = "";
+        while (rs.next()) {
+            // gebruik getBytes ipv. getString vanwege optredende fout
+            // "java.lang.NoSuchMethodError: org.postgresql.core.BaseConnection.getEncoding()Lorg/postgresql/core/Encoding;"
+            // waarschijnlijk veroorzaakt door de postgis dependency...
+            //            message="org.postgresql.core.BaseConnection.getEncoding()Lorg/postgresql/core/Encoding;" type="java.lang.NoSuchMethodError">java.lang.NoSuchMethodError: org.postgresql.core.BaseConnection.getEncoding()Lorg/postgresql/core/Encoding;
+            //	at org.postgresql.jdbc2.AbstractJdbc2ResultSet.getString(AbstractJdbc2ResultSet.java:1889)
+            //	at nl.b3p.web.IndexPageIntegrationTest.testDefaultUserPresent(IndexPageIntegrationTest.java:99)
+
+            //actual_gebruikersnaam = rs.getObject(1, String.class);
+            //actual_hash = rs.getString(2);
+            actual_gebruikersnaam = new String(rs.getBytes(1));
+            actual_hash = new String(rs.getBytes(2));
+        }
+        assertThat("Er is maar 1 'user' record (eerste en laatste zijn dezelfde record).", rs.isLast(), equalTo(rs.isFirst()));
+
+        rs.close();
+        connection.close();
+
+        assertEquals("De record moet de verwachte naam hebben.", default_gebruikersnaam, actual_gebruikersnaam);
+        assertEquals("De record moet de verwachte password hash hebben.", default_hash, actual_hash);
+    }
+
+    /**
+     * Test login/index/about/logout sequentie.
+     *
+     * @throws IOException mag niet optreden
+     * @throws URISyntaxException mag niet optreden
+     */
+    @Test
+    public void testLoginLogout() throws IOException, URISyntaxException {
+        // login
+        response = client.execute(new HttpGet(BASE_TEST_URL));
+        EntityUtils.consume(response.getEntity());
+
+        HttpUriRequest login = RequestBuilder.post()
+                .setUri(new URI(BASE_TEST_URL + "j_security_check"))
+                .addParameter("j_username", "brmo")
+                .addParameter("j_password", "brmo")
+                .build();
+        response = client.execute(login);
+        EntityUtils.consume(response.getEntity());
+        assertThat("Response status is OK.", response.getStatusLine().getStatusCode(),
+                equalTo(HttpStatus.SC_OK));
+
+        // index
+        response = client.execute(new HttpGet(BASE_TEST_URL + "index.jsp"));
+        String body = EntityUtils.toString(response.getEntity());
+        assertNotNull("Response body mag niet null zijn.", body);
+        assertTrue("Response moet 'BRMO Service' heading hebben.", body.contains("<h1>BRMO Service</h1>"));
+
+        // about
+        response = client.execute(new HttpGet(BASE_TEST_URL + "about.jsp"));
+        body = EntityUtils.toString(response.getEntity());
+        assertNotNull("Response body mag niet null zijn.", body);
+        assertTrue("Response moet 'BRMO Service' heading hebben.", body.contains("<h1>BRMO versie informatie</h1>"));
+
+        // logout
+        response = client.execute(new HttpGet(BASE_TEST_URL + "logout.jsp"));
+        body = EntityUtils.toString(response.getEntity());
+        assertThat("Response status is OK.", response.getStatusLine().getStatusCode(),
+                equalTo(HttpStatus.SC_OK));
+        assertNotNull("Response body mag niet null zijn.", body);
+        assertTrue("Response moet 'Uitgelogd' heading hebben.", body.contains("<h1>Uitgelogd</h1>"));
+    }
+}

--- a/brmo-service/src/test/java/nl/b3p/web/TestUtil.java
+++ b/brmo-service/src/test/java/nl/b3p/web/TestUtil.java
@@ -1,0 +1,67 @@
+package nl.b3p.web;
+
+import java.io.IOException;
+import java.util.Properties;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.LaxRedirectStrategy;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ *
+ * @author Mark Prins
+ */
+public abstract class TestUtil {
+
+    /**
+     * the server root url. {@value}
+     */
+    public static final String BASE_TEST_URL = "http://localhost:9090/brmo-service/";
+    /**
+     * This has the database properties as defined in 'postgres.properties'.
+     *
+     * @see #loadDBprop()
+     */
+    protected static final Properties POSTGRESPROPS = new Properties();
+
+    /**
+     * our test client.
+     */
+    protected static CloseableHttpClient client;
+
+    /**
+     * initialize database props.
+     *
+     * @throws java.io.IOException if loading the property file fails
+     */
+    @BeforeClass
+    public static void loadDBprop() throws IOException {
+        POSTGRESPROPS.load(IndexPageIntegrationTest.class.getClassLoader().getResourceAsStream("postgres.properties"));
+    }
+
+    /**
+     * initialize http client.
+     */
+    @BeforeClass
+    public static void setUpClass() {
+        client = HttpClients.custom()
+                .useSystemProperties()
+                .setUserAgent("brmo integration test")
+                .setRedirectStrategy(new LaxRedirectStrategy())
+                .setDefaultCookieStore(new BasicCookieStore())
+                .build();
+    }
+
+    /**
+     * close http client connections.
+     *
+     * @throws IOException if any occurs closing the http connection
+     */
+    @AfterClass
+    public static void tearDownClass() throws IOException {
+        client.close();
+    }
+}

--- a/brmo-service/src/test/resources/log4j.xml
+++ b/brmo-service/src/test/resources/log4j.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration PUBLIC "-//APACHE//DTD LOG4J 1.2//EN" "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+    <appender name="consoleAppender" class="org.apache.log4j.ConsoleAppender">
+        <param name="Threshold" value="debug" />
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="BRMO-SERVICE-TEST: %5p %d{HH:mm:ss} (%C#%M:%L) - %m%n" />
+        </layout>
+    </appender>
+    <root>
+        <level value="debug" />
+        <appender-ref ref="consoleAppender" />
+    </root>
+</log4j:configuration>

--- a/brmo-service/src/test/resources/postgres.properties
+++ b/brmo-service/src/test/resources/postgres.properties
@@ -1,0 +1,9 @@
+rsgb.username=rsgb
+rsgb.password=rsgb
+rsgb.url=jdbc:postgresql://localhost:5432/rsgb
+
+staging.username=staging
+staging.password=staging
+staging.url=jdbc:postgresql://localhost:5432/staging
+
+postgres.driverClassName=org.postgresql.Driver

--- a/brmo-service/src/test/tomcatconf/testcontext.xml
+++ b/brmo-service/src/test/tomcatconf/testcontext.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Context path="/brmo-service">
+    <!-- properties komen uit postgres.properties tijdens package? phase -->
+
+    <Resource name="jdbc/brmo/staging"
+              auth="Container"
+              type="javax.sql.DataSource"
+              maxActive="40"
+              validationQuery="select 1"
+              timeBetweenEvictionRunsMillis="30000"
+              minEvictableIdleTimeMillis="5000"
+              username="${staging.username}"
+              password="${staging.password}"
+              driverClassName="${postgres.driverClassName}"
+              url="${staging.url}"
+    />
+    
+    <Resource name="jdbc/brmo/rsgb"
+              auth="Container"
+              type="javax.sql.DataSource"
+              maxActive="40"
+              validationQuery="select 1"
+              timeBetweenEvictionRunsMillis="30000"
+              minEvictableIdleTimeMillis="5000"
+              username="${rsgb.username}"
+              password="${rsgb.password}"
+              driverClassName="${postgres.driverClassName}"
+              url="${rsgb.url}"
+    />
+
+    <Resource name="mail/session"
+              auth="Container"
+              type="javax.mail.Session"
+              mail.smtp.host="localhost"
+              mail.smtp.from="no-reply@b3partners.nl"
+    />
+
+    <Realm allRolesMode="authOnly"
+           className="org.apache.catalina.realm.DataSourceRealm"
+           digest="SHA-1"
+           roleNameCol="groep_"
+           userCredCol="wachtwoord"
+           userNameCol="gebruikersnaam"
+           userRoleTable="gebruiker_groepen"
+           userTable="gebruiker_"
+           dataSourceName="jdbc/brmo/staging"
+           localDataSource="true"
+    />
+
+    <!-- Realm allRolesMode="authOnly"
+           className="org.apache.catalina.realm.JDBCRealm"
+           digest="SHA-1"
+           roleNameCol="groep_"
+           userCredCol="wachtwoord"
+           userNameCol="gebruikersnaam"
+           userRoleTable="gebruiker_groepen"
+           userTable="gebruiker_"
+           driverName="${postgres.driverClassName}"
+           connectionURL="${staging.url}?user=${staging.username}&amp;password=${staging.password}"
+    / -->
+</Context>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <hibernate.version>3.6.10.Final</hibernate.version>
         <geotools.version>9.2</geotools.version>
         <postgresql.jdbc.version>9.3-1102-jdbc4</postgresql.jdbc.version>
-        <oracle.jdbc.version>11.1.0.7.0</oracle.jdbc.version>
+        <oracle.jdbc.version>11.2.0.3</oracle.jdbc.version>
         <javasimon.version>4.0.1</javasimon.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- om unit tests met postgres te draaien gebruik je
@@ -157,7 +157,7 @@
             -->
             <dependency>
                 <groupId>com.oracle</groupId>
-                <artifactId>ojdbc5</artifactId>
+                <artifactId>ojdbc6</artifactId>
                 <version>${oracle.jdbc.version}</version>
                 <!-- Bij JNDI db verbinding moeten Oracle jars in tomcat lib staan -->
             </dependency>
@@ -303,6 +303,14 @@
     </distributionManagement>
     <repositories>
         <repository>
+            <id>B3Partners</id>
+            <name>Releases hosted by B3Partners</name>
+            <url>http://repo.b3p.nl/nexus/content/repositories/public/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>osgeo</id>
             <name>Open Source Geospatial Foundation Repository</name>
             <url>http://download.osgeo.org/webdav/geotools/</url>
@@ -312,27 +320,20 @@
             <name>Boundless Maven Repository</name>
             <url>https://boundless.artifactoryonline.com/boundless/main/</url>
         </repository>
-        <repository>
-            <id>B3Partners</id>
-            <name>Releases hosted by B3Partners</name>
-            <url>http://repo.b3p.nl/nexus/content/repositories/public/</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
         <!-- see:
           https://docs.oracle.com/middleware/1213/core/MAVEN/config_maven_repo.htm#MAVEN9010
         of:
         https://www.oracle.com/webapps/maven/register/register.html
         -->
-        <!-- lijkt niet goed te werken met maven 3.3.3, voorlopig zelf installeren; 
-        zie brmo-loader/pom.xml 
+        <!-- lijkt niet goed te werken met maven 3.3.3, voorlopig zelf installeren;        
+        zie brmo-loader/pom.xml  
         <repository>
             <id>maven.oracle.com</id>
+            <url>https://maven.oracle.com</url>
+            <layout>default</layout>
             <releases>
                 <enabled>true</enabled>
             </releases>
-            <url>https://maven.oracle.com</url>
         </repository>
         -->
     </repositories>
@@ -606,4 +607,19 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>travis-ci</id>
+            <repositories>
+                <repository>
+                    <id>maven.oracle.com</id>
+                    <url>https://code.lds.org/nexus/content/groups/main-repo</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <oracle.jdbc.artifactId>ojdbc5</oracle.jdbc.artifactId>
         <javasimon.version>4.0.1</javasimon.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- om unit tests met postgres te draaien gebruik je
         -Dtest.persistence.unit=brmo.persistence.postgresql
         voor oracle:
@@ -56,7 +57,7 @@
         -->
         <test.persistence.unit>brmo.persistence.h2</test.persistence.unit>
         <test.h2.version>1.4.190</test.h2.version>
-        <maven.surefire.version>2.19</maven.surefire.version>
+        <maven.surefire.version>2.19.1</maven.surefire.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -405,6 +406,32 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven.surefire.version}</version>
+                    <configuration>
+                        <excludes>
+                            <exclude>**/*IntegrationTest.java</exclude>
+                        </excludes>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven.surefire.version}</version>
+                    <configuration>
+                        <includes>
+                            <include>**/*IntegrationTest.java</include>
+                        </includes>
+                        <systemPropertyVariables />
+                        <trimStackTrace>false</trimStackTrace>
+                        <useFile>false</useFile>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -435,6 +462,16 @@
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>
                     <version>2.2.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>properties-maven-plugin</artifactId>
+                    <version>1.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.tomcat.maven</groupId>
+                    <artifactId>tomcat7-maven-plugin</artifactId>
+                    <version>2.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,8 @@
         <hibernate.version>3.6.10.Final</hibernate.version>
         <geotools.version>9.2</geotools.version>
         <postgresql.jdbc.version>9.3-1102-jdbc4</postgresql.jdbc.version>
-        <oracle.jdbc.version>11.2.0.3</oracle.jdbc.version>
+        <oracle.jdbc.version>11.1.0.7.0</oracle.jdbc.version>
+        <oracle.jdbc.artifactId>ojdbc5</oracle.jdbc.artifactId>
         <javasimon.version>4.0.1</javasimon.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- om unit tests met postgres te draaien gebruik je
@@ -157,7 +158,7 @@
             -->
             <dependency>
                 <groupId>com.oracle</groupId>
-                <artifactId>ojdbc6</artifactId>
+                <artifactId>${oracle.jdbc.artifactId}</artifactId>
                 <version>${oracle.jdbc.version}</version>
                 <!-- Bij JNDI db verbinding moeten Oracle jars in tomcat lib staan -->
             </dependency>
@@ -610,6 +611,10 @@
     <profiles>
         <profile>
             <id>travis-ci</id>
+            <properties>
+                <oracle.jdbc.artifactId>ojdbc6</oracle.jdbc.artifactId>
+                <oracle.jdbc.version>11.2.0.3</oracle.jdbc.version>
+            </properties>
             <repositories>
                 <repository>
                     <id>maven.oracle.com</id>


### PR DESCRIPTION
Met deze PR komt de basis voor het testen op Travis-CI.

Vooralsnog: 
  - worden de databases schema's aangemaakt in PostgreSQL 9.4
  - worden de beschikbare unit tests gedraaid op oracle java 7 en 8 en openjdk 7
  - wordt een tomcat instantie gestart met daarin de brmo-service webapplicatie
  - wordt een [integratie test](https://github.com/B3Partners/brmo/blob/travis-integration/brmo-service/src/test/java/nl/b3p/web/IndexPageIntegrationTest.java) uitgevoerd om te kijken of de webapplicatie gestart is en of inloggen lukt