### PR TITLE
Maven refactoring

### DIFF
--- a/brmo-dist/assembly.xml
+++ b/brmo-dist/assembly.xml
@@ -27,7 +27,7 @@
     <fileSets>
         <fileSet>
             <directory>../${project.basedir}/brmo-persistence/target/ddlscripts/</directory>
-            <outputDirectory>/db/staging</outputDirectory>
+            <outputDirectory>db/staging</outputDirectory>
             <includes>
                 <include>**/*oracle.sql</include>
                 <include>**/*postgresql.sql</include>
@@ -35,7 +35,7 @@
         </fileSet>
          <fileSet>
             <directory>../${project.basedir}/datamodel/generated_scripts/</directory>
-            <outputDirectory>/db/rsgb</outputDirectory>
+            <outputDirectory>db/rsgb</outputDirectory>
             <includes>
                 <include>**/*oracle.sql</include>
                 <include>**/*postgresql.sql</include>
@@ -43,7 +43,7 @@
         </fileSet>
         <fileSet>
             <directory>../${project.basedir}/brmo-persistence/db/</directory>
-            <outputDirectory>/db/staging/</outputDirectory>
+            <outputDirectory>db/staging/</outputDirectory>
             <includes>
                 <include>**/*.sql</include>
             </includes>

--- a/brmo-loader/pom.xml
+++ b/brmo-loader/pom.xml
@@ -15,29 +15,45 @@
         <dependency>
             <groupId>commons-dbutils</groupId>
             <artifactId>commons-dbutils</artifactId>
-            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vividsolutions</groupId>
+            <artifactId>jts</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-main</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-epsg-hsql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools.xsd</groupId>
+            <artifactId>gt-xsd-gml3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools.jdbc</groupId>
+            <artifactId>gt-jdbc-oracle</artifactId>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${postgresql.jdbc.version}</version>
             <!-- Bij JNDI db verbinding moeten postgis jars in tomcat lib samen
             met postgresql jdbc driver staan -->
+            <scope>provided</scope>
         </dependency>
         <!--
             Bij gebruik van oracle met maven moet je de oracle jdbc driver
@@ -50,45 +66,18 @@
         <dependency>
             <groupId>com.oracle</groupId>
             <artifactId>ojdbc5</artifactId>
-            <version>${oracle.jdbc.version}</version>
             <!-- Bij JNDI db verbinding moeten Oracle jars in tomcat lib staan -->
-        </dependency>
-        <dependency>
-            <groupId>com.vividsolutions</groupId>
-            <artifactId>jts</artifactId>
-            <version>1.13</version>
-        </dependency>
-        <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-main</artifactId>
-            <version>${geotools.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-epsg-hsql</artifactId>
-            <version>${geotools.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.geotools.xsd</groupId>
-            <artifactId>gt-xsd-gml3</artifactId>
-            <version>${geotools.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.geotools.jdbc</groupId>
-            <artifactId>gt-jdbc-oracle</artifactId>
-            <version>${geotools.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.postgis</groupId>
             <artifactId>postgis-jdbc</artifactId>
-            <version>1.3.3</version>
             <!-- Bij JNDI db verbinding moeten postgis jars in tomcat lib samen
             met postgresql jdbc driver staan -->
         </dependency>
         <dependency>
             <groupId>org.javasimon</groupId>
             <artifactId>javasimon-core</artifactId>
-            <version>${javasimon.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -119,6 +108,7 @@
                         </goals>
                         <configuration>
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                            <excludeGroupIds>com.oracle</excludeGroupIds>
                         </configuration>
                     </execution>
                 </executions>

--- a/brmo-persistence/pom.xml
+++ b/brmo-persistence/pom.xml
@@ -17,55 +17,42 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
-            <version>${hibernate.version}</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${postgresql.jdbc.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.oracle</groupId>
             <artifactId>ojdbc5</artifactId>
-            <version>${oracle.jdbc.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <!-- nodig voor hibernate -->
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.10</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.185</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.1</version>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>nl.b3p</groupId>
             <artifactId>kadaster-gds2</artifactId>
-            <version>1.0</version>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.stripesstuff</groupId>
             <artifactId>stripersist</artifactId>
-            <version>1.0.3</version>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
-            <type>jar</type>
         </dependency>
     </dependencies>
     <build>
@@ -127,11 +114,10 @@
                         als test scope dep wordt opgevoerd treedt er een CNFE op tijdens de build. -->
                         <groupId>com.h2database</groupId>
                         <artifactId>h2</artifactId>
-                        <version>1.4.185</version>
+                        <version>${test.h2.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/brmo-proxyservice/pom.xml
+++ b/brmo-proxyservice/pom.xml
@@ -18,13 +18,10 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>javax</groupId>
             <artifactId>javaee-web-api</artifactId>
-            <version>7.0</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>
@@ -61,8 +58,6 @@
                                 <artifactItem>
                                     <groupId>javax</groupId>
                                     <artifactId>javaee-endorsed-api</artifactId>
-                                    <version>7.0</version>
-                                    <type>jar</type>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/brmo-service/pom.xml
+++ b/brmo-service/pom.xml
@@ -18,43 +18,35 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20140107</version>
         </dependency>
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.3.1</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.stripes</groupId>
             <artifactId>stripes</artifactId>
-            <version>1.5.8</version>
         </dependency>
         <dependency>
             <groupId>org.stripesstuff</groupId>
             <artifactId>stripesstuff</artifactId>
-            <version>0.4.1</version>
         </dependency>
         <dependency>
             <groupId>org.stripesstuff</groupId>
             <artifactId>stripersist</artifactId>
-            <version>1.0.3</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
-            <version>2.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jstl</groupId>
             <artifactId>jstl</artifactId>
-            <version>1.2</version>
         </dependency>
         <dependency>
             <groupId>nl.b3p</groupId>
@@ -83,35 +75,28 @@
         <dependency>
             <groupId>org.javasimon</groupId>
             <artifactId>javasimon-console-embed</artifactId>
-            <version>${javasimon.version}</version>
         </dependency>
         <dependency>
-            <!-- de volledige mail api dient door de servlet containet te worden geleverd. -->
+            <!-- de volledige mail api dient door de servlet container te worden geleverd. -->
             <groupId>javax.mail</groupId>
             <artifactId>javax.mail-api</artifactId>
-            <version>1.5.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
-            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz-jobs</artifactId>
-            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.8.1</version>
         </dependency>
         <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>jaxws-rt</artifactId>
-            <version>2.2.8</version>
-            <type>jar</type>
         </dependency>
     </dependencies>
     <build>
@@ -157,8 +142,6 @@
                                 <artifactItem>
                                     <groupId>javax</groupId>
                                     <artifactId>javaee-endorsed-api</artifactId>
-                                    <version>7.0</version>
-                                    <type>jar</type>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>
@@ -172,7 +155,7 @@
                     <execution>
                         <goals>
                             <goal>revision</goal>
-                         </goals>
+                        </goals>
                     </execution>
                 </executions>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -53,9 +53,217 @@
         de schema's voor posgresql en oracle worden niet automatisch aangemaakt.
         -->
         <test.persistence.unit>brmo.persistence.h2</test.persistence.unit>
+        <test.h2.version>1.4.190</test.h2.version>
         <maven.surefire.version>2.18.1</maven.surefire.version>
     </properties>
-    <dependencyManagement />
+    <dependencyManagement>
+        <dependencies>
+            <!-- logging libs -->
+            <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>1.2</version>
+            </dependency>
+            <dependency>
+                <!-- oa. nodig voor hibernate -->
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+                <version>1.7.10</version>
+            </dependency>
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>1.2.17</version>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.4</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-cli</groupId>
+                <artifactId>commons-cli</artifactId>
+                <version>1.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.1</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-fileupload</groupId>
+                <artifactId>commons-fileupload</artifactId>
+                <version>1.3.1</version>
+            </dependency>
+
+            <!-- spatial -->
+            <dependency>
+                <groupId>com.vividsolutions</groupId>
+                <artifactId>jts</artifactId>
+                <version>1.13</version>
+            </dependency>
+            <dependency>
+                <groupId>org.geotools</groupId>
+                <artifactId>gt-main</artifactId>
+                <version>${geotools.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.geotools</groupId>
+                <artifactId>gt-epsg-hsql</artifactId>
+                <version>${geotools.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.geotools.xsd</groupId>
+                <artifactId>gt-xsd-gml3</artifactId>
+                <version>${geotools.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.geotools.jdbc</groupId>
+                <artifactId>gt-jdbc-oracle</artifactId>
+                <version>${geotools.version}</version>
+            </dependency>
+            <!-- database en persistence -->
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-entitymanager</artifactId>
+                <version>${hibernate.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-dbutils</groupId>
+                <artifactId>commons-dbutils</artifactId>
+                <version>1.6</version>
+            </dependency>
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${postgresql.jdbc.version}</version>
+                <!-- Bij JNDI db verbinding moeten postgis jars in tomcat lib samen
+                met postgresql jdbc driver staan -->
+            </dependency>
+            <!--
+                Bij gebruik van oracle met maven moet je de oracle jdbc driver
+                handmatig toevoegen aan je locale mvn repo (licentie blabla): Dit
+                kan met: mvn install:install-file
+                -Dfile=/mnt/x_b3p_install/Databases/JDBC\ drivers/ojdbc5.jar
+                -DgroupId=com.oracle -DartifactId=ojdbc5 -Dversion=11.1.0.7.0
+                -Dpackaging=jar -DgeneratePom=true
+            -->
+            <dependency>
+                <groupId>com.oracle</groupId>
+                <artifactId>ojdbc5</artifactId>
+                <version>${oracle.jdbc.version}</version>
+                <!-- Bij JNDI db verbinding moeten Oracle jars in tomcat lib staan -->
+            </dependency>
+            <dependency>
+                <groupId>org.postgis</groupId>
+                <artifactId>postgis-jdbc</artifactId>
+                <version>1.3.3</version>
+            </dependency>
+            <dependency>
+                <groupId>nl.b3p</groupId>
+                <artifactId>kadaster-gds2</artifactId>
+                <version>1.0</version>
+            </dependency>           
+            <!-- J2EE dependencies en stripes -->
+            <dependency>
+                <groupId>org.stripesstuff</groupId>
+                <artifactId>stripersist</artifactId>
+                <version>1.0.3</version>
+            </dependency>
+            <dependency>
+                <groupId>net.sourceforge.stripes</groupId>
+                <artifactId>stripes</artifactId>
+                <version>1.5.8</version>
+            </dependency>
+            <dependency>
+                <groupId>org.stripesstuff</groupId>
+                <artifactId>stripesstuff</artifactId>
+                <version>0.4.1</version>
+            </dependency>
+            <dependency>
+                <groupId>javax</groupId>
+                <artifactId>javaee-web-api</artifactId>
+                <version>7.0</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax</groupId>
+                <artifactId>javaee-endorsed-api</artifactId>
+                <version>7.0</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <!-- de volledige mail api dient door de servlet container te worden geleverd. -->
+                <groupId>javax.mail</groupId>
+                <artifactId>javax.mail-api</artifactId>
+                <version>1.5.2</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>servlet-api</artifactId>
+                <version>2.5</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>jstl</groupId>
+                <artifactId>jstl</artifactId>
+                <version>1.2</version>
+            </dependency>
+            <!-- simon monitoring -->
+            <dependency>
+                <groupId>org.javasimon</groupId>
+                <artifactId>javasimon-core</artifactId>
+                <version>${javasimon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.javasimon</groupId>
+                <artifactId>javasimon-console-embed</artifactId>
+                <version>${javasimon.version}</version>
+            </dependency>
+            <!-- quartz scheduling -->
+            <dependency>
+                <groupId>org.quartz-scheduler</groupId>
+                <artifactId>quartz</artifactId>
+                <version>2.2.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.quartz-scheduler</groupId>
+                <artifactId>quartz-jobs</artifactId>
+                <version>2.2.1</version>
+            </dependency>
+            <!-- parsing ed. -->
+            <dependency>
+                <groupId>org.jsoup</groupId>
+                <artifactId>jsoup</artifactId>
+                <version>1.8.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.ws</groupId>
+                <artifactId>jaxws-rt</artifactId>
+                <version>2.2.8</version>
+            </dependency>
+            <dependency>
+                <groupId>org.json</groupId>
+                <artifactId>json</artifactId>
+                <version>20140107</version>
+            </dependency>
+            <!-- test dependencies -->
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${test.h2.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.12</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <prerequisites>
         <maven>3.2.5</maven>
     </prerequisites>
@@ -121,18 +329,14 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
  - [x] gebruik een dependency management sectie in de parent pom om alle versie te zetten
  - [x] zet scope voor postgres en oracle jdbc drivers op provided
  - [x] sluit oracle jdbc driver uit van packaging en dus distributie in de brmo-loader command line tool
    **NB** voor de command-line loader moet je dus een oracle jdbc driver in de classpath opnemen