### PR TITLE
BRMO tag library module

### DIFF
--- a/brmo-service/pom.xml
+++ b/brmo-service/pom.xml
@@ -73,6 +73,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>nl.b3p</groupId>
+            <artifactId>brmo-taglib</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.javasimon</groupId>
             <artifactId>javasimon-console-embed</artifactId>
         </dependency>

--- a/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/editberichtdoorsturenproces.jsp
+++ b/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/editberichtdoorsturenproces.jsp
@@ -19,8 +19,11 @@
         </td>
     </tr>
     <tr>
-        <td><stripes:label name="">Planning (cron expressie)</stripes:label></td>
-        <td><stripes:text name="proces.cronExpressie"/></td>
+        <td><stripes:label name="">Planning <a href="http://cronmaker.com" target="_blank">(cron expressie)</a></stripes:label></td>
+        <td>
+            <stripes:text name="proces.cronExpressie"/>
+            <brmo:formatCron cronExpression="${actionBean.proces.cronExpressie}" />
+        </td>
     </tr>
     <tr>
         <td><stripes:label name="">Commit page size (leeg voor default)</stripes:label></td>

--- a/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/editbrkdirscannerproces.jsp
+++ b/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/editbrkdirscannerproces.jsp
@@ -13,8 +13,11 @@
         <td><stripes:text name="config['archiefdirectory']"  /></td>
     </tr>
     <tr>
-        <td><stripes:label name="">Planning (cron expressie)</stripes:label></td>
-        <td><stripes:text name="proces.cronExpressie"/></td>
+        <td><stripes:label name="">Planning <a href="http://cronmaker.com" target="_blank">(cron expressie)</a></stripes:label></td>
+        <td>
+            <stripes:text name="proces.cronExpressie"/>
+            <brmo:formatCron cronExpression="${actionBean.proces.cronExpressie}" />
+        </td>
     </tr>
     <tr>
         <td><stripes:label name="">Commit page size (leeg voor default)</stripes:label></td>

--- a/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/editdirscannerproces.jsp
+++ b/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/editdirscannerproces.jsp
@@ -13,7 +13,10 @@
         <td><stripes:text name="config['archiefdirectory']"  /></td>
     </tr>
     <tr>
-        <td><stripes:label name="">Planning (cron expressie)</stripes:label></td>
-        <td><stripes:text name="proces.cronExpressie"/></td>
+        <td><stripes:label name="">Planning <a href="http://cronmaker.com" target="_blank">(cron expressie)</a></stripes:label></td>
+        <td>
+            <stripes:text name="proces.cronExpressie"/>
+            <brmo:formatCron cronExpression="${actionBean.proces.cronExpressie}" />
+        </td>
     </tr>
 </table>

--- a/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/editgds2proces.jsp
+++ b/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/editgds2proces.jsp
@@ -25,8 +25,11 @@
 <%--tr><td>Pad naar keystore:</td><td><stripes:text name="config['keystore_path']" size="80"/></td></tr--%>
 <%--tr><td>Wachtwoord keystore:</td><td><stripes:password name="config['keystore_password']" size="20"/></td></tr--%>
 <tr>
-    <td><stripes:label name="">Planning (cron expressie)</stripes:label></td>
-    <td><stripes:text name="proces.cronExpressie"/></td>
+    <td><stripes:label name="">Planning <a href="http://cronmaker.com" target="_blank">(cron expressie)</a></stripes:label></td>
+    <td>
+        <stripes:text name="proces.cronExpressie"/>
+        <brmo:formatCron cronExpression="${actionBean.proces.cronExpressie}" />
+    </td>
 </tr>
 <tr>
     <td>datum vanaf (dd-MM-yyyy formaat)</td>

--- a/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/editmailproces.jsp
+++ b/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/editmailproces.jsp
@@ -23,7 +23,10 @@
             </stripes:select></td>
     </tr>
     <tr>
-        <td><stripes:label name="">Planning (cron expressie)</stripes:label></td>
-        <td><stripes:text name="proces.cronExpressie"/></td>
+        <td><stripes:label name="">Planning <a href="http://cronmaker.com" target="_blank">(cron expressie)</a></stripes:label></td>
+        <td>
+            <stripes:text name="proces.cronExpressie"/>
+            <brmo:formatCron cronExpression="${actionBean.proces.cronExpressie}" />
+        </td>
     </tr>
 </table>

--- a/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/edittransformatieproces.jsp
+++ b/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/edittransformatieproces.jsp
@@ -5,7 +5,10 @@
         <td><stripes:text name="config['label']"/></td>
     </tr>
     <tr>
-        <td><stripes:label name="">Planning (cron expressie)</stripes:label></td>
-        <td><stripes:text name="proces.cronExpressie"/></td>
+        <td><stripes:label name="">Planning <a href="http://cronmaker.com" target="_blank">(cron expressie)</a></stripes:label></td>
+        <td>
+            <stripes:text name="proces.cronExpressie"/>
+            <brmo:formatCron cronExpression="${actionBean.proces.cronExpressie}" />
+        </td>
     </tr>
 </table>

--- a/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/editwebdirscannerproces.jsp
+++ b/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/editwebdirscannerproces.jsp
@@ -17,7 +17,10 @@
         <td><stripes:text name="config['csspath']" value="td:nth-child(2) > a[href]" /></td>
     </tr>
     <tr>
-        <td><stripes:label name="">Planning (cron expressie)</stripes:label></td>
-        <td><stripes:text name="proces.cronExpressie"/></td>
+        <td><stripes:label name="">Planning <a href="http://cronmaker.com" target="_blank">(cron expressie)</a></stripes:label></td>
+        <td>
+            <stripes:text name="proces.cronExpressie"/>
+            <brmo:formatCron cronExpression="${actionBean.proces.cronExpressie}" />
+        </td>
     </tr>
 </table>

--- a/brmo-service/src/main/webapp/WEB-INF/taglibs.jsp
+++ b/brmo-service/src/main/webapp/WEB-INF/taglibs.jsp
@@ -1,6 +1,7 @@
 <%@taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<%@taglib uri="http://brmo.b3p.nl/jsp/brmo" prefix="brmo" %>
 
 <%@taglib prefix="stripes" uri="http://stripes.sourceforge.net/stripes.tld" %>
 

--- a/brmo-taglib/pom.xml
+++ b/brmo-taglib/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>nl.b3p</groupId>
+    <artifactId>brmo-taglib</artifactId>
+    <version>1.3.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>nl.b3p</groupId>
+        <artifactId>brmo</artifactId>
+        <version>1.3.1-SNAPSHOT</version>
+    </parent>
+    <name>brmo taglibrary</name>
+    <build>
+        <plugins>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>net.redhogs.cronparser</groupId>
+            <artifactId>cron-parser-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax</groupId>
+            <artifactId>javaee-web-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/brmo-taglib/src/main/java/nl/b3p/web/jsp/CronFormatterTag.java
+++ b/brmo-taglib/src/main/java/nl/b3p/web/jsp/CronFormatterTag.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.web.jsp;
+
+import java.util.Locale;
+import net.redhogs.cronparser.CronExpressionDescriptor;
+import java.text.ParseException;
+import javax.servlet.jsp.tagext.SimpleTagSupport;
+import javax.servlet.jsp.JspException;
+import java.io.IOException;
+
+/**
+ * Formatter voor cron expressies. The default locale for this tag is
+ * {@code nl}.
+ *
+ * @author mprins
+ */
+public class CronFormatterTag extends SimpleTagSupport {
+
+    private String cronExpression;
+    private Locale locale;
+
+    public CronFormatterTag() {
+        setLocale("nl");
+    }
+
+    public void setCronExpression(String cronExpression) {
+        this.cronExpression = cronExpression;
+    }
+
+    public void setLocale(String locale) {
+        try {
+            this.locale = new Locale(locale);
+        } catch (NullPointerException npe) {
+            this.locale = null;
+        }
+    }
+
+    @Override
+    public void doTag() throws JspException, IOException {
+        String formatted = "";
+        if (cronExpression != null && !cronExpression.isEmpty()) {
+            try {
+                if (locale != null) {
+                    formatted = CronExpressionDescriptor.getDescription(cronExpression, locale);
+                } else {
+                    formatted = CronExpressionDescriptor.getDescription(cronExpression);
+                }
+            } catch (ParseException e) {
+                // ignore this error
+            }
+        }
+        getJspContext().getOut().write(formatted);
+    }
+
+}

--- a/brmo-taglib/src/main/resources/META-INF/brmo.tld
+++ b/brmo-taglib/src/main/resources/META-INF/brmo.tld
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<taglib xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd"
+        version="2.1">
+    <description>BRMO Custom Tags</description>
+    <tlib-version>2.1</tlib-version>
+    <short-name>brmo</short-name>
+    <uri>http://brmo.b3p.nl/jsp/brmo</uri>
+    <tag>
+        <name>formatCron</name>
+        <tag-class>nl.b3p.web.jsp.CronFormatterTag</tag-class>
+        <body-content>empty</body-content>
+        <description>Geeft een beschrijving van de cron expressie. Geeft een lege string als parsing van de expressie mislukt.</description>
+        <display-name>Cron Formatter</display-name>
+        <attribute>
+            <name>cronExpression</name>
+            <required>true</required>
+            <rtexprvalue>true</rtexprvalue>
+            <description>De te beschrijven expressie</description>
+        </attribute>
+        <attribute>
+            <name>locale</name>
+            <required>false</required>
+            <description>language code, bijv. 'nl'</description>
+        </attribute>
+    </tag>
+</taglib>

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
     <modules>
         <module>brmo-persistence</module>
         <module>brmo-loader</module>
+        <module>brmo-taglib</module>
         <module>brmo-service</module>
         <module>brmo-proxyservice</module>
         <module>brmo-soap</module>
@@ -240,6 +241,11 @@
                 <groupId>org.quartz-scheduler</groupId>
                 <artifactId>quartz-jobs</artifactId>
                 <version>2.2.2</version>
+            </dependency>
+            <dependency>
+                <groupId>net.redhogs.cronparser</groupId>
+                <artifactId>cron-parser-core</artifactId>
+                <version>2.8</version>
             </dependency>
             <!-- parsing ed. -->
             <dependency>


### PR DESCRIPTION
Met een tag om de cron expressie verstaanbaar te maken mbv. de cron-parser library. De cron expressie `0 15 11 ? * MON-FRI *` in de gui krijgt een beschrijving "Om 11:15 AM, van maandag tot vrijdag, elke jaar" 

NB mbt ''elke" zie RedHogs/cron-parser#32

Tevens een link naar de cronmaker website in de edit pagina's

![image](https://cloud.githubusercontent.com/assets/1165786/12822290/b381920a-cb67-11e5-84cf-6d3c1caa47e2.png)


close #50 