### PR TITLE
Voeg een ORDER BY toe bij sqlserver pagina queries (als die er niet is)

### DIFF
--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/jdbc/MssqlJdbcConverter.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/jdbc/MssqlJdbcConverter.java
@@ -3,6 +3,7 @@ package nl.b3p.brmo.loader.jdbc;
 
 import com.vividsolutions.jts.io.ParseException;
 import java.sql.SQLException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geolatte.geom.Geometry;
@@ -80,6 +81,11 @@ public class MssqlJdbcConverter extends GeometryJdbcConverter {
     @Override
     public String buildPaginationSql(String sql, int offset, int limit) {
         StringBuilder builder = new StringBuilder(sql);
+        if (!StringUtils.containsIgnoreCase(sql, "ORDER BY")) {
+            // OFFSET ... FETCH queries require order by,
+            // see https://msdn.microsoft.com/en-us/library/gg699618.aspx?f=255&MSPPError=-2147217396
+            builder.append(" ORDER BY id ");
+        }
         builder.append(" OFFSET ");
         builder.append(offset);
         builder.append(" ROWS FETCH NEXT ");


### PR DESCRIPTION
Het gebruik van een ORDER BY is verplicht bij gebruik van OFFSET ... FETCH queries, deze fix voegt een `order by id` toe aan de query tenzij er al eentje is gedefinieerd.

zie: https://msdn.microsoft.com/en-us/library/gg699618.aspx?f=255&MSPPError=-2147217396

zie: [mantis 5654](http://mantis.b3p.nl/view.php?id=5654)


close #130 