### PR TITLE
Bouw (en test) op AppVeyor (en SQL server 2012)

### DIFF
--- a/.appveyor/setting-tcp-ip-ports.ps1
+++ b/.appveyor/setting-tcp-ip-ports.ps1
@@ -1,0 +1,31 @@
+# See: http://www.appveyor.com/docs/services-databases#sql2012
+# Set the $instanceName value below to the name of the instance you
+# want to configure a static port for. This could conceivably be
+# passed into the script as a parameter.
+
+[reflection.assembly]::LoadWithPartialName("Microsoft.SqlServer.Smo") | Out-Null
+[reflection.assembly]::LoadWithPartialName("Microsoft.SqlServer.SqlWmiManagement") | Out-Null
+
+$serverName = $env:COMPUTERNAME
+$instanceName = $env:INSTANCENAME
+$wmi = new-object ('Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer')
+
+echo "computer name: $serverName"
+echo "instance name: $instanceName"
+
+# For the named instance, on the current computer, for the TCP protocol,
+# loop through all the IPs and configure them to use the standard port of 1433.
+$urn = "ManagedComputer[@Name='$serverName']/ServerInstance[@Name='$instanceName']/ServerProtocol[@Name='Tcp']"
+
+echo "getting uri: $urn"
+
+$Tcp = $wmi.GetSmoObject($urn)
+foreach ($ipAddress in $Tcp.IPAddresses)
+{
+    $ipAddress.IPAddressProperties["TcpDynamicPorts"].Value = ""
+    $ipAddress.IPAddressProperties["TcpPort"].Value = "1433"
+}
+$Tcp.Alter()
+
+# Restart the named instance of SQL Server to enable the changes.
+Restart-Service "MSSQL`$$instanceName"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/target/**
 **/git.properties
+**/local.*.properties
 
 # te groot + mogelijk gevoelige data
 /brmo-loader/src/test/resources/nl/b3p/brmo/loader/xml/BURBX01-ASN00-20091130-6000015280-9100000039.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
   - $HOME/.m2
 
 before_install:
-# set up STAGING
+# set up STAGING db
   - psql --version
   - psql -U postgres -a -c "CREATE ROLE staging LOGIN PASSWORD 'staging' SUPERUSER CREATEDB;"
   - psql -U postgres -a -c "CREATE ROLE rsgb LOGIN PASSWORD 'rsgb' SUPERUSER CREATEDB;"
@@ -26,11 +26,11 @@ before_install:
   - psql -U postgres -c 'create database rsgb;'
   - psql -U postgres -d rsgb -c 'create extension postgis;'
   - ls -l ./datamodel/generated_scripts/
-# set up RSGB
-  - travis_wait psql -U postgres -w -d rsgb -a -f ./datamodel/generated_scripts/datamodel_postgresql.sql
-  - ls -l ./datamodel/utility_scripts/
-#  - psql -U postgres -d rsgb -a -f ./datamodel/utility_scripts/111a_update_gemeente_geom.sql
-#  - psql -U postgres -d rsgb -a -f ./datamodel/utility_scripts/113a_update_wijk_geom.sql
+# set up RSGB db
+  - travis_wait psql -U postgres -w -d rsgb -f ./datamodel/generated_scripts/datamodel_postgresql.sql
+  - ls -l ./datamodel/utility_scripts/postgresql/
+  - travis_wait psql -U postgres -w -d rsgb -f ./datamodel/utility_scripts/postgresql/111a_update_gemeente_geom.sql
+  - travis_wait psql -U postgres -w -d rsgb -f ./datamodel/utility_scripts/postgresql/113a_update_wijk_geom.sql
 
 install:
   # install all dependencies + artifacts without any testing, create staging db scripts

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,76 @@
+version: "{build}-{branch}"
+clone_folder: c:\projects\brmo
+clone_depth: 5
+skip_tags: true
+
+services: mssql2012sp1
+
+environment:
+  INSTANCENAME: SQL2012SP1
+
+matrix:
+  fast_finish: false
+
+init:
+  - git config --global core.autocrlf input
+  - git config --global core.safecrlf true
+
+install:
+  - ps: >-
+      Add-Type -AssemblyName System.IO.Compression.FileSystem
+          if (!(Test-Path -Path "C:\maven\apache-maven-3.3.3" )) {
+            (new-object System.Net.WebClient).DownloadFile(
+              'http://www.us.apache.org/dist/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.zip',
+              'C:\maven-bin.zip'
+            )
+            [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
+          }
+  - cmd: SET PATH=C:\maven\apache-maven-3.3.3\bin;%JAVA_HOME%\bin;%PATH%
+  - cmd: echo %PATH%
+  - cmd: java -version
+  - cd C:\projects\brmo
+  # initial build, no testing
+  - mvn install -Dmaven.test.skip=true -B -V -fae -q -Pappveyor-ci -pl "!brmo-dist"  
+
+
+# before_build: does nothing
+build: off
+# after_build: does nothing
+
+before_test:
+# services are started after install, so we need to wait 
+# create STAGING DB
+  - sqlcmd -S (local)\SQL2012SP1 -U sa -P Password12! -Q "CREATE DATABASE staging" -d "master"
+  - dir -w .\datamodel\generated_scripts\
+# create + set up RSGB DB
+  - sqlcmd -S (local)\SQL2012SP1 -U sa -P Password12! -Q "CREATE DATABASE rsgb" -d "master"
+  - dir -w .\datamodel\utility_scripts\
+  - sqlcmd -S (local)\SQL2012SP1 -U sa -P Password12! -d "rsgb" -i .\datamodel\generated_scripts\datamodel_sqlserver.sql
+# set up STAGING DB
+  - dir -w .\brmo-persistence\target\ddlscripts\
+#  - sqlcmd -S localhost,1433 -U sa -P Password12! -d "staging" -i .\brmo-persistence\target\ddlscripts\create-brmo-persistence-sqlserver.sql
+  - sqlcmd -S (local)\SQL2012SP1 -U sa -P Password12! -d "staging" -i .\brmo-persistence\db\create-brmo-persistence-sqlserver.sql
+  - dir -w .\brmo-persistence\db\
+  - sqlcmd -S (local)\SQL2012SP1 -U sa -P Password12! -d "staging" -i .\brmo-persistence\db\01_create_indexes.sql
+  - sqlcmd -S (local)\SQL2012SP1 -U sa -P Password12! -d "staging" -i .\brmo-persistence\db\02_insert_default_user.sql
+  - cmd: echo "computer name:" %COMPUTERNAME%
+  - cmd: echo "instance name:" %INSTANCENAME%
+  - ps: .\.appveyor\setting-tcp-ip-ports.ps1
+
+test_script:
+# run unit tests
+  - mvn -e test -B -Pappveyor-ci -pl "!brmo-dist"
+# run integration tests
+# TODO configure sql server to listen on ip address, see: https://www.appveyor.com/docs/services-databases
+  - mvn -e verify -B -Pappveyor-ci -pl "!brmo-dist"
+
+after_test:
+  - ps: Get-Date
+
+# on_success:
+# on_failure:
+# on_finish:
+
+cache:
+  - C:\maven\apache-maven-3.3.3 -> appveyor.yml
+  - C:\Users\appveyor\.m2\repository -> pom.xml

--- a/brmo-service/pom.xml
+++ b/brmo-service/pom.xml
@@ -241,10 +241,10 @@
                         <artifactId>tomcat7-maven-plugin</artifactId>
                         <configuration>
                             <port>9090</port>
-                            <!-- Note: dit bestand wordt neergezet tijdens 'test' phase. 
+                            <!-- Note: dit bestand wordt neergezet tijdens 'test' phase.
                             Om Tomcat standalone te draaien gebruik je
                             'mvn clean test tomcat7:run -Ptravis-ci' -->
-                            <contextFile>${project.build.directory}/test-classes/testcontext.xml</contextFile>--&gt;
+                            <contextFile>${project.build.directory}/test-classes/testcontext.xml</contextFile>
                         </configuration>
                         <executions>
                             <execution>
@@ -285,7 +285,112 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <configuration />
+                        <configuration>
+                            <systemPropertyVariables>
+                                <database.properties.file>postgres.properties</database.properties.file>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>appveyor-ci</id>
+            <properties>
+                <test.persistence.unit>brmo.persistence.sqlserver</test.persistence.unit>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>net.sourceforge.jtds</groupId>
+                    <artifactId>jtds</artifactId>
+                    <version>${sqlserver.jtds.version}</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <filters>
+                    <filter>${project.basedir}/src/test/resources/sqlserver.properties</filter>
+                </filters>
+                <testResources>
+                    <testResource>
+                        <directory>${project.basedir}/src/test/tomcatconf/</directory>
+                        <filtering>true</filtering>
+                    </testResource>
+                    <testResource>
+                        <directory>${project.basedir}/src/test/resources/</directory>
+                    </testResource>
+                </testResources>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>properties-maven-plugin</artifactId>
+                        <configuration>
+                            <files>
+                                <file>${project.basedir}/src/test/resources/sqlserver.properties</file>
+                            </files>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>read-project-properties</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.tomcat.maven</groupId>
+                        <artifactId>tomcat7-maven-plugin</artifactId>
+                        <configuration>
+                            <port>9090</port>
+                            <!-- Note: dit bestand wordt neergezet tijdens 'test' phase.
+                            Om Tomcat standalone te draaien gebruik je
+                            'mvn clean test tomcat7:run -Pappveyor-ci' -->
+                            <contextFile>${project.build.directory}/test-classes/testcontext.xml</contextFile>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>tomcat-run</id>
+                                <goals>
+                                    <goal>run-war-only</goal>
+                                </goals>
+                                <phase>pre-integration-test</phase>
+                                <configuration>
+                                    <fork>true</fork>
+                                    <skip>${maven.test.skip}</skip>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>tomcat-shutdown</id>
+                                <goals>
+                                    <goal>shutdown</goal>
+                                </goals>
+                                <phase>post-integration-test</phase>
+                                <configuration>
+                                    <skip>${maven.test.skip}</skip>
+                                    <skipErrorOnShutdown>true</skipErrorOnShutdown>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>javax.mail</groupId>
+                                <artifactId>mail</artifactId>
+                                <version>1.4.7</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>net.sourceforge.jtds</groupId>
+                                <artifactId>jtds</artifactId>
+                                <version>${sqlserver.jtds.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <database.properties.file>sqlserver.properties</database.properties.file>
+                            </systemPropertyVariables>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/brmo-service/src/test/java/nl/b3p/web/IndexPageIntegrationTest.java
+++ b/brmo-service/src/test/java/nl/b3p/web/IndexPageIntegrationTest.java
@@ -30,12 +30,12 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.util.EntityUtils;
 import static org.hamcrest.CoreMatchers.equalTo;
+import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import org.junit.Test;
 
 /**
  * Integration test for the index page.
@@ -79,14 +79,13 @@ public class IndexPageIntegrationTest extends TestUtil {
         String default_hash = "6310227872580fec7d1262ab7ab3b4b3902a9f61";
 
         try {
-            Class.forName(POSTGRESPROPS.getProperty("postgres.driverClassName"));
+            Class.forName(DBPROPS.getProperty("jdbc.driverClassName"));
         } catch (ClassNotFoundException ex) {
-            fail("Laden van Postgres driver is mislukt.");
+            fail("Laden van database driver (" + DBPROPS.getProperty("jdbc.driverClassName") + ") is mislukt.");
         }
-        Connection connection = DriverManager.getConnection(
-                POSTGRESPROPS.getProperty("staging.url"),
-                POSTGRESPROPS.getProperty("staging.username"),
-                POSTGRESPROPS.getProperty("staging.password")
+        Connection connection = DriverManager.getConnection(DBPROPS.getProperty("staging.url"),
+                DBPROPS.getProperty("staging.username"),
+                DBPROPS.getProperty("staging.password")
         );
         ResultSet rs = connection.createStatement().executeQuery("SELECT gebruikersnaam, wachtwoord FROM gebruiker_;");
 

--- a/brmo-service/src/test/java/nl/b3p/web/TestUtil.java
+++ b/brmo-service/src/test/java/nl/b3p/web/TestUtil.java
@@ -1,10 +1,12 @@
 package nl.b3p.web;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.junit.AfterClass;
@@ -21,11 +23,12 @@ public abstract class TestUtil {
      */
     public static final String BASE_TEST_URL = "http://localhost:9090/brmo-service/";
     /**
-     * This has the database properties as defined in 'postgres.properties'.
+     * This has the database properties as defined in 'postgres.properties' or
+     * sqlserver.properties.
      *
      * @see #loadDBprop()
      */
-    protected static final Properties POSTGRESPROPS = new Properties();
+    protected static final Properties DBPROPS = new Properties();
 
     /**
      * our test client.
@@ -33,13 +36,22 @@ public abstract class TestUtil {
     protected static CloseableHttpClient client;
 
     /**
-     * initialize database props.
+     * initialize database props using the environment provided file.
      *
      * @throws java.io.IOException if loading the property file fails
      */
     @BeforeClass
     public static void loadDBprop() throws IOException {
-        POSTGRESPROPS.load(IndexPageIntegrationTest.class.getClassLoader().getResourceAsStream("postgres.properties"));
+        // the `database.properties.file`  is set in the pom.xml or using the commandline
+        DBPROPS.load(IndexPageIntegrationTest.class.getClassLoader()
+                .getResourceAsStream(System.getProperty("database.properties.file")));
+        try {
+            // see if a local version exists and use that to override
+            DBPROPS.load(IndexPageIntegrationTest.class.getClassLoader()
+                    .getResourceAsStream("local." + System.getProperty("database.properties.file")));
+        } catch (IOException | NullPointerException e) {
+            // ignore this 
+        }
     }
 
     /**

--- a/brmo-service/src/test/resources/postgres.properties
+++ b/brmo-service/src/test/resources/postgres.properties
@@ -6,4 +6,4 @@ staging.username=staging
 staging.password=staging
 staging.url=jdbc:postgresql://localhost:5432/staging
 
-postgres.driverClassName=org.postgresql.Driver
+jdbc.driverClassName=org.postgresql.Driver

--- a/brmo-service/src/test/resources/sqlserver.properties
+++ b/brmo-service/src/test/resources/sqlserver.properties
@@ -1,0 +1,9 @@
+rsgb.username=sa
+rsgb.password=Password12!
+rsgb.url=jdbc:jtds:sqlserver://127.0.0.1:1433/rsgb;instance=SQL2012SP1
+
+staging.username=sa
+staging.password=Password12!
+staging.url=jdbc:jtds:sqlserver://127.0.0.1:1433/staging;instance=SQL2012SP1
+
+jdbc.driverClassName=net.sourceforge.jtds.jdbc.Driver

--- a/brmo-service/src/test/tomcatconf/testcontext.xml
+++ b/brmo-service/src/test/tomcatconf/testcontext.xml
@@ -11,7 +11,7 @@
               minEvictableIdleTimeMillis="5000"
               username="${staging.username}"
               password="${staging.password}"
-              driverClassName="${postgres.driverClassName}"
+              driverClassName="${jdbc.driverClassName}"
               url="${staging.url}"
     />
     
@@ -24,7 +24,7 @@
               minEvictableIdleTimeMillis="5000"
               username="${rsgb.username}"
               password="${rsgb.password}"
-              driverClassName="${postgres.driverClassName}"
+              driverClassName="${jdbc.driverClassName}"
               url="${rsgb.url}"
     />
 
@@ -55,7 +55,7 @@
            userNameCol="gebruikersnaam"
            userRoleTable="gebruiker_groepen"
            userTable="gebruiker_"
-           driverName="${postgres.driverClassName}"
+           driverName="${jdbc.driverClassName}"
            connectionURL="${staging.url}?user=${staging.username}&amp;password=${staging.password}"
     / -->
 </Context>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <postgresql.jdbc.version>9.3-1102-jdbc4</postgresql.jdbc.version>
         <oracle.jdbc.version>11.1.0.7.0</oracle.jdbc.version>
         <oracle.jdbc.artifactId>ojdbc5</oracle.jdbc.artifactId>
+        <sqlserver.jtds.version>1.3.1</sqlserver.jtds.version>
         <javasimon.version>4.0.1</javasimon.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -173,7 +174,7 @@
                 <groupId>nl.b3p</groupId>
                 <artifactId>kadaster-gds2</artifactId>
                 <version>1.0</version>
-            </dependency>           
+            </dependency>
             <!-- J2EE dependencies en stripes -->
             <dependency>
                 <groupId>org.stripesstuff</groupId>
@@ -333,8 +334,8 @@
         of:
         https://www.oracle.com/webapps/maven/register/register.html
         -->
-        <!-- lijkt niet goed te werken met maven 3.3.3, voorlopig zelf installeren;        
-        zie brmo-loader/pom.xml  
+        <!-- lijkt niet goed te werken met maven 3.3.3, voorlopig zelf installeren;
+        zie brmo-loader/pom.xml
         <repository>
             <id>maven.oracle.com</id>
             <url>https://maven.oracle.com</url>
@@ -654,6 +655,23 @@
     <profiles>
         <profile>
             <id>travis-ci</id>
+            <properties>
+                <oracle.jdbc.artifactId>ojdbc6</oracle.jdbc.artifactId>
+                <oracle.jdbc.version>11.2.0.3</oracle.jdbc.version>
+            </properties>
+            <repositories>
+                <repository>
+                    <id>maven.oracle.com</id>
+                    <url>https://code.lds.org/nexus/content/groups/main-repo</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                </repository>
+            </repositories>
+        </profile>
+        <profile>
+            <id>appveyor-ci</id>
             <properties>
                 <oracle.jdbc.artifactId>ojdbc6</oracle.jdbc.artifactId>
                 <oracle.jdbc.version>11.2.0.3</oracle.jdbc.version>


### PR DESCRIPTION
Met deze PR komt de basis voor het testen op AppVeyor.

Vooralsnog: 
  - [x] worden de databases schema's aangemaakt in SQL server 2012
  - [x] worden de beschikbare unit tests gedraaid op oracle java 7 en 8 
  - [x] wordt een tomcat instantie gestart met daarin de brmo-service webapplicatie
  - [x] wordt een [integratie test](https://github.com/B3Partners/brmo/blob/travis-integration/brmo-service/src/test/java/nl/b3p/web/IndexPageIntegrationTest.java) uitgevoerd om te kijken of de webapplicatie gestart is en of inloggen lukt

zie ook: #85