### PR TITLE
Fix typo in datamodel conversie

### DIFF
--- a/bgt-gml-loader/src/main/java/nl/b3p/brmo/loader/gml/BGTGMLLightLoader.java
+++ b/bgt-gml-loader/src/main/java/nl/b3p/brmo/loader/gml/BGTGMLLightLoader.java
@@ -182,7 +182,7 @@ public class BGTGMLLightLoader {
                     LOG.warn("Overslaan zip entry geen GML bestand: " + entry.getName());
                 } else {
                     eName = entry.getName();
-                    LOG.debug("Lezen GML bestand: " + eName + " uit zip file: " + zipExtract.getCanonicalPath());
+                    LOG.info("Lezen GML bestand: " + eName + " uit zip file: " + zipExtract.getCanonicalPath());
                     result = storeFeatureCollection(new CloseShieldInputStream(zip), eName.toLowerCase());
                     opmerkingen.append(result)
                             .append(" features geladen uit: ")

--- a/bgt-gml-loader/src/main/xml/datamodel.xml
+++ b/bgt-gml-loader/src/main/xml/datamodel.xml
@@ -100,10 +100,9 @@ Copyright (C) 2016 B3Partners B.V.
         <attribuut xslname="identificatieBAGOPR" sqlname="identif_bagopr" sqltype="varchar(255)" />
         <attribuut xslname="openbareRuimteNaam.tekst" sqlname="oprnm_tekst" sqltype="varchar(255)" />
 
-        <!--attribuut xslname="openbareRuimteNaam.positie_1.plaatsingspunt" sqlname="oprnm_pos_1_punt" sqltype="point" /-->
         <attribuut xslname="openbareRuimteNaam.positie_1.plaatsingspunt" sqlname="DEFAULT_GEOM_NAME" sqltype="point" />
         <attribuut xslname="openbareRuimteNaam.positie_1.hoek" sqlname="oprnm_pos_1_hoek" sqltype="float(23)" />
-        <attribuut xslname="openbareRuimteNaam.positie_1.plaatsingspunt" sqlname="oprnm_pos_2_punt" sqltype="point" />
+        <attribuut xslname="openbareRuimteNaam.positie_2.plaatsingspunt" sqlname="oprnm_pos_2_punt" sqltype="point" />
         <attribuut xslname="openbareRuimteNaam.positie_2.hoek" sqlname="oprnm_pos_2_hoek" sqltype="float(23)" />
         <attribuut xslname="openbareRuimteNaam.positie_3.plaatsingspunt" sqlname="oprnm_pos_3_punt" sqltype="point" />
         <attribuut xslname="openbareRuimteNaam.positie_3.hoek" sqlname="oprnm_pos_3_hoek" sqltype="float(23)" />

--- a/datamodel/upgrade_scripts/1.3.4-1.3.5/oracle/rsgbbgt.sql
+++ b/datamodel/upgrade_scripts/1.3.4-1.3.5/oracle/rsgbbgt.sql
@@ -1,0 +1,9 @@
+-- upgrade RSGBBGT datamodel van 1.3.4 naar 1.3.5 (Oracle)
+
+-- fix verkeerde data in openbareruimtelabel tabel (zie https://github.com/B3Partners/brmo/issues/192)
+-- kopieer de data uit oprnm_pos_2_punt naar geom2d waar deze initieel geladen zou zijn
+-- het is mogelijk dat hierbij data die werkelijk oprnm_pos_2_punt is in oprnm_pos_1_punt terecht komt
+-- dat is alleen te verhelpen door de GML bestanden opnieuw te transformeren
+update OPENBARERUIMTELABEL
+   set GEOM2D = OPRNM_POS_2_PUNT
+   where GEOM2D is null;

--- a/datamodel/upgrade_scripts/1.3.4-1.3.5/postgresql/rsgbbgt.sql
+++ b/datamodel/upgrade_scripts/1.3.4-1.3.5/postgresql/rsgbbgt.sql
@@ -1,0 +1,10 @@
+-- upgrade RSGBBGT datamodel van 1.3.4 naar 1.3.5 (PostgreSQL)
+
+-- fix verkeerde data in openbareruimtelabel tabel (zie https://github.com/B3Partners/brmo/issues/192)
+-- kopieer de data uit oprnm_pos_2_punt naar geom2d waar deze initieel geladen zou zijn
+-- het is mogelijk dat hierbij data die werkelijk oprnm_pos_2_punt is in oprnm_pos_1_punt terecht komt
+-- dat is alleen te verhelpen door de GML bestanden opnieuw te transformeren
+UPDATE openbareruimtelabel
+   SET geom2d = oprnm_pos_2_punt
+   WHERE geom2d is null;
+

--- a/datamodel/upgrade_scripts/1.3.4-1.3.5/sqlserver/rsgbbgt.sql
+++ b/datamodel/upgrade_scripts/1.3.4-1.3.5/sqlserver/rsgbbgt.sql
@@ -1,0 +1,9 @@
+-- upgrade RSGBBGT datamodel van 1.3.4 naar 1.3.5 (MS SQL server)
+
+-- fix verkeerde data in openbareruimtelabel tabel (zie https://github.com/B3Partners/brmo/issues/192)
+-- kopieer de data uit oprnm_pos_2_punt naar geom2d waar deze initieel geladen zou zijn
+-- het is mogelijk dat hierbij data die werkelijk oprnm_pos_2_punt is in oprnm_pos_1_punt terecht komt
+-- dat is alleen te verhelpen door de GML bestanden opnieuw te transformeren
+UPDATE openbareruimtelabel
+   SET geom2d = oprnm_pos_2_punt
+   WHERE geom2d is null;


### PR DESCRIPTION
 - [x] oplossen fout
 - [x] upgrade/datafix script: 
        kopieert de data (geometrie) uit oprnm_pos_2_punt naar geom2d waar deze initieel geladen zou zijn, het is mogelijk dat hierbij een geometrie die werkelijk `openbareRuimteNaam.positie_2.plaatsingspunt`(`oprnm_pos_2_punt`) is in `openbareRuimteNaam.positie_1.plaatsingspunt` (`geom2d`) terecht komt dat is alleen te verhelpen door  alle openbare ruimte GML bestanden opnieuw te transformeren, maar dat wordt sowieso -integraal- gedaan met de eerstvolgende data update. Gezien het kleine aantal draaiende implementaties laten we het hierbij.
 - [x] release note


close #192