### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,12 @@
         <netbeans.hint.license>default_1</netbeans.hint.license>
         <hibernate.version>3.6.10.Final</hibernate.version>
         <geotools.version>14.4</geotools.version>
-        <postgresql.jdbc.version>9.4.1208.jre7</postgresql.jdbc.version>
+        <postgresql.jdbc.version>9.4.1209.jre7</postgresql.jdbc.version>
         <oracle.jdbc.version>11.1.0.7.0</oracle.jdbc.version>
         <oracle.jdbc.artifactId>ojdbc5</oracle.jdbc.artifactId>
         <sqlserver.jtds.version>1.3.1</sqlserver.jtds.version>
-        <javasimon.version>4.0.1</javasimon.version>
+        <javasimon.version>4.1.1</javasimon.version>
+        <quartz.version>2.2.3</quartz.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- om unit tests met postgres te draaien gebruik je
@@ -61,11 +62,15 @@
         de schema's voor posgresql en oracle worden niet automatisch aangemaakt.
         -->
         <test.persistence.unit>brmo.persistence.h2</test.persistence.unit>
-        <test.h2.version>1.4.191</test.h2.version>
+        <test.h2.version>1.4.192</test.h2.version>
         <test.onlyITs>false</test.onlyITs>
         <maven.surefire.version>2.19.1</maven.surefire.version>
     </properties>
     <dependencyManagement>
+        <!--
+        voor een update controle gebruik je het volgende maven commando:
+        mvn -U org.codehaus.mojo:versions-maven-plugin:2.3:display-dependency-updates
+        -->
         <dependencies>
             <!-- logging libs -->
             <dependency>
@@ -77,7 +82,7 @@
                 <!-- oa. nodig voor hibernate -->
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
-                <version>1.7.12</version>
+                <version>1.7.21</version>
             </dependency>
             <dependency>
                 <groupId>log4j</groupId>
@@ -88,22 +93,22 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.4</version>
+                <version>2.5</version>
             </dependency>
             <dependency>
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
-                <version>1.2</version>
+                <version>1.3.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.1</version>
+                <version>3.4</version>
             </dependency>
             <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
-                <version>1.3.1</version>
+                <version>1.3.2</version>
             </dependency>
 
             <!-- spatial -->
@@ -232,7 +237,7 @@
                 <!-- de volledige mail api dient door de servlet container te worden geleverd. -->
                 <groupId>javax.mail</groupId>
                 <artifactId>javax.mail-api</artifactId>
-                <version>1.5.4</version>
+                <version>1.5.5</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -261,12 +266,12 @@
             <dependency>
                 <groupId>org.quartz-scheduler</groupId>
                 <artifactId>quartz</artifactId>
-                <version>2.2.2</version>
+                <version>${quartz.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.quartz-scheduler</groupId>
                 <artifactId>quartz-jobs</artifactId>
-                <version>2.2.2</version>
+                <version>${quartz.version}</version>
             </dependency>
             <dependency>
                 <groupId>net.redhogs.cronparser</groupId>
@@ -277,22 +282,22 @@
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.8.3</version>
+                <version>1.9.2</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.ws</groupId>
                 <artifactId>jaxws-rt</artifactId>
-                <version>2.2.8</version>
+                <version>2.2.10</version>
             </dependency>
             <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
-                <version>20140107</version>
+                <version>20160807</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.9.1</version>
+                <version>2.9.4</version>
             </dependency>
             <!-- test dependencies -->
             <dependency>
@@ -337,7 +342,7 @@
     </distributionManagement>
     <repositories>
         <repository>
-            <id>boundless</id>
+            <id>Boundless</id>
             <name>Boundless Maven Repository</name>
             <url>http://repo.boundlessgeo.com/main</url>
         </repository>
@@ -347,7 +352,7 @@
             <url>http://maven.geo-solutions.it/</url>
         </repository>
         <repository>
-            <id>osgeo</id>
+            <id>OSGeo</id>
             <name>Open Source Geospatial Foundation Repository</name>
             <url>http://download.osgeo.org/webdav/geotools/</url>
         </repository>
@@ -379,6 +384,7 @@
             <id>nexus.codehaus.org</id>
             <name>Former (now non-existant) CodeHaus Maven Repository</name>
             <url>https://nexus.codehaus.org/snapshots/</url>
+            <!-- both releases and snapshots set to false -->
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -404,6 +410,10 @@
     <build>
         <pluginManagement>
             <plugins>
+                <!--
+                voor een update controle gebruik je het volgende maven commando:
+                mvn -U org.codehaus.mojo:versions-maven-plugin:2.3:display-plugin-updates
+                -->
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>


### PR DESCRIPTION
update van de volgende libraries:
  - javasimon
  - quartz
  - commons-io
  - commons-cli
  - commons-lang3
  - commons-fileupload
  - jsoup
  - jaxws-rt
  - json
  - joda-time

en een aantal provided en test scope dependencies.

fixes voor security issues:
  - [CVE-2016-3092](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3092)
