### PR TITLE
Aankoopdatum perceel beschikbaar maken

### DIFF
--- a/brmo-loader/src/main/resources/xsl/brk-snapshot-to-rsgb-xml.xsl
+++ b/brmo-loader/src/main/resources/xsl/brk-snapshot-to-rsgb-xml.xsl
@@ -677,12 +677,30 @@
 					<xsl:value-of select="."/>
 				</datum>
 			</xsl:for-each>
-            <xsl:for-each select="Stuk:deelEnNummer">
-                <omschrijving><xsl:text>deel: </xsl:text><xsl:value-of select="Stuk:deel"/>
-                <xsl:text>, nummer: </xsl:text><xsl:value-of select="Stuk:nummer"/>
-                <xsl:text>, registercode: </xsl:text><xsl:value-of select="Stuk:registercode/typ:waarde"/>
-                <xsl:text>, soortregister: </xsl:text><xsl:value-of select="Stuk:soortRegister/typ:waarde"/></omschrijving>
-            </xsl:for-each>
+            <xsl:choose>
+                <xsl:when test="Stuk:deelEnNummer">
+                    <xsl:for-each select="Stuk:deelEnNummer">
+                        <omschrijving>
+                            <xsl:text>deel: </xsl:text>
+                            <xsl:value-of select="Stuk:deel"/>
+                            <xsl:text>, nummer: </xsl:text>
+                            <xsl:value-of select="Stuk:nummer"/>
+                            <xsl:text>, registercode: </xsl:text>
+                            <xsl:value-of select="Stuk:registercode/typ:waarde"/>
+                            <xsl:text>, soortregister: </xsl:text>
+                            <xsl:value-of select="Stuk:soortRegister/typ:waarde"/>
+                        </omschrijving>
+                    </xsl:for-each>
+                </xsl:when>
+                <xsl:otherwise>
+                    <omschrijving>
+                        <xsl:if test="Stuk:AKRPortefeuilleNr">
+                            <xsl:text>AKR Portefeuille Nr: </xsl:text>
+                            <xsl:value-of select="Stuk:AKRPortefeuilleNr"/>
+                        </xsl:if>
+                    </omschrijving>
+                </xsl:otherwise>
+            </xsl:choose>
 			<xsl:choose>
 				<xsl:when test="../ko:Perceel">
 					<tabel>KAD_PERCEEL</tabel>

--- a/brmo-loader/src/main/resources/xsl/brk-snapshot-to-rsgb-xml.xsl
+++ b/brmo-loader/src/main/resources/xsl/brk-snapshot-to-rsgb-xml.xsl
@@ -184,15 +184,9 @@
             <ks_bedrag>
                 <xsl:value-of select="$oz/ko:koopsom/ko:bedrag/typ:som"/>
             </ks_bedrag>
-            <!--ks_valutasoort>
-				<!- - TODO: zoek waarde op van groepsattribuut
-                  Toelichting RSGB: "De attribuutsort maakt deel uit van het groepattribuutsoort
-                  Koopsom en is afgeleid van het subdomein CurrencyID van het domein Koopsom in
-                  de catalogus BRK. Zie verder de toelichting in de BRK.
-				- ->
-				0
-                <!- -xsl:value-of select="$oz/ko:koopsom/ko:bedrag/typ:valuta/typ:code"/- ->
-            </ks_valutasoort-->
+            <ks_valutasoort>
+                <xsl:value-of select="$oz/ko:koopsom/ko:bedrag/typ:valuta/typ:waarde"/>
+            </ks_valutasoort>
             <xsl:if test="$oz/ko:koopsom/ko:koopjaar">
                 <ks_koopjaar>
                     <xsl:value-of select="$oz/ko:koopsom/ko:koopjaar"/>
@@ -202,6 +196,9 @@
 				<xsl:if test="$oz/ko:koopsom/ko:indicatieMeerObjecten">J</xsl:if>
 				<xsl:if test="not($oz/ko:koopsom/ko:indicatieMeerObjecten)">N</xsl:if>
             </ks_meer_onroerendgoed>
+            <!-- TODO: van eerste tenaamstelling recht het stukdeel ophalen; van dat stuk de datum nemen
+            <ks_transactiedatum></ks_transactiedatum>
+             -->
             <cu_aard_bebouwing>
                 <xsl:value-of select="$oz/ko:heeftLocatie/ko:LocatieKadastraalObject/ko:cultuurBebouwd/ko:code"/>
             </cu_aard_bebouwing>
@@ -680,18 +677,30 @@
 					<xsl:value-of select="."/>
 				</datum>
 			</xsl:for-each>
+            <xsl:for-each select="Stuk:deelEnNummer">
+                <omschrijving><xsl:text>deel: </xsl:text><xsl:value-of select="Stuk:deel"/>
+                <xsl:text>, nummer: </xsl:text><xsl:value-of select="Stuk:nummer"/>
+                <xsl:text>, registercode: </xsl:text><xsl:value-of select="Stuk:registercode/typ:waarde"/>
+                <xsl:text>, soortregister: </xsl:text><xsl:value-of select="Stuk:soortRegister/typ:waarde"/></omschrijving>
+            </xsl:for-each>
 			<xsl:choose>
 				<xsl:when test="../ko:Perceel">
 					<tabel>KAD_PERCEEL</tabel>
 					<tabel_identificatie>
-						<xsl:value-of select="../ko:Perceel/ko:identificatie/nen:lokaalId"/>
+                        <xsl:value-of select="../ko:Perceel/ko:identificatie/nen:lokaalId"/>
 					</tabel_identificatie>
+                    <ref_id>
+                        <xsl:value-of select="../ko:Perceel/ko:identificatie/nen:lokaalId"/>
+                    </ref_id>
 				</xsl:when>
 				<xsl:when test="../ko:Appartementsrecht">
 					<tabel>APP_RE</tabel>
 					<tabel_identificatie>
 						<xsl:value-of select="../ko:Appartementsrecht/ko:identificatie/nen:lokaalId"/>
 					</tabel_identificatie>
+                    <ref_id>
+                        <xsl:value-of select="../ko:Appartementsrecht/ko:identificatie/nen:lokaalId"/>
+                    </ref_id>
 				</xsl:when>
 				<!--
 				<xsl:otherwise>
@@ -703,6 +712,7 @@
 				-->
 			</xsl:choose>
 		</brondocument>
+        
 		<xsl:for-each select="Stuk:omvat/Stuk:Stukdeel">
 			<brondocument ignore-duplicates="yes">
 				<identificatie>
@@ -712,6 +722,13 @@
 				</identificatie>
 				<tabel>BRONDOCUMENT</tabel>
 				<tabel_identificatie><xsl:value-of select="$parent-id"/></tabel_identificatie>
+                <xsl:for-each select="Stuk:aardStukdeel">
+                    <omschrijving><xsl:value-of select="typ:waarde"/></omschrijving>
+                </xsl:for-each>
+                <xsl:for-each select="../../Stuk:tijdstipAanbieding">
+                    <datum><xsl:value-of select="."/></datum>
+                </xsl:for-each>
+                <ref_id><xsl:value-of select="$kad_oz_id"/></ref_id>
 			</brondocument>
 		</xsl:for-each>
     </xsl:template>
@@ -735,6 +752,7 @@
 				<xsl:if test="$omschrijving">
 					<omschrijving><xsl:value-of select="$omschrijving"/></omschrijving>
                 </xsl:if>
+				<datum><xsl:value-of select="//Stuk:Stukdeel[@id = $id]/../../Stuk:tijdstipAanbieding"/></datum>
 				<xsl:if test="$ref_id">
 					<ref_id><xsl:value-of select="$ref_id"/></ref_id>
                </xsl:if>

--- a/brmo-loader/src/main/resources/xsl/update-brondocument.xsl
+++ b/brmo-loader/src/main/resources/xsl/update-brondocument.xsl
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+    Document   : update-brondocument.xsl
+    Created on : August 18, 2016, 9:30 AM
+    Author     : mark
+    Description:
+        update brondocument velden omschrijving, datum, ref_id
+-->
+
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:snp="http://www.kadaster.nl/schemas/brk-levering/snapshot/v20120901"
+                xmlns:ko="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject/v20120701"
+                xmlns:typ="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201"
+                xmlns:nen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201"
+                xmlns:gml="http://www.opengis.net/gml"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201"
+                xmlns:rechtref="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht-ref/v20120201"
+                xmlns:pers="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon/v20120201"
+                xmlns:nhr="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-nhr-rechtspersoon/v20120201"
+                xmlns:gba="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon/v20120901"
+                xmlns:GbaPersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon-ref/v20120201"
+                xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201"
+                xmlns:bagadres="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-bag-adres/v20120201"
+                xmlns:fn="http://www.w3.org/2005/xpath-functions">
+
+    <xsl:variable name="kad_oz_id" select="/snp:KadastraalObjectSnapshot/ko:Perceel/ko:identificatie/nen:lokaalId | /snp:KadastraalObjectSnapshot/ko:Appartementsrecht/ko:identificatie/nen:lokaalId"/>
+
+    <xsl:template match="/">
+        <root>
+            <data>
+
+                <xsl:apply-templates select="/snp:KadastraalObjectSnapshot/Stuk:*"/>
+
+                <xsl:for-each select="/snp:KadastraalObjectSnapshot/recht:Tenaamstelling">
+                    <xsl:apply-templates select="."/>
+                </xsl:for-each>
+   
+                <xsl:for-each select="/snp:KadastraalObjectSnapshot/recht:ZakelijkRecht">
+                    <xsl:variable name="parent-id">
+                        <xsl:call-template name="nen_identificatie">
+                            <xsl:with-param name="id" select="recht:identificatie"/>
+                        </xsl:call-template>
+                    </xsl:variable>
+                    <xsl:for-each select="recht:ontstaanUit//recht:isGebaseerdOp | recht:betrokkenBij//recht:isGebaseerdOp">
+                        <xsl:call-template name="is_gebaseerd_op_brondocument">
+                            <xsl:with-param name="tabel">ZAK_RECHT</xsl:with-param>
+                            <xsl:with-param name="tabel_identificatie" select="$parent-id"/>
+                            <xsl:with-param name="omschrijving" select="concat(local-name(../..), ' ', local-name(..))"/>
+                        </xsl:call-template>
+                    </xsl:for-each>
+                </xsl:for-each>
+
+                <xsl:for-each select="/snp:KadastraalObjectSnapshot/recht:Aantekening">
+                    <xsl:apply-templates select="."/>
+                </xsl:for-each>
+            </data>
+        </root>
+    </xsl:template>
+
+    <xsl:template match="/snp:KadastraalObjectSnapshot/recht:Tenaamstelling">
+        <xsl:variable name="parent-id">
+            <xsl:call-template name="nen_identificatie">
+                <xsl:with-param name="id" select="recht:identificatie"/>
+            </xsl:call-template>
+        </xsl:variable>
+        <xsl:for-each select="recht:isGebaseerdOp">
+            <xsl:call-template name="is_gebaseerd_op_brondocument">
+                <xsl:with-param name="tabel">ZAK_RECHT</xsl:with-param>
+                <xsl:with-param name="tabel_identificatie" select="$parent-id"/>
+                <xsl:with-param name="omschrijving" select="concat(local-name(), ' ', local-name(..))"/>
+            </xsl:call-template>
+        </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template match="/snp:KadastraalObjectSnapshot/recht:Aantekening">
+        <xsl:variable name="parent-id">
+            <xsl:call-template name="nen_identificatie">
+                <xsl:with-param name="id" select="recht:identificatie"/>
+            </xsl:call-template>
+        </xsl:variable>
+
+        <xsl:if test="recht:betreftAantekeningKadastraalObject">
+            <xsl:for-each select="recht:isGebaseerdOp">
+                <xsl:call-template name="is_gebaseerd_op_brondocument">
+                    <xsl:with-param name="tabel">KAD_ONRRND_ZAAK_AANTEK</xsl:with-param>
+                    <xsl:with-param name="tabel_identificatie" select="$parent-id"/>
+                    <xsl:with-param name="omschrijving" select="concat(local-name(), ' ', local-name(..))"/>
+                </xsl:call-template>
+            </xsl:for-each>
+        </xsl:if>
+        <xsl:if test="recht:betreftAantekeningRecht" >
+            <xsl:for-each select="recht:isGebaseerdOp">
+                <xsl:call-template name="is_gebaseerd_op_brondocument">
+                    <xsl:with-param name="tabel">KAD_ONRRND_ZAAK_AANTEK</xsl:with-param>
+                    <xsl:with-param name="tabel_identificatie" select="$parent-id"/>
+                    <xsl:with-param name="omschrijving" select="concat(local-name(), ' ', local-name(..))"/>
+                </xsl:call-template>
+            </xsl:for-each>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template match="Stuk:*">
+        <xsl:variable name="parent-id">
+            <xsl:call-template name="nen_identificatie">
+                <xsl:with-param name="id" select="Stuk:identificatie"/>
+            </xsl:call-template>
+        </xsl:variable>
+    
+        <brondocument ignore-duplicates="yes">
+            <identificatie>
+                <xsl:value-of select="$parent-id"/>
+            </identificatie>
+
+            <xsl:for-each select="Stuk:deelEnNummer">
+                <omschrijving>
+                    <xsl:text>deel: </xsl:text>
+                    <xsl:value-of select="Stuk:deel"/>
+                    <xsl:text>, nummer: </xsl:text>
+                    <xsl:value-of select="Stuk:nummer"/>
+                    <xsl:text>, registercode: </xsl:text>
+                    <xsl:value-of select="Stuk:registercode/typ:waarde"/>
+                    <xsl:text>, soortregister: </xsl:text>
+                    <xsl:value-of select="Stuk:soortRegister/typ:waarde"/>
+                </omschrijving>
+            </xsl:for-each>
+
+            <xsl:choose>
+                <xsl:when test="../ko:Perceel">
+                    <tabel>KAD_PERCEEL</tabel>
+                    <tabel_identificatie>
+                        <xsl:value-of select="../ko:Perceel/ko:identificatie/nen:lokaalId"/>
+                    </tabel_identificatie>
+                    <ref_id>
+                        <xsl:value-of select="../ko:Perceel/ko:identificatie/nen:lokaalId"/>
+                    </ref_id>
+                </xsl:when>
+                <xsl:when test="../ko:Appartementsrecht">
+                    <tabel>APP_RE</tabel>
+                    <tabel_identificatie>
+                        <xsl:value-of select="../ko:Appartementsrecht/ko:identificatie/nen:lokaalId"/>
+                    </tabel_identificatie>
+                    <ref_id>
+                        <xsl:value-of select="../ko:Appartementsrecht/ko:identificatie/nen:lokaalId"/>
+                    </ref_id>
+                </xsl:when>
+            </xsl:choose>
+        </brondocument>
+
+        <xsl:for-each select="Stuk:omvat/Stuk:Stukdeel">
+            <brondocument ignore-duplicates="yes">
+                <identificatie>
+                    <xsl:call-template name="nen_identificatie">
+                        <xsl:with-param name="id" select="Stuk:identificatie"/>
+                    </xsl:call-template>
+                </identificatie>
+                <tabel>BRONDOCUMENT</tabel>
+                <tabel_identificatie>
+                    <xsl:value-of select="$parent-id"/>
+                </tabel_identificatie>
+                <xsl:for-each select="Stuk:aardStukdeel">
+                    <omschrijving>
+                        <xsl:value-of select="typ:waarde"/>
+                    </omschrijving>
+                </xsl:for-each>
+                <xsl:for-each select="../../Stuk:tijdstipAanbieding">
+                    <datum>
+                        <xsl:value-of select="."/>
+                    </datum>
+                </xsl:for-each>
+                <ref_id>
+                    <xsl:value-of select="$kad_oz_id"/>
+                </ref_id>
+            </brondocument>
+        </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template name="is_gebaseerd_op_brondocument">
+        <xsl:param name="tabel"/>
+        <xsl:param name="tabel_identificatie"/>
+        <xsl:param name="omschrijving"/>
+        <xsl:param name="ref_id" select="$kad_oz_id"/>
+
+        <xsl:for-each select="StukRef:StukdeelRef" xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201">
+            <xsl:variable name="id" select="substring(@xlink:href,2)"/>
+            <brondocument ignore-duplicates="yes">
+                <identificatie>
+                    <xsl:call-template name="nen_identificatie">
+                        <xsl:with-param name="id" select="//Stuk:Stukdeel[@id = $id]/Stuk:identificatie"/>
+                    </xsl:call-template>
+                </identificatie>
+                <tabel>
+                    <xsl:value-of select="$tabel"/>
+                </tabel>
+                <tabel_identificatie>
+                    <xsl:value-of select="$tabel_identificatie"/>
+                </tabel_identificatie>
+                <xsl:if test="$omschrijving">
+                    <omschrijving>
+                        <xsl:value-of select="$omschrijving"/>
+                    </omschrijving>
+                </xsl:if>
+                <datum>
+                    <xsl:value-of select="//Stuk:Stukdeel[@id = $id]/../../Stuk:tijdstipAanbieding"/>
+                </datum>
+                <xsl:if test="$ref_id">
+                    <ref_id>
+                        <xsl:value-of select="$ref_id"/>
+                    </ref_id>
+                </xsl:if>
+            </brondocument>
+        </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template name="nen_identificatie">
+        <xsl:param name="id"/>
+        <xsl:value-of select="$id/nen:namespace"/>.<xsl:value-of select="$id/nen:lokaalId"/>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/brmo-loader/src/main/resources/xsl/update-brondocument.xsl
+++ b/brmo-loader/src/main/resources/xsl/update-brondocument.xsl
@@ -114,19 +114,30 @@
             <identificatie>
                 <xsl:value-of select="$parent-id"/>
             </identificatie>
-
-            <xsl:for-each select="Stuk:deelEnNummer">
-                <omschrijving>
-                    <xsl:text>deel: </xsl:text>
-                    <xsl:value-of select="Stuk:deel"/>
-                    <xsl:text>, nummer: </xsl:text>
-                    <xsl:value-of select="Stuk:nummer"/>
-                    <xsl:text>, registercode: </xsl:text>
-                    <xsl:value-of select="Stuk:registercode/typ:waarde"/>
-                    <xsl:text>, soortregister: </xsl:text>
-                    <xsl:value-of select="Stuk:soortRegister/typ:waarde"/>
-                </omschrijving>
-            </xsl:for-each>
+            <xsl:choose>
+                <xsl:when test="Stuk:deelEnNummer">
+                    <xsl:for-each select="Stuk:deelEnNummer">
+                        <omschrijving>
+                            <xsl:text>deel: </xsl:text>
+                            <xsl:value-of select="Stuk:deel"/>
+                            <xsl:text>, nummer: </xsl:text>
+                            <xsl:value-of select="Stuk:nummer"/>
+                            <xsl:text>, registercode: </xsl:text>
+                            <xsl:value-of select="Stuk:registercode/typ:waarde"/>
+                            <xsl:text>, soortregister: </xsl:text>
+                            <xsl:value-of select="Stuk:soortRegister/typ:waarde"/>
+                        </omschrijving>
+                    </xsl:for-each>
+                </xsl:when>
+                <xsl:otherwise>
+                    <omschrijving>
+                        <xsl:if test="Stuk:AKRPortefeuilleNr">
+                            <xsl:text>AKR Portefeuille Nr: </xsl:text>
+                            <xsl:value-of select="Stuk:AKRPortefeuilleNr"/>
+                        </xsl:if>
+                    </omschrijving>
+                </xsl:otherwise>
+            </xsl:choose>
 
             <xsl:choose>
                 <xsl:when test="../ko:Perceel">

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/UpdatesActionBean.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/UpdatesActionBean.java
@@ -157,7 +157,8 @@ public class UpdatesActionBean implements ActionBean, ProgressUpdateListener {
 
         updateProcesses = Arrays.asList(new UpdateProcess[] {
             new UpdateProcess("Toevoegen BSN aan ingeschreven natuurlijk persoon", BrmoFramework.BR_BRK, "/xsl/update-bsn.xsl"),
-            new UpdateProcess("Toevoegen RSIN aan ingeschreven niet-natuurlijk persoon", BrmoFramework.BR_BRK, "/xsl/update-rsin.xsl")
+            new UpdateProcess("Toevoegen RSIN aan ingeschreven niet-natuurlijk persoon", BrmoFramework.BR_BRK, "/xsl/update-rsin.xsl"),
+            new UpdateProcess("Bijwerken van omschrijving, datum en ref_id in brondocument", BrmoFramework.BR_BRK, "/xsl/update-brondocument.xsl")
         });
     }
 

--- a/datamodel/datamodel_ddl.xsl
+++ b/datamodel/datamodel_ddl.xsl
@@ -3,16 +3,25 @@
 	<xsl:output method="text" encoding="utf-8"/>
 	<xsl:variable name="geometryTypes" select="'polygon multipolygon linestring multilinestring point multipoint geometry'"/>
 	<xsl:template name="header">
-		<xsl:text>
+<xsl:text>
+--
 -- BRMO RSGB script voor </xsl:text>
 		<xsl:value-of select="$dbtype"/>
-		<xsl:text>
+<xsl:text>
 -- Gegenereerd op </xsl:text>
-		<xsl:value-of select="current-dateTime()"/>
-		<xsl:text>
+		<xsl:value-of select="current-dateTime()"/><xsl:text>
+--
 
 </xsl:text>
+        <xsl:if test="'oracle'=$dbtype">
+<xsl:text>
+-- voor sqldeveloper define evt. uitzetten omdat er ampersand tekens in sommige namen voorkomen.
+-- set define off;
+
+</xsl:text>
+        </xsl:if>
 	</xsl:template>
+
 	<xsl:template match="schema">
 		<xsl:call-template name="header"/>
 		<xsl:apply-templates select="table">

--- a/datamodel/extra_scripts/oracle/102_metagegevens_brondocument.sql
+++ b/datamodel/extra_scripts/oracle/102_metagegevens_brondocument.sql
@@ -13,7 +13,7 @@ create table brondocument (
   tabel_identificatie varchar2(50),
   identificatie varchar2(50),
   gemeente number,
-  omschrijving varchar2(40),
+  omschrijving varchar2(255),
   datum date,
   ref_id varchar2(50),
   primary key(tabel,tabel_identificatie,identificatie)

--- a/datamodel/extra_scripts/postgresql/102_metagegevens_brondocument.sql
+++ b/datamodel/extra_scripts/postgresql/102_metagegevens_brondocument.sql
@@ -13,7 +13,7 @@ create table brondocument (
   tabel_identificatie varchar(50),
   identificatie varchar(50),
   gemeente integer,
-  omschrijving varchar(40),
+  omschrijving varchar(255),
   datum date,
   ref_id varchar(50),
   primary key(tabel,tabel_identificatie,identificatie)

--- a/datamodel/extra_scripts/postgresql/107_brk_views.sql
+++ b/datamodel/extra_scripts/postgresql/107_brk_views.sql
@@ -213,6 +213,25 @@ SELECT
      JOIN kad_perceel kp ON v.perceel_identif::NUMERIC = kp.sc_kad_identif
      JOIN app_re ar ON v.app_re_identif::NUMERIC = ar.sc_kad_identif;    
 
+-- aankoopdatum uit brondocumenten
+CREATE OR REPLACE VIEW
+    v_aankoopdatum AS
+SELECT
+    b.ref_id AS kadaster_identificatie,
+    b.datum  AS aankoopdatum
+FROM
+    (
+        SELECT
+            ref_id,
+            MAX(datum) datum
+        FROM
+            brondocument
+        WHERE
+            omschrijving = 'Akte van Koop en Verkoop'
+        GROUP BY
+            ref_id
+    ) b ;
+
 -- Eigenarenkaart - percelen en appartementen met hun eigenaren
 CREATE OR REPLACE VIEW
     V_KAD_EIGENARENKAART
@@ -225,6 +244,7 @@ CREATE OR REPLACE VIEW
         AANDEEL_NOEMER,
         AARD_RECHT_AAND,
         ZAKELIJK_RECHT_OMSCHRIJVING,
+        AANKOOPDATUM,
         SOORT_EIGENAAR,
         GESLACHTSNAAM,
         VOORVOEGSEL,
@@ -256,6 +276,7 @@ SELECT
     zr.ar_noemer        AS aandeel_noemer,
     zr.fk_3avr_aand     AS aard_recht_aand,
     ark.omschr          AS zakelijk_recht_omschrijving,
+    b.aankoopdatum,
     CASE
         WHEN np.sc_identif IS NOT NULL
         THEN 'Natuurlijk persoon'
@@ -324,6 +345,10 @@ LEFT JOIN
     subject innp_subject
 ON
     innp_subject.identif = innp.sc_identif
+LEFT JOIN
+    v_aankoopdatum b
+ON
+    b.kadaster_identificatie::numeric(15,0) = p.kadaster_identificatie
 WHERE
     zr.kadaster_identif like 'NL.KAD.Tenaamstelling%';
   

--- a/datamodel/extra_scripts/sqlserver/102_metagegevens_brondocument.sql
+++ b/datamodel/extra_scripts/sqlserver/102_metagegevens_brondocument.sql
@@ -13,7 +13,7 @@ create table brondocument (
   tabel_identificatie varchar(50) not null,
   identificatie varchar(50) not null,
   gemeente integer,
-  omschrijving varchar(40),
+  omschrijving varchar(255),
   datum date,
   ref_id varchar(50),
   primary key clustered(tabel,tabel_identificatie,identificatie)

--- a/datamodel/extra_scripts/sqlserver/107_brk_views.sql
+++ b/datamodel/extra_scripts/sqlserver/107_brk_views.sql
@@ -213,7 +213,25 @@ SELECT
      JOIN kad_perceel kp ON v.perceel_identif = kp.sc_kad_identif
      JOIN app_re ar ON v.app_re_identif = ar.sc_kad_identif;    
 
--- Eigenarenkaart - percelen en appartementen met hun eigenaren
+-- aankoopdatum uit brondocumenten
+CREATE VIEW
+    v_aankoopdatum AS
+SELECT
+    b.ref_id AS kadaster_identificatie,
+    b.datum  AS aankoopdatum
+FROM
+    (
+        SELECT
+            ref_id,
+            MAX(datum) datum
+        FROM
+            brondocument
+        WHERE
+            omschrijving = 'Akte van Koop en Verkoop'
+        GROUP BY
+            ref_id
+    ) b;
+
 -- Eigenarenkaart - percelen en appartementen met hun eigenaren
 CREATE VIEW
     v_kad_eigenarenkaart
@@ -226,6 +244,7 @@ CREATE VIEW
         aandeel_noemer,
         aard_recht_aand,
         zakelijk_recht_omschrijving,
+        aankoopdatum,
         soort_eigenaar,
         geslachtsnaam,
         voorvoegsel,
@@ -257,6 +276,7 @@ SELECT
     zr.ar_noemer        AS aandeel_noemer,
     zr.fk_3avr_aand     AS aard_recht_aand,
     ark.omschr          AS zakelijk_recht_omschrijving,
+    b.aankoopdatum,
     CASE
         WHEN np.sc_identif IS NOT NULL
         THEN 'Natuurlijk persoon'
@@ -325,6 +345,10 @@ LEFT JOIN
     subject innp_subject
 ON
     innp_subject.identif = innp.sc_identif
+LEFT JOIN
+    v_aankoopdatum b
+ON
+    b.kadaster_identificatie = p.kadaster_identificatie
 WHERE
     zr.kadaster_identif like 'NL.KAD.Tenaamstelling%';
    

--- a/datamodel/generated_scripts/datamodel_oracle.sql
+++ b/datamodel/generated_scripts/datamodel_oracle.sql
@@ -1,6 +1,6 @@
 
 -- BRMO RSGB script voor oracle
--- Gegenereerd op 2016-08-04T12:02:40.178+02:00
+-- Gegenereerd op 2016-08-16T17:14:19.706+02:00
 
 create table sbi_activiteit(
 	omschr varchar2(60),
@@ -3688,7 +3688,7 @@ create table brondocument (
   tabel_identificatie varchar2(50),
   identificatie varchar2(50),
   gemeente number,
-  omschrijving varchar2(40),
+  omschrijving varchar2(255),
   datum date,
   ref_id varchar2(50),
   primary key(tabel,tabel_identificatie,identificatie)

--- a/datamodel/generated_scripts/datamodel_postgresql.sql
+++ b/datamodel/generated_scripts/datamodel_postgresql.sql
@@ -1,6 +1,6 @@
 
 -- BRMO RSGB script voor postgresql
--- Gegenereerd op 2016-08-04T12:02:32.887+02:00
+-- Gegenereerd op 2016-08-16T17:14:10.051+02:00
 
 create table sbi_activiteit(
 	omschr character varying(60),
@@ -3388,7 +3388,7 @@ create table brondocument (
   tabel_identificatie varchar(50),
   identificatie varchar(50),
   gemeente integer,
-  omschrijving varchar(40),
+  omschrijving varchar(255),
   datum date,
   ref_id varchar(50),
   primary key(tabel,tabel_identificatie,identificatie)

--- a/datamodel/generated_scripts/datamodel_sqlserver.sql
+++ b/datamodel/generated_scripts/datamodel_sqlserver.sql
@@ -1,6 +1,6 @@
 
 -- BRMO RSGB script voor sqlserver
--- Gegenereerd op 2016-08-04T12:02:47.414+02:00
+-- Gegenereerd op 2016-08-16T17:14:28.077+02:00
 
 create table sbi_activiteit(
 	omschr varchar(60),
@@ -2264,7 +2264,7 @@ create table brondocument (
   tabel_identificatie varchar(50) not null,
   identificatie varchar(50) not null,
   gemeente integer,
-  omschrijving varchar(40),
+  omschrijving varchar(255),
   datum date,
   ref_id varchar(50),
   primary key clustered(tabel,tabel_identificatie,identificatie)

--- a/datamodel/upgrade_scripts/1.3.5-1.3.6/oracle/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.3.5-1.3.6/oracle/rsgb.sql
@@ -1,10 +1,155 @@
 -- upgrade RSGB datamodel van 1.3.5 naar 1.3.6 (Oracle)
 
 -- vergroten van het veld 'omschrijving' in de tabel brondocument van 40 naar 255 characters
---oracle
 ALTER TABLE
     BRONDOCUMENT
 MODIFY
     OMSCHRIJVING VARCHAR2(255);
 
--- hierna invalid views compileren
+-- aankoopdatum uit brondocumenten
+CREATE OR REPLACE VIEW
+    V_AANKOOPDATUM
+    (
+        KADASTER_IDENTIFICATIE,
+        AANKOOPDATUM
+    ) AS
+SELECT
+    b.ref_id AS KADASTER_IDENTIFICATIE,
+    b.datum  AS AANKOOPDATUM
+FROM
+    (
+        SELECT
+            ref_id ,
+            datum ,
+            row_number() over (partition BY ref_id ORDER BY datum DESC) AS rnk
+        FROM
+            brondocument
+        WHERE
+            omschrijving = 'Akte van Koop en Verkoop' ) b
+WHERE
+    b.rnk = 1;
+
+
+-- aanpassen eigenarenkaart
+-- Eigenarenkaart - percelen en appartementen met hun eigenaren
+CREATE OR REPLACE VIEW
+    V_KAD_EIGENARENKAART
+    (
+        OBJECTID,
+        KADASTER_IDENTIFICATIE,
+        TYPE,
+        ZAKELIJK_RECHT_IDENTIFICATIE,
+        AANDEEL_TELLER,
+        AANDEEL_NOEMER,
+        AARD_RECHT_AAND,
+        ZAKELIJK_RECHT_OMSCHRIJVING,
+        AANKOOPDATUM,
+        SOORT_EIGENAAR,
+        GESLACHTSNAAM,
+        VOORVOEGSEL,
+        VOORNAMEN,
+        GESLACHT,
+        PERCEEL_ZAK_RECHT_NAAM,
+        PERSOON_IDENTIFICATIE,
+        WOONADRES,
+        GEBOORTEDATUM,
+        GEBOORTEPLAATS,
+        OVERLIJDENSDATUM,
+        NAAM_NIET_NATUURLIJK_PERSOON,
+        RECHTSVORM,
+        STATUTAIRE_ZETEL,
+        KVK_NUMMER,
+        KA_APPARTEMENTSINDEX,
+        KA_DEELPERCEELNUMMER,
+        KA_PERCEELNUMMER,
+        KA_KAD_GEMEENTECODE,
+        KA_SECTIE,
+        BEGRENZING_PERCEEL
+    ) AS
+SELECT
+    row_number() OVER () AS objectid,
+    p.kadaster_identificatie    AS kadaster_identificatie,
+    p.type,
+    zr.kadaster_identif AS zakelijk_recht_identificatie,
+    zr.ar_teller        AS aandeel_teller,
+    zr.ar_noemer        AS aandeel_noemer,
+    zr.fk_3avr_aand     AS aard_recht_aand,
+    ark.omschr          AS zakelijk_recht_omschrijving,
+    b.aankoopdatum,
+    CASE
+        WHEN np.sc_identif IS NOT NULL
+        THEN 'Natuurlijk persoon'
+        WHEN nnp.sc_identif IS NOT NULL
+        THEN 'Niet natuurlijk persoon'
+        ELSE 'Onbekend'
+    END                             AS soort_eigenaar,
+    np.nm_geslachtsnaam             AS geslachtsnaam,
+    np.nm_voorvoegsel_geslachtsnaam AS voorvoegsel,
+    np.nm_voornamen                 AS voornamen,
+    np.geslachtsaand                AS geslacht,
+    CASE
+        WHEN np.sc_identif IS NOT NULL
+        THEN np.NM_GESLACHTSNAAM || ', ' || np.NM_VOORNAMEN || ' ' ||
+            np.NM_VOORVOEGSEL_GESLACHTSNAAM
+        WHEN nnp.sc_identif IS NOT NULL
+        THEN nnp.NAAM
+        ELSE 'Onbekend'
+    END                     AS perceel_zak_recht_naam,
+    inp.sc_identif          AS persoon_identificatie,
+    inp.va_loc_beschrijving AS woonadres,
+    inp.gb_geboortedatum    AS geboortedatum,
+    inp.gb_geboorteplaats   AS geboorteplaats,
+    inp.ol_overlijdensdatum AS overlijdensdatum,
+    nnp.naam                AS naam_niet_natuurlijk_persoon,
+    innp.rechtsvorm,
+    innp.statutaire_zetel,
+    innp_subject.kvk_nummer,
+    p.ka_appartementsindex,
+    p.ka_deelperceelnummer,
+    p.ka_perceelnummer,
+    p.ka_kad_gemeentecode,
+    p.ka_sectie,
+    p.begrenzing_perceel
+FROM
+    v_bd_app_re_and_kad_perceel p
+JOIN
+    zak_recht zr
+ON
+    zr.fk_7koz_kad_identif = p.kadaster_identificatie
+LEFT JOIN
+    aard_recht_verkort ark
+ON
+    zr.fk_3avr_aand = ark.aand
+LEFT JOIN
+    aard_verkregen_recht ar
+ON
+    zr.fk_3avr_aand = ar.aand
+LEFT JOIN
+    nat_prs np
+ON
+    np.sc_identif = zr.fk_8pes_sc_identif
+LEFT JOIN
+    ingeschr_nat_prs inp
+ON
+    inp.sc_identif = np.sc_identif
+LEFT JOIN
+    niet_nat_prs nnp
+ON
+    nnp.sc_identif = zr.fk_8pes_sc_identif
+LEFT JOIN
+    ingeschr_niet_nat_prs innp
+ON
+    innp.sc_identif = nnp.sc_identif
+LEFT JOIN
+    subject innp_subject
+ON
+    innp_subject.identif = innp.sc_identif
+LEFT JOIN
+    v_aankoopdatum b
+ON
+    b.kadaster_identificatie = p.kadaster_identificatie
+WHERE
+    zr.kadaster_identif like 'NL.KAD.Tenaamstelling%';
+
+
+-- hierna evt. views hercompileren

--- a/datamodel/upgrade_scripts/1.3.5-1.3.6/oracle/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.3.5-1.3.6/oracle/rsgb.sql
@@ -1,0 +1,3 @@
+-- upgrade RSGB datamodel van 1.3.5 naar 1.3.6 (Oracle)
+
+-- vergroten van het veld 'omschrijving' in de tabel brondocument van 40 naar 255 characters

--- a/datamodel/upgrade_scripts/1.3.5-1.3.6/oracle/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.3.5-1.3.6/oracle/rsgb.sql
@@ -1,3 +1,10 @@
 -- upgrade RSGB datamodel van 1.3.5 naar 1.3.6 (Oracle)
 
 -- vergroten van het veld 'omschrijving' in de tabel brondocument van 40 naar 255 characters
+--oracle
+ALTER TABLE
+    BRONDOCUMENT
+MODIFY
+    OMSCHRIJVING VARCHAR2(255);
+
+-- hierna invalid views compileren

--- a/datamodel/upgrade_scripts/1.3.5-1.3.6/postgresql/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.3.5-1.3.6/postgresql/rsgb.sql
@@ -1,0 +1,16 @@
+-- upgrade RSGB datamodel van 1.3.5 naar 1.3.6 (PostgreSQL)
+
+-- vergroten van het veld 'omschrijving' in de tabel brondocument van 40 naar 255 characters
+-- drop de van van brondocument afhankelijke views
+
+-- DROP VIEW v_bd_kad_perceel_met_app;
+-- DROP VIEW v_bd_kad_perceel_with_app_re;
+-- DROP VIEW v_bd_app_re_all_kad_perceel;
+-- DROP VIEW kad_perceel_app_rechten;
+
+-- pas tabel aan
+ALTER TABLE brondocument ALTER COLUMN omschrijving TYPE character varying(255);
+-- bouw views weer op (uit 107_brk_views.sql)
+
+-- en uit 105_appartements_rechten.sql
+-- en...

--- a/datamodel/upgrade_scripts/1.3.5-1.3.6/postgresql/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.3.5-1.3.6/postgresql/rsgb.sql
@@ -3,15 +3,20 @@
 --
 -- vergroten van het veld 'omschrijving' in de tabel brondocument van 40 naar 255 characters
 --    drop de van van brondocument afhankelijke views
-DROP VIEW v_bd_kad_perceel_met_app;
-DROP VIEW v_bd_kad_perceel_with_app_re;
-DROP VIEW v_bd_app_re_bij_perceel;
-DROP VIEW v_bd_app_re_all_kad_perceel;
-DROP VIEW v_bd_app_re_app_re;
-DROP VIEW kad_perceel_app_rechten;
+DROP VIEW IF EXISTS v_kad_eigenarenkaart;
+DROP VIEW IF EXISTS v_aankoopdatum;
+DROP VIEW IF EXISTS v_bd_kad_perceel_met_app;
+DROP VIEW IF EXISTS v_bd_kad_perceel_with_app_re;
+DROP VIEW IF EXISTS v_bd_app_re_bij_perceel;
+DROP VIEW IF EXISTS v_bd_app_re_and_kad_perceel;
+DROP VIEW IF EXISTS v_bd_app_re_all_kad_perceel;
+DROP VIEW IF EXISTS v_bd_app_re_app_re;
+DROP VIEW IF EXISTS kad_perceel_app_rechten;
+
 --    pas tabel brondocument aan
 ALTER TABLE
     brondocument ALTER COLUMN omschrijving TYPE CHARACTER VARYING(255);
+
 --    herstel gedropte views uit 105_appartements_rechten.sql
 --    v_bd_app_re_app_re
 CREATE OR REPLACE VIEW
@@ -74,7 +79,7 @@ SELECT
     rar.*
 FROM
     related_app_re rar;
---    v_bd_app_re_bij_perceel          
+--    v_bd_app_re_bij_perceel
 CREATE OR REPLACE VIEW
     v_bd_app_re_bij_perceel AS
 SELECT
@@ -130,6 +135,8 @@ JOIN
     kad_perceel kp
 ON
     v.perceel_identif = kp.sc_kad_identif::VARCHAR;
+
+
 --    herstel gedropte views uit 107_brk_views.sql
 --    kad_perceel_app_rechten
 CREATE OR REPLACE VIEW
@@ -265,3 +272,172 @@ ORDER BY
     kpe.toevoeging,
     kpe.huisletter,
     KA_APPARTEMENTSINDEX::INT;
+
+-- percelen plus appartementen op de percelen
+CREATE OR REPLACE VIEW v_bd_app_re_and_kad_perceel AS
+select
+    p.sc_kad_identif    AS kadaster_identificatie,
+    'perceel' as type,
+    p.ka_deelperceelnummer,
+    '' as ka_appartementsindex,
+    p.ka_perceelnummer,
+    p.ka_kad_gemeentecode,
+    p.ka_sectie,
+    p.begrenzing_perceel
+FROM
+    kad_perceel p
+union all
+SELECT
+    ar.sc_kad_identif,
+    'appartement' as type,
+    '' as ka_deelperceelnummer,
+    ar.ka_appartementsindex,
+    ar.ka_perceelnummer,
+    ar.ka_kad_gemeentecode,
+    ar.ka_sectie,
+    kp.begrenzing_perceel
+   FROM v_bd_app_re_all_kad_perceel v
+     JOIN kad_perceel kp ON v.perceel_identif::NUMERIC = kp.sc_kad_identif
+     JOIN app_re ar ON v.app_re_identif::NUMERIC = ar.sc_kad_identif;
+
+-- aankoopdatum uit brondocumenten
+CREATE OR REPLACE VIEW
+    v_aankoopdatum AS
+SELECT
+    b.ref_id AS kadaster_identificatie,
+    b.datum  AS aankoopdatum
+FROM
+    (
+        SELECT
+            ref_id,
+            MAX(datum) datum
+        FROM
+            brondocument
+        WHERE
+            omschrijving = 'Akte van Koop en Verkoop'
+        GROUP BY
+            ref_id
+    ) b ;
+
+-- aanpassen eigenarenkaart
+
+-- Eigenarenkaart - percelen en appartementen met hun eigenaren
+CREATE OR REPLACE VIEW
+    V_KAD_EIGENARENKAART
+    (
+        OBJECTID,
+        KADASTER_IDENTIFICATIE,
+        TYPE,
+        ZAKELIJK_RECHT_IDENTIFICATIE,
+        AANDEEL_TELLER,
+        AANDEEL_NOEMER,
+        AARD_RECHT_AAND,
+        ZAKELIJK_RECHT_OMSCHRIJVING,
+        AANKOOPDATUM,
+        SOORT_EIGENAAR,
+        GESLACHTSNAAM,
+        VOORVOEGSEL,
+        VOORNAMEN,
+        GESLACHT,
+        PERCEEL_ZAK_RECHT_NAAM,
+        PERSOON_IDENTIFICATIE,
+        WOONADRES,
+        GEBOORTEDATUM,
+        GEBOORTEPLAATS,
+        OVERLIJDENSDATUM,
+        NAAM_NIET_NATUURLIJK_PERSOON,
+        RECHTSVORM,
+        STATUTAIRE_ZETEL,
+        KVK_NUMMER,
+        KA_APPARTEMENTSINDEX,
+        KA_DEELPERCEELNUMMER,
+        KA_PERCEELNUMMER,
+        KA_KAD_GEMEENTECODE,
+        KA_SECTIE,
+        BEGRENZING_PERCEEL
+    ) AS
+SELECT
+    row_number() OVER () AS objectid,
+    p.kadaster_identificatie    AS kadaster_identificatie,
+    p.type,
+    zr.kadaster_identif AS zakelijk_recht_identificatie,
+    zr.ar_teller        AS aandeel_teller,
+    zr.ar_noemer        AS aandeel_noemer,
+    zr.fk_3avr_aand     AS aard_recht_aand,
+    ark.omschr          AS zakelijk_recht_omschrijving,
+    b.aankoopdatum,
+    CASE
+        WHEN np.sc_identif IS NOT NULL
+        THEN 'Natuurlijk persoon'
+        WHEN nnp.sc_identif IS NOT NULL
+        THEN 'Niet natuurlijk persoon'
+        ELSE 'Onbekend'
+    END                             AS soort_eigenaar,
+    np.nm_geslachtsnaam             AS geslachtsnaam,
+    np.nm_voorvoegsel_geslachtsnaam AS voorvoegsel,
+    np.nm_voornamen                 AS voornamen,
+    np.geslachtsaand                AS geslacht,
+    CASE
+        WHEN np.sc_identif IS NOT NULL
+        THEN np.NM_GESLACHTSNAAM || ', ' || np.NM_VOORNAMEN || ' ' ||
+            np.NM_VOORVOEGSEL_GESLACHTSNAAM
+        WHEN nnp.sc_identif IS NOT NULL
+        THEN nnp.NAAM
+        ELSE 'Onbekend'
+    END                     AS perceel_zak_recht_naam,
+    inp.sc_identif          AS persoon_identificatie,
+    inp.va_loc_beschrijving AS woonadres,
+    inp.gb_geboortedatum    AS geboortedatum,
+    inp.gb_geboorteplaats   AS geboorteplaats,
+    inp.ol_overlijdensdatum AS overlijdensdatum,
+    nnp.naam                AS naam_niet_natuurlijk_persoon,
+    innp.rechtsvorm,
+    innp.statutaire_zetel,
+    innp_subject.kvk_nummer,
+    p.ka_appartementsindex,
+    p.ka_deelperceelnummer,
+    p.ka_perceelnummer,
+    p.ka_kad_gemeentecode,
+    p.ka_sectie,
+    p.begrenzing_perceel
+FROM
+    v_bd_app_re_and_kad_perceel p
+JOIN
+    zak_recht zr
+ON
+    zr.fk_7koz_kad_identif = p.kadaster_identificatie
+LEFT JOIN
+    aard_recht_verkort ark
+ON
+    zr.fk_3avr_aand = ark.aand
+LEFT JOIN
+    aard_verkregen_recht ar
+ON
+    zr.fk_3avr_aand = ar.aand
+LEFT JOIN
+    nat_prs np
+ON
+    np.sc_identif = zr.fk_8pes_sc_identif
+LEFT JOIN
+    ingeschr_nat_prs inp
+ON
+    inp.sc_identif = np.sc_identif
+LEFT JOIN
+    niet_nat_prs nnp
+ON
+    nnp.sc_identif = zr.fk_8pes_sc_identif
+LEFT JOIN
+    ingeschr_niet_nat_prs innp
+ON
+    innp.sc_identif = nnp.sc_identif
+LEFT JOIN
+    subject innp_subject
+ON
+    innp_subject.identif = innp.sc_identif
+LEFT JOIN
+    v_aankoopdatum b
+ON
+    b.kadaster_identificatie::numeric(15,0) = p.kadaster_identificatie
+WHERE
+    zr.kadaster_identif like 'NL.KAD.Tenaamstelling%';
+

--- a/datamodel/upgrade_scripts/1.3.5-1.3.6/postgresql/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.3.5-1.3.6/postgresql/rsgb.sql
@@ -1,16 +1,267 @@
+--
 -- upgrade RSGB datamodel van 1.3.5 naar 1.3.6 (PostgreSQL)
-
+--
 -- vergroten van het veld 'omschrijving' in de tabel brondocument van 40 naar 255 characters
--- drop de van van brondocument afhankelijke views
-
--- DROP VIEW v_bd_kad_perceel_met_app;
--- DROP VIEW v_bd_kad_perceel_with_app_re;
--- DROP VIEW v_bd_app_re_all_kad_perceel;
--- DROP VIEW kad_perceel_app_rechten;
-
--- pas tabel aan
-ALTER TABLE brondocument ALTER COLUMN omschrijving TYPE character varying(255);
--- bouw views weer op (uit 107_brk_views.sql)
-
--- en uit 105_appartements_rechten.sql
--- en...
+--    drop de van van brondocument afhankelijke views
+DROP VIEW v_bd_kad_perceel_met_app;
+DROP VIEW v_bd_kad_perceel_with_app_re;
+DROP VIEW v_bd_app_re_bij_perceel;
+DROP VIEW v_bd_app_re_all_kad_perceel;
+DROP VIEW v_bd_app_re_app_re;
+DROP VIEW kad_perceel_app_rechten;
+--    pas tabel brondocument aan
+ALTER TABLE
+    brondocument ALTER COLUMN omschrijving TYPE CHARACTER VARYING(255);
+--    herstel gedropte views uit 105_appartements_rechten.sql
+--    v_bd_app_re_app_re
+CREATE OR REPLACE VIEW
+    v_bd_app_re_app_re AS
+SELECT
+    b1.ref_id AS app_re_identif,
+    b2.ref_id AS parent_app_re_identif
+FROM
+    brondocument b1
+JOIN
+    brondocument b2
+ON
+    b2.identificatie = b1.identificatie
+WHERE
+    b2.omschrijving = 'betrokkenBij Ondersplitsing'
+AND b1.omschrijving = 'ontstaanUit Ondersplitsing'
+GROUP BY
+    b1.ref_id,
+    b2.ref_id;
+--    v_bd_app_re_all_kad_perceel
+CREATE OR REPLACE VIEW
+    v_bd_app_re_all_kad_perceel AS
+WITH
+    recursive related_app_re
+    (
+        app_re_identif,
+        perceel_identif
+    ) AS
+    (
+        SELECT
+            b1.ref_id AS app_re_identif,
+            b2.ref_id AS perceel_identif
+        FROM
+            brondocument b1
+        JOIN
+            brondocument b2
+        ON
+            b2.identificatie = b1.identificatie
+        WHERE
+            b2.omschrijving = 'betrokkenBij HoofdSplitsing'
+        AND b1.omschrijving = 'ontstaanUit HoofdSplitsing'
+        GROUP BY
+            b1.ref_id,
+            b2.ref_id
+        UNION
+        SELECT
+            vaa.app_re_identif,
+            vap.perceel_identif
+        FROM
+            v_bd_app_re_app_re vaa
+        JOIN
+            related_app_re vap
+        ON
+            vaa.parent_app_re_identif = vap.app_re_identif
+        GROUP BY
+            vaa.app_re_identif,
+            vap.perceel_identif
+    )
+SELECT
+    rar.*
+FROM
+    related_app_re rar;
+--    v_bd_app_re_bij_perceel          
+CREATE OR REPLACE VIEW
+    v_bd_app_re_bij_perceel AS
+SELECT
+    ar.sc_kad_identif,
+    ar.fk_2nnp_sc_identif,
+    ar.ka_appartementsindex,
+    ar.ka_kad_gemeentecode,
+    ar.ka_perceelnummer,
+    ar.ka_sectie,
+    kp.begrenzing_perceel
+FROM
+    v_bd_app_re_all_kad_perceel v
+JOIN
+    kad_perceel kp
+ON
+    v.perceel_identif = kp.sc_kad_identif::VARCHAR
+JOIN
+    app_re ar
+ON
+    v.app_re_identif = ar.sc_kad_identif::VARCHAR;
+--     v_bd_kad_perceel_with_app_re
+CREATE OR REPLACE VIEW
+    v_bd_kad_perceel_with_app_re AS
+SELECT DISTINCT
+    b2.ref_id AS perceel_identif
+FROM
+    brondocument b1
+JOIN
+    brondocument b2
+ON
+    b2.identificatie = b1.identificatie
+WHERE
+    b2.omschrijving = 'betrokkenBij HoofdSplitsing'
+AND b1.omschrijving = 'ontstaanUit HoofdSplitsing';
+CREATE OR REPLACE VIEW
+    v_bd_kad_perceel_met_app AS
+SELECT
+    v.perceel_identif,
+    kp.sc_kad_identif,
+    kp.aand_soort_grootte,
+    kp.grootte_perceel,
+    kp.omschr_deelperceel,
+    kp.fk_7kdp_sc_kad_identif,
+    kp.ka_deelperceelnummer,
+    kp.ka_kad_gemeentecode,
+    kp.ka_perceelnummer,
+    kp.ka_sectie,
+    kp.begrenzing_perceel,
+    kp.plaatscoordinaten_perceel
+FROM
+    v_bd_kad_perceel_with_app_re v
+JOIN
+    kad_perceel kp
+ON
+    v.perceel_identif = kp.sc_kad_identif::VARCHAR;
+--    herstel gedropte views uit 107_brk_views.sql
+--    kad_perceel_app_rechten
+CREATE OR REPLACE VIEW
+    kad_perceel_app_rechten AS
+SELECT
+    kpe.SC_KAD_IDENTIF AS perceel_identificatie,
+    -- kpe.KA_SECTIE || ' ' || kpe.KA_PERCEELNUMMER as perceelnr,
+    kpe.aanduiding,
+    kpe.straat,
+    kpe.huisnummer,
+    kpe.toevoeging,
+    kpe.huisletter,
+    kpe.straat || ' ' || kpe.huisnummer || ' ' || kpe.huisletter || ' ' || kpe.toevoeging || ' ' ||
+    kpe.postcode AS adres,
+    -- zr.kadaster_identif as links_zak_recht,
+    zr.FK_3AVR_AAND AS complex_zak_recht_aard_aand,
+    -- zr.FK2_PERSOON as links_zak_recht_persoon,
+    --    case when np1.PK_PERSOON is not null then 'Natuurlijk persoon' else 'Niet natuurlijk
+    -- persoon' end as l_soort_eigenaar,
+    CASE
+        WHEN np1.sc_identif IS NOT NULL
+        THEN np1.NM_GESLACHTSNAAM || ', ' || np1.NM_VOORNAMEN || ' ' ||
+            np1.NM_VOORVOEGSEL_GESLACHTSNAAM
+        ELSE nnp1.NAAM
+    END AS perceel_zak_recht_naam,
+    --    nnp1.NAAM as l_nnp,
+    -- bd1.identificatie as brondocument,
+    -- zr2.kadaster_identif as rechts_zak_recht,
+    zr2.FK_3AVR_AAND AS app_re_zak_recht_aard_aand,
+    -- zr2.FK2_PERSOON as rechts_zak_recht_persoon,
+    --    case when np2.PK_PERSOON is not null then 'Natuurlijk persoon' else 'Niet natuurlijk
+    -- persoon' end as r_soort_eigenaar,
+    CASE
+        WHEN np2.sc_identif IS NOT NULL
+        THEN np2.NM_GESLACHTSNAAM || ', ' || np2.NM_VOORNAMEN || ' ' ||
+            np2.NM_VOORVOEGSEL_GESLACHTSNAAM
+        ELSE nnp2.NAAM
+    END AS app_re_zak_recht_naam,
+    --    nnp2.NAAM as r_nnp,
+    ar.SC_KAD_IDENTIF            AS app_re_identificatie,
+    ar.KA_APPARTEMENTSINDEX::INT AS appartementsindex --,
+    -- ar.FK1_NIET_NAT_PERSOON as app_re_vve,
+    -- ar_vve_nnp.naam as app_re_vve_naam,
+    -- ar_vve_innp.rechtsvorm as app_re_vve_rechtsvorm,
+    -- ar_vve_innp.rsin as app_re_vve_rsin
+FROM
+    v_kad_perceel_eenvoudig kpe
+JOIN
+    zak_recht zr
+ON
+    (
+        zr.FK_7KOZ_KAD_IDENTIF = kpe.SC_KAD_IDENTIF)
+LEFT JOIN
+    nat_prs np1
+ON
+    (
+        np1.SC_IDENTIF = zr.FK_8PES_SC_IDENTIF)
+LEFT JOIN
+    ingeschr_nat_prs inp1
+ON
+    (
+        inp1.SC_IDENTIF = np1.SC_IDENTIF)
+LEFT JOIN
+    niet_nat_prs nnp1
+ON
+    (
+        nnp1.sc_identif = zr.FK_8PES_SC_IDENTIF)
+LEFT JOIN
+    ingeschr_niet_nat_prs innp1
+ON
+    (
+        innp1.sc_identif = nnp1.sc_identif)
+JOIN
+    brondocument bd1
+ON
+    (
+        bd1.tabel = 'ZAK_RECHT'
+    AND bd1.tabel_identificatie = zr.kadaster_identif)
+JOIN
+    brondocument bd2
+ON
+    (
+        bd2.tabel = 'ZAK_RECHT'
+    AND bd2.tabel_identificatie <> zr.kadaster_identif
+    AND bd2.identificatie = bd1.identificatie)
+JOIN
+    zak_recht zr2
+ON
+    (
+        zr2.kadaster_identif = bd2.tabel_identificatie)
+LEFT JOIN
+    nat_prs np2
+ON
+    (
+        np2.SC_IDENTIF = zr2.FK_8PES_SC_IDENTIF)
+LEFT JOIN
+    ingeschr_nat_prs inp2
+ON
+    (
+        inp2.SC_IDENTIF = np2.SC_IDENTIF)
+LEFT JOIN
+    niet_nat_prs nnp2
+ON
+    (
+        nnp2.sc_identif = zr2.FK_8PES_SC_IDENTIF)
+LEFT JOIN
+    ingeschr_niet_nat_prs innp2
+ON
+    (
+        innp2.sc_identif = nnp2.sc_identif)
+JOIN
+    app_re ar
+ON
+    (
+        ar.SC_KAD_IDENTIF = zr2.FK_7KOZ_KAD_IDENTIF)
+JOIN
+    niet_nat_prs ar_vve_nnp
+ON
+    (
+        ar_vve_nnp.sc_identif = ar.FK_2NNP_SC_IDENTIF)
+JOIN
+    INGESCHR_NIET_NAT_PRS ar_vve_innp
+ON
+    (
+        ar_vve_innp.sc_identif = ar_vve_nnp.sc_identif)
+WHERE
+    bd1.omschrijving LIKE 'betrokkenBij%'
+AND zr2.FK_8PES_SC_IDENTIF IS NOT NULL
+ORDER BY
+    kpe.SC_KAD_IDENTIF,
+    kpe.straat,
+    kpe.huisnummer,
+    kpe.toevoeging,
+    kpe.huisletter,
+    KA_APPARTEMENTSINDEX::INT;

--- a/datamodel/upgrade_scripts/1.3.5-1.3.6/sqlserver/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.3.5-1.3.6/sqlserver/rsgb.sql
@@ -1,3 +1,7 @@
 -- upgrade RSGB datamodel van 1.3.5 naar 1.3.6 (MS SQLserver)
 
 -- vergroten van het veld 'omschrijving' in de tabel brondocument van 40 naar 255 characters
+ALTER TABLE
+    brondocument
+ALTER COLUMN
+    omschrijving VARCHAR(255);

--- a/datamodel/upgrade_scripts/1.3.5-1.3.6/sqlserver/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.3.5-1.3.6/sqlserver/rsgb.sql
@@ -1,0 +1,3 @@
+-- upgrade RSGB datamodel van 1.3.5 naar 1.3.6 (MS SQLserver)
+
+-- vergroten van het veld 'omschrijving' in de tabel brondocument van 40 naar 255 characters

--- a/datamodel/upgrade_scripts/1.3.5-1.3.6/sqlserver/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.3.5-1.3.6/sqlserver/rsgb.sql
@@ -5,3 +5,146 @@ ALTER TABLE
     brondocument
 ALTER COLUMN
     omschrijving VARCHAR(255);
+
+-- aankoopdatum uit brondocumenten
+CREATE VIEW
+    v_aankoopdatum AS
+SELECT
+    b.ref_id AS kadaster_identificatie,
+    b.datum  AS aankoopdatum
+FROM
+    (
+        SELECT
+            ref_id,
+            MAX(datum) datum
+        FROM
+            brondocument
+        WHERE
+            omschrijving = 'Akte van Koop en Verkoop'
+        GROUP BY
+            ref_id
+    ) b;
+
+
+-- aanpassen eigenarenkaart
+DROP VIEW v_kad_eigenarenkaart;
+-- Eigenarenkaart - percelen en appartementen met hun eigenaren
+CREATE VIEW
+    v_kad_eigenarenkaart
+    (
+        objectid,
+        kadaster_identificatie,
+        type,
+        zakelijk_recht_identificatie,
+        aandeel_teller,
+        aandeel_noemer,
+        aard_recht_aand,
+        zakelijk_recht_omschrijving,
+        aankoopdatum,
+        soort_eigenaar,
+        geslachtsnaam,
+        voorvoegsel,
+        voornamen,
+        geslacht,
+        perceel_zak_recht_naam,
+        persoon_identificatie,
+        woonadres,
+        geboortedatum,
+        geboorteplaats,
+        overlijdensdatum,
+        naam_niet_natuurlijk_persoon,
+        rechtsvorm,
+        statutaire_zetel,
+        kvk_nummer,
+        ka_appartementsindex,
+        ka_deelperceelnummer,
+        ka_perceelnummer,
+        ka_kad_gemeentecode,
+        ka_sectie,
+        begrenzing_perceel
+    ) AS
+SELECT
+    row_number() OVER (order by p.kadaster_identificatie) AS objectid,
+    p.kadaster_identificatie    AS kadaster_identificatie,
+    p.type,
+    zr.kadaster_identif AS zakelijk_recht_identificatie,
+    zr.ar_teller        AS aandeel_teller,
+    zr.ar_noemer        AS aandeel_noemer,
+    zr.fk_3avr_aand     AS aard_recht_aand,
+    ark.omschr          AS zakelijk_recht_omschrijving,
+    b.aankoopdatum,
+    CASE
+        WHEN np.sc_identif IS NOT NULL
+        THEN 'Natuurlijk persoon'
+        WHEN nnp.sc_identif IS NOT NULL
+        THEN 'Niet natuurlijk persoon'
+        ELSE 'Onbekend'
+    END                             AS soort_eigenaar,
+    np.nm_geslachtsnaam             AS geslachtsnaam,
+    np.nm_voorvoegsel_geslachtsnaam AS voorvoegsel,
+    np.nm_voornamen                 AS voornamen,
+    np.geslachtsaand                AS geslacht,
+    CASE
+        WHEN np.sc_identif IS NOT NULL
+        THEN np.NM_GESLACHTSNAAM + ', ' + np.NM_VOORNAMEN + ' ' +
+            np.NM_VOORVOEGSEL_GESLACHTSNAAM
+        WHEN nnp.sc_identif IS NOT NULL
+        THEN nnp.NAAM
+        ELSE 'Onbekend'
+    END                     AS perceel_zak_recht_naam,
+    inp.sc_identif          AS persoon_identificatie,
+    inp.va_loc_beschrijving AS woonadres,
+    inp.gb_geboortedatum    AS geboortedatum,
+    inp.gb_geboorteplaats   AS geboorteplaats,
+    inp.ol_overlijdensdatum AS overlijdensdatum,
+    nnp.naam                AS naam_niet_natuurlijk_persoon,
+    innp.rechtsvorm,
+    innp.statutaire_zetel,
+    innp_subject.kvk_nummer,
+    p.ka_appartementsindex,
+    p.ka_deelperceelnummer,
+    p.ka_perceelnummer,
+    p.ka_kad_gemeentecode,
+    p.ka_sectie,
+    p.begrenzing_perceel
+FROM
+    v_bd_app_re_and_kad_perceel p
+JOIN
+    zak_recht zr
+ON
+    zr.fk_7koz_kad_identif = p.kadaster_identificatie
+LEFT JOIN
+    aard_recht_verkort ark
+ON
+    zr.fk_3avr_aand = ark.aand
+LEFT JOIN
+    aard_verkregen_recht ar
+ON
+    zr.fk_3avr_aand = ar.aand
+LEFT JOIN
+    nat_prs np
+ON
+    np.sc_identif = zr.fk_8pes_sc_identif
+LEFT JOIN
+    ingeschr_nat_prs inp
+ON
+    inp.sc_identif = np.sc_identif
+LEFT JOIN
+    niet_nat_prs nnp
+ON
+    nnp.sc_identif = zr.fk_8pes_sc_identif
+LEFT JOIN
+    ingeschr_niet_nat_prs innp
+ON
+    innp.sc_identif = nnp.sc_identif
+LEFT JOIN
+    subject innp_subject
+ON
+    innp_subject.identif = innp.sc_identif
+LEFT JOIN
+    v_aankoopdatum b
+ON
+    b.kadaster_identificatie = p.kadaster_identificatie
+WHERE
+    zr.kadaster_identif like 'NL.KAD.Tenaamstelling%';
+


### PR DESCRIPTION
__NB__ "aankoopdatum" in deze definitie is de jongste datum waarop het stuk (stukdeel) ("Akte van Koop en Verkoop") van verkoop is aangeboden/verwerkt door Kadaster. In het XML mutatie bericht `<Stuk:TerInschrijvingAangebodenStuk...>/<Stuk:tijdstipAanbieding>`

In deze PR:
  - [x] aankoop valuta vullen
  - [x] uitgebreid vullen van brondocument tabel
  - upgrade procedures datamodel
    - [x] oracle
    - [x] postgresql
    - [x] sqlserver
  - [x] datafix ("snelle update")
  - [x] view maken met `aankoopdatum` en aanpassen `VM_KAD_EIGENARENKAART` materialized view om deze datum op te nemen

[MANTIS 5974](http://mantis.b3p.nl/view.php?id=5974)