### PR TITLE
Voeg aard recht codes 23 en 24 toe

### DIFF
--- a/datamodel/extra_scripts/oracle/108_insert_aard_recht_verkort.sql
+++ b/datamodel/extra_scripts/oracle/108_insert_aard_recht_verkort.sql
@@ -20,3 +20,5 @@ INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('19', 'Voorrecht');
 INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('20', 'Zakelijk recht na twee of meer zakelijke belastingen');
 INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('21', 'Zakelijke belasting derde of volgende');
 INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('22', 'BP-recht');
+INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('23', 'Opstalrecht Nutsvoorzieningen op gedeelte van perceel');
+INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('24', 'Zakelijk recht (als bedoeld in artikel 5, lid 3, onder b)');

--- a/datamodel/extra_scripts/oracle/109_insert_aard_verkregen_recht.sql
+++ b/datamodel/extra_scripts/oracle/109_insert_aard_verkregen_recht.sql
@@ -20,3 +20,5 @@ INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('1
 INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('20', 'Zakelijk recht na twee of meer zakelijke belastingen');
 INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('21', 'Zakelijke belasting derde of volgende');
 INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('22', 'BP-recht');
+INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('23', 'Opstalrecht Nutsvoorzieningen op gedeelte van perceel');
+INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('24', 'Zakelijk recht als bedoeld in artikel 5, lid 3, onder b, van de Belemmeringenwet Privaatrecht op gedeelte van perceel');

--- a/datamodel/extra_scripts/postgresql/108_insert_aard_recht_verkort.sql
+++ b/datamodel/extra_scripts/postgresql/108_insert_aard_recht_verkort.sql
@@ -20,3 +20,5 @@ INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('19', 'Voorrecht');
 INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('20', 'Zakelijk recht na twee of meer zakelijke belastingen');
 INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('21', 'Zakelijke belasting derde of volgende');
 INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('22', 'BP-recht');
+INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('23', 'Opstalrecht Nutsvoorzieningen op gedeelte van perceel');
+INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('24', 'Zakelijk recht (als bedoeld in artikel 5, lid 3, onder b)');

--- a/datamodel/extra_scripts/postgresql/109_insert_aard_verkregen_recht.sql
+++ b/datamodel/extra_scripts/postgresql/109_insert_aard_verkregen_recht.sql
@@ -20,3 +20,5 @@ INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('1
 INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('20', 'Zakelijk recht na twee of meer zakelijke belastingen');
 INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('21', 'Zakelijke belasting derde of volgende');
 INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('22', 'BP-recht');
+INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('23', 'Opstalrecht Nutsvoorzieningen op gedeelte van perceel');
+INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('24', 'Zakelijk recht als bedoeld in artikel 5, lid 3, onder b, van de Belemmeringenwet Privaatrecht op gedeelte van perceel');

--- a/datamodel/extra_scripts/sqlserver/108_insert_aard_recht_verkort.sql
+++ b/datamodel/extra_scripts/sqlserver/108_insert_aard_recht_verkort.sql
@@ -20,3 +20,5 @@ INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('19', 'Voorrecht');
 INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('20', 'Zakelijk recht na twee of meer zakelijke belastingen');
 INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('21', 'Zakelijke belasting derde of volgende');
 INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('22', 'BP-recht');
+INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('23', 'Opstalrecht Nutsvoorzieningen op gedeelte van perceel');
+INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('24', 'Zakelijk recht (als bedoeld in artikel 5, lid 3, onder b)');

--- a/datamodel/extra_scripts/sqlserver/109_insert_aard_verkregen_recht.sql
+++ b/datamodel/extra_scripts/sqlserver/109_insert_aard_verkregen_recht.sql
@@ -20,3 +20,5 @@ INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('1
 INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('20', 'Zakelijk recht na twee of meer zakelijke belastingen');
 INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('21', 'Zakelijke belasting derde of volgende');
 INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('22', 'BP-recht');
+INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('23', 'Opstalrecht Nutsvoorzieningen op gedeelte van perceel');
+INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('24', 'Zakelijk recht als bedoeld in artikel 5, lid 3, onder b, van de Belemmeringenwet Privaatrecht op gedeelte van perceel');

--- a/datamodel/upgrade_scripts/1.3.6-1.4.0/oracle/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.3.6-1.4.0/oracle/rsgb.sql
@@ -1,3 +1,19 @@
 --
 -- upgrade RSGB datamodel van 1.3.6 naar 1.4.0 (Oracle)
 --
+-- merge van de nieuwe waarden voor Aard Recht codelijst (issue#234)
+MERGE INTO aard_recht_verkort USING dual ON (aand='23')
+WHEN MATCHED THEN UPDATE SET omschr='Opstalrecht Nutsvoorzieningen op gedeelte van perceel'
+WHEN NOT MATCHED THEN INSERT (aand, omschr) VALUES ('23','Opstalrecht Nutsvoorzieningen op gedeelte van perceel');
+
+MERGE INTO aard_recht_verkort USING dual ON (aand='24')
+WHEN MATCHED THEN UPDATE SET omschr='Zakelijk recht (als bedoeld in artikel 5, lid 3, onder b)'
+WHEN NOT MATCHED THEN INSERT (aand, omschr) VALUES ('24','Zakelijk recht (als bedoeld in artikel 5, lid 3, onder b)');
+
+MERGE INTO aard_verkregen_recht USING dual ON (aand='23')
+WHEN MATCHED THEN UPDATE SET omschr_aard_verkregenr_recht='Opstalrecht Nutsvoorzieningen op gedeelte van perceel'
+WHEN NOT MATCHED THEN INSERT (aand, omschr_aard_verkregenr_recht) VALUES ('23','Opstalrecht Nutsvoorzieningen op gedeelte van perceel');
+  
+MERGE INTO aard_verkregen_recht USING dual ON (aand='24')
+WHEN MATCHED THEN UPDATE SET omschr_aard_verkregenr_recht='Zakelijk recht als bedoeld in artikel 5, lid 3, onder b, van de Belemmeringenwet Privaatrecht op gedeelte van perceel'
+WHEN NOT MATCHED THEN INSERT (aand, omschr_aard_verkregenr_recht) VALUES ('24','Zakelijk recht als bedoeld in artikel 5, lid 3, onder b, van de Belemmeringenwet Privaatrecht op gedeelte van perceel');

--- a/datamodel/upgrade_scripts/1.3.6-1.4.0/postgresql/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.3.6-1.4.0/postgresql/rsgb.sql
@@ -1,3 +1,21 @@
 --
 -- upgrade RSGB datamodel van 1.3.6 naar 1.4.0 (PostgreSQL)
--- 
+--
+-- upsert van de nieuwe waarden voor Aard Recht codelijst (issue#234)
+WITH new_values (id, txt) AS (VALUES
+        ('23','Opstalrecht Nutsvoorzieningen op gedeelte van perceel'),
+        ('24','Zakelijk recht (als bedoeld in artikel 5, lid 3, onder b)')
+    ), upsert AS (
+        UPDATE aard_recht_verkort m SET omschr = nv.txt
+        FROM new_values nv WHERE  m.aand = nv.id RETURNING m.* 
+    )
+INSERT INTO aard_recht_verkort (aand, omschr) SELECT id, txt FROM new_values WHERE NOT EXISTS (SELECT 1 FROM upsert up WHERE up.aand = new_values.id);
+                  
+WITH new_values (id, txt) AS (VALUES
+        ('23','Opstalrecht Nutsvoorzieningen op gedeelte van perceel'),
+        ('24','Zakelijk recht als bedoeld in artikel 5, lid 3, onder b, van de Belemmeringenwet Privaatrecht op gedeelte van perceel')
+    ), upsert AS (
+        UPDATE aard_verkregen_recht m SET omschr_aard_verkregenr_recht = nv.txt
+        FROM new_values nv WHERE  m.aand = nv.id RETURNING m.* 
+    )
+INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) SELECT id, txt FROM new_values WHERE NOT EXISTS (SELECT 1 FROM upsert up WHERE up.aand = new_values.id);

--- a/datamodel/upgrade_scripts/1.3.6-1.4.0/sqlserver/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.3.6-1.4.0/sqlserver/rsgb.sql
@@ -1,3 +1,19 @@
 --
 -- upgrade RSGB datamodel van 1.3.6 naar 1.4.0 (MS SQLserver)
 --
+-- merge van de nieuwe waarden voor Aard Recht codelijst (issue#234)
+MERGE INTO aard_recht_verkort t USING (
+    VALUES 
+        ('23','Opstalrecht Nutsvoorzieningen op gedeelte van perceel'),
+        ('24','Zakelijk recht (als bedoeld in artikel 5, lid 3, onder b)')
+    ) AS src (code,txt) ON t.aand = src.code
+WHEN MATCHED THEN UPDATE SET omschr = src.txt
+WHEN NOT MATCHED THEN INSERT (aand,omschr) VALUES (src.code, src.txt);
+
+MERGE INTO aard_verkregen_recht t USING (
+    VALUES 
+        ('23','Opstalrecht Nutsvoorzieningen op gedeelte van perceel'),
+        ('24','Zakelijk recht als bedoeld in artikel 5, lid 3, onder b, van de Belemmeringenwet Privaatrecht op gedeelte van perceel')
+    ) AS src (code,txt) ON t.aand = src.code
+WHEN MATCHED THEN UPDATE SET omschr_aard_verkregenr_recht = src.txt
+WHEN NOT MATCHED THEN INSERT (aand,omschr_aard_verkregenr_recht) VALUES (src.code, src.txt);


### PR DESCRIPTION
dit zijn codes die afgelopen jaar zijn bedacht.

- [ ] wacht nog op bevestiging van Kadaster of `24` echt `24` moet zijn, of dat het `25` moet zijn; op [website staat](http://www.kadaster.nl/schemas/waardelijsten/AardZakelijkRecht/) `25`, in [csv download](http://www.kadaster.nl/web/pagina/Informatiemodel-Kadaster/Waardelijsten.htm) van juli `24`
- [x] toevoegen aan bron bestanden
- [x] in rsgb upgrade script voor de verschillende databases nog toevoegen:
- [ ] datamodel scripts hergenereren

close #234