### PR TITLE
Travis-CI fixes voor brmo-loader integratie test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: java
 
 addons:
    postgresql: "9.5"
-   # fix voor OpenJDK bufferoverflow, zie: 
+   # fix voor OpenJDK bufferoverflow, zie:
    #  - https://docs.travis-ci.com/user/hostname
    #  - https://github.com/travis-ci/travis-ci/issues/5227
    #  - https://github.com/travis-ci/travis-ci/issues/5669
@@ -30,7 +30,7 @@ before_install:
   - unzip -qq apache-maven-3.3.9-bin.zip
   - export M2_HOME=$PWD/apache-maven-3.3.9
   - export PATH=$M2_HOME/bin:$PATH
-  # installeer/update postgis 2.2 op 9.5  
+  # installeer/update postgis 2.2 op 9.5
   - sudo service postgresql stop
   - sudo -E apt-get -qq update &>> ~/apt-get-update.log
   - sudo apt-get -qq install postgis-2.2 gdal-bin graphviz
@@ -39,31 +39,21 @@ before_install:
   - sudo service postgresql stop
   - sudo service postgresql start 9.5
   #- export PGHOST=localhost
-  #- export PGPORT=5433
+  #- export PGPORT=5432
   - export PAGER=cat
   # set up STAGING db
   - psql --version
   - psql -U postgres -d postgres -c 'SELECT Version();'
   - psql -U postgres -a -c "CREATE ROLE staging LOGIN PASSWORD 'staging' SUPERUSER CREATEDB;"
   - psql -U postgres -a -c "CREATE ROLE rsgb LOGIN PASSWORD 'rsgb' SUPERUSER CREATEDB;"
+  - psql -U postgres -a -c "CREATE ROLE rsgbbgt LOGIN PASSWORD 'rsgbbgt' SUPERUSER CREATEDB;"
   - psql -U postgres -c 'create database staging;'
   - psql -U postgres -c 'create database rsgb;'
   - psql -U postgres -d rsgb -c 'create extension postgis;'
-  - psql -U postgres -d rsgb -c 'SELECT PostGIS_full_version();' 
-  - ls -l ./datamodel/generated_scripts/
-  # bgt test schema
-  - psql -U postgres -d rsgb -c "CREATE SCHEMA bgttest AUTHORIZATION rsgb;"
-  - psql -U postgres -d rsgb -c "GRANT ALL ON SCHEMA bgttest TO public;"
-  # set up RSGB db
-  - travis_wait psql -U postgres -w -q -d rsgb -f ./datamodel/generated_scripts/datamodel_postgresql.sql
-  #- ls -l ./datamodel/utility_scripts/postgresql/
-  #- travis_wait psql -U postgres -w -d rsgb -f ./datamodel/utility_scripts/postgresql/111a_update_gemeente_geom.sql
-  #- travis_wait psql -U postgres -w -d rsgb -f ./datamodel/utility_scripts/postgresql/113a_update_wijk_geom.sql
-  # set up staging db
-  - ls -l ./brmo-persistence/db/
-  - psql -U postgres -d staging -f ./brmo-persistence/db/create-brmo-persistence-postgresql.sql
-  - psql -U postgres -d staging -f ./brmo-persistence/db/01_create_indexes.sql
-  - psql -U postgres -d staging -f ./brmo-persistence/db/02_insert_default_user.sql
+  - psql -U postgres -d rsgb -c 'SELECT PostGIS_full_version();'
+  - psql -U postgres -c 'create database rsgbbgt;'
+  - psql -U postgres -d rsgbbgt -c 'create extension postgis;'
+  - psql -U postgres -d rsgbbgt -c 'SELECT PostGIS_full_version();'
 
 install:
   # install all dependencies + artifacts without any testing, create staging db scripts
@@ -71,10 +61,20 @@ install:
 
 before_script:
   # dit dient na afloop van de 'install' gedaan te worden omdat de sql gegenereerd wordt
-  # bgt test tabellen
-  - psql "dbname=rsgb options=--search_path=bgttest,public" -U postgres -w -q -f ./bgt-gml-loader/target/generated-resources/ddl/postgresql/create_rsgb_bgt.sql
+  # set up staging db
+  - ls -l ./brmo-persistence/db/
+  - psql -U postgres -d staging -f ./brmo-persistence/db/create-brmo-persistence-postgresql.sql
+  - psql -U postgres -d staging -f ./brmo-persistence/db/01_create_indexes.sql
+  - psql -U postgres -d staging -f ./brmo-persistence/db/02_insert_default_user.sql
+  # set up rsgb tabellen
+  - ls -l ./datamodel/generated_scripts/
+  - travis_wait psql -U postgres -w -q -d rsgb -f ./datamodel/generated_scripts/datamodel_postgresql.sql
+  #- ls -l ./datamodel/utility_scripts/postgresql/
+  #- travis_wait psql -U postgres -w -d rsgb -f ./datamodel/utility_scripts/postgresql/111a_update_gemeente_geom.sql
+  #- travis_wait psql -U postgres -w -d rsgb -f ./datamodel/utility_scripts/postgresql/113a_update_wijk_geom.sql
+  # set up rsgbbgt tabellen
+  - psql -U postgres -w -q -d rsgbbgt -f ./bgt-gml-loader/target/generated-resources/ddl/postgresql/create_rsgb_bgt.sql
 
-# run tests
 script:
   # run unit tests
   - mvn -e test -B -Ppostgresql -pl '!brmo-dist'
@@ -82,7 +82,7 @@ script:
   # run integratie tests voor bgt-gml-loader module
   - mvn -e verify -B -Ppostgresql -Dtest.onlyITs=true -pl 'bgt-gml-loader'
   # run integratie tests voor brmo-loader module
-  - travis_wait mvn -e verify -B -Ppostgresql -Dtest.onlyITs=true -pl 'brmo-loader'
+  - mvn -e verify -B -Ppostgresql -Dtest.onlyITs=true -pl 'brmo-loader'
   # run integratie tests voor brmo-service module
   - travis_wait mvn -e verify -B -Ppostgresql -Dtest.onlyITs=true -pl 'brmo-service'
   # test of javadoc compliant is met java-8 strict checks

--- a/bgt-gml-loader/src/test/resources/postgis.properties
+++ b/bgt-gml-loader/src/test/resources/postgis.properties
@@ -3,10 +3,10 @@
 dbtype=postgis
 host=localhost
 port=5432
-database=rsgb
-schema=bgttest
-user=rsgb
-passwd=rsgb
+database=rsgbbgt
+schema=public
+user=rsgbbgt
+passwd=rsgbbgt
 # regular jdbc
 jdbc.driverClassName=org.postgresql.Driver
-jdbc.url=jdbc:postgresql://localhost:5432/rsgb?currentSchema=bgttest,searchpath=bgttest,public
+jdbc.url=jdbc:postgresql://localhost:5432/rsgbbgt

--- a/brmo-loader/src/test/java/nl/b3p/Mantis6098IntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/Mantis6098IntegrationTest.java
@@ -53,11 +53,14 @@ public class Mantis6098IntegrationTest extends AbstractDatabaseIntegrationTest {
         dsStaging.setUrl(params.getProperty("staging.jdbc.url"));
         dsStaging.setUsername(params.getProperty("staging.passwd"));
         dsStaging.setPassword(params.getProperty("staging.user"));
+        dsStaging.setAccessToUnderlyingConnectionAllowed(true);
 
         BasicDataSource dsRsgb = new BasicDataSource();
         dsRsgb.setUrl(params.getProperty("rsgb.jdbc.url"));
         dsRsgb.setUsername(params.getProperty("rsgb.passwd"));
         dsRsgb.setPassword(params.getProperty("rsgb.user"));
+        dsRsgb.setAccessToUnderlyingConnectionAllowed(true);
+        dsRsgb.setDefaultCatalog(params.getProperty("rsgb.schema"));
 
         rsgb = new DatabaseDataSourceConnection(dsRsgb);
         staging = new DatabaseDataSourceConnection(dsStaging);

--- a/brmo-loader/src/test/resources/postgis.properties
+++ b/brmo-loader/src/test/resources/postgis.properties
@@ -6,6 +6,7 @@ rsgb.host=localhost
 rsgb.port=5432
 rsgb.database=rsgb
 rsgb.schema=public
+
 rsgb.user=rsgb
 rsgb.passwd=rsgb
 # regular jdbc


### PR DESCRIPTION
dbunit raakt in de war met public en rsgbbgt schema in 1 db, mogelijk dat de vogende melding daarmee te maken heeft: 
```
BRMO-LOADER-TEST:  WARN 23:21:15 (org.dbunit.database.DatabaseDataSet#getTableMetaData:303) - Potential problem found: The configured data type factory 'class org.dbunit.dataset.datatype.DefaultDataTypeFactory' might cause problems with the current database 'PostgreSQL' (e.g. some datatypes may not be supported properly). In rare cases you might see this message because the list of supported database products is incomplete (list=[derby]). If so please request a java-class update via the forums.If you are using your own IDataTypeFactory extending DefaultDataTypeFactory, ensure that you override getValidDbProducts() to specify the supported database products.
```
zie: https://travis-ci.org/B3Partners/brmo/jobs/169573897#L5285