### PR TITLE
Maven plugin en dependency updates

### DIFF
--- a/brmo-soap/pom.xml
+++ b/brmo-soap/pom.xml
@@ -13,36 +13,37 @@
     <name>brmo-soap</name>
     <properties>
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
+        <glassfish.version>2.3.1</glassfish.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.glassfish.metro</groupId>
             <artifactId>webservices-tools</artifactId>
-            <version>2.2-b03</version>
+            <version>${glassfish.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.metro</groupId>
             <artifactId>webservices-rt</artifactId>
-            <version>2.3</version>
+            <version>${glassfish.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.metro</groupId>
             <artifactId>webservices-extra</artifactId>
-            <version>2.2-b03</version>
+            <version>${glassfish.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.metro</groupId>
             <artifactId>webservices-api</artifactId>
-            <version>2.2-b03</version>
+            <version>${glassfish.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.glassfish.metro</groupId>
             <artifactId>webservices-extra-api</artifactId>
-            <version>2.2-b03</version>
+            <version>${glassfish.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -58,7 +59,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <compilerArguments>
@@ -67,14 +67,12 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         de schema's voor posgresql en oracle worden niet automatisch aangemaakt.
         -->
         <test.persistence.unit>brmo.persistence.h2</test.persistence.unit>
-        <test.h2.version>1.4.192</test.h2.version>
+        <test.h2.version>1.4.193</test.h2.version>
         <test.onlyITs>false</test.onlyITs>
         <maven.surefire.version>2.19.1</maven.surefire.version>
     </properties>
@@ -104,7 +104,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.4</version>
+                <version>3.5</version>
             </dependency>
             <dependency>
                 <groupId>commons-fileupload</groupId>
@@ -298,7 +298,7 @@
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.9.2</version>
+                <version>1.10.1</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.ws</groupId>
@@ -487,7 +487,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>3.6.0</version>
                     <configuration>
                         <source>${java.version}</source>
                         <target>${java.version}</target>


### PR DESCRIPTION
### maven plugins
  - maven compiler plugin update

### libraries
  - upgrade commons-lang3 van 3.4 -> 3.5 (https://commons.apache.org/proper/commons-lang/release-notes/RELEASE-NOTES-3.5.txt)
  - upgrade jsoup 1.9.2 -> 1.10.1 (https://jsoup.org/news/release-1.10.1)
  - upgrade glassfish componenten 2.2-b03 -> 2.3.1