### PR TITLE
Aanpassen BAG woonplaats bij nummeraanduiding selectie

### DIFF
--- a/datamodel/extra_scripts/oracle/106_bag_views.sql
+++ b/datamodel/extra_scripts/oracle/106_bag_views.sql
@@ -41,7 +41,12 @@ SELECT
     VBO.SC_IDENTIF              AS FID,
     FKPAND.FK_NN_RH_PND_IDENTIF AS PAND_ID,
     GEM.NAAM                    AS GEMEENTE,
-    WP.NAAM                     AS WOONPLAATS,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM           
+    END                         AS WOONPLAATS,
     GEOR.NAAM_OPENB_RMTE        AS STRAATNAAM,
     ADDROBJ.HUINUMMER           AS HUISNUMMER,
     ADDROBJ.HUISLETTER,
@@ -309,7 +314,12 @@ SELECT
     CAST(ROWNUM AS INTEGER) AS OBJECTID,
     LP.SC_IDENTIF           AS FID,
     GEM.NAAM                AS GEMEENTE,
-    WP.NAAM                 AS WOONPLAATS,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM           
+    END                     AS WOONPLAATS,
     GEOR.NAAM_OPENB_RMTE    AS STRAATNAAM,
     ADDROBJ.HUINUMMER       AS HUISNUMMER,
     ADDROBJ.HUISLETTER,
@@ -382,7 +392,12 @@ SELECT
     CAST(ROWNUM AS INTEGER) AS OBJECTID,
     SP.SC_IDENTIF           AS FID,
     GEM.NAAM                AS GEMEENTE,
-    WP.NAAM                 AS WOONPLAATS,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM           
+    END                     AS WOONPLAATS,
     GEOR.NAAM_OPENB_RMTE    AS STRAATNAAM,
     ADDROBJ.HUINUMMER       AS HUISNUMMER,
     ADDROBJ.HUISLETTER,
@@ -459,7 +474,12 @@ SELECT
     CAST(ROWNUM AS INTEGER) AS OBJECTID,
     VBO.SC_IDENTIF          AS FID,
     GEM.NAAM                AS GEMEENTE,
-    WP.NAAM                 AS WOONPLAATS,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM           
+    END                     AS WOONPLAATS,
     GEOR.NAAM_OPENB_RMTE    AS STRAATNAAM,
     ADDROBJ.HUINUMMER       AS HUISNUMMER,
     ADDROBJ.HUISLETTER,
@@ -536,7 +556,12 @@ CREATE  OR REPLACE VIEW
 SELECT
     LPA.SC_IDENTIF       AS FID,
     GEM.NAAM             AS GEMEENTE,
-    WP.NAAM              AS WOONPLAATS,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM           
+    END                  AS WOONPLAATS,
     GEOR.NAAM_OPENB_RMTE AS STRAATNAAM,
     ADDROBJ.HUINUMMER    AS HUISNUMMER,
     ADDROBJ.HUISLETTER,
@@ -611,7 +636,12 @@ CREATE OR REPLACE VIEW
 SELECT
     SPL.SC_IDENTIF       AS FID,
     GEM.NAAM             AS GEMEENTE,
-    WP.NAAM              AS WOONPLAATS,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM           
+    END                  AS WOONPLAATS,
     GEOR.NAAM_OPENB_RMTE AS STRAATNAAM,
     ADDROBJ.HUINUMMER    AS HUISNUMMER,
     ADDROBJ.HUISLETTER,

--- a/datamodel/extra_scripts/postgresql/106_bag_views.sql
+++ b/datamodel/extra_scripts/postgresql/106_bag_views.sql
@@ -42,7 +42,12 @@ SELECT
     vbo.sc_identif              AS fid,
     fkpand.fk_nn_rh_pnd_identif AS pand_id,
     gem.naam                    AS gemeente,
-    wp.naam                     AS woonplaats,
+    CASE
+        WHEN addrobj.fk_6wpl_identif IS NOT NULL
+        -- opzoeken want in andere woonplaats
+        THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+        ELSE wp.naam           
+    END                         AS woonplaats,
     geor.naam_openb_rmte        AS straatnaam,
     addrobj.huinummer           AS huisnummer,
     addrobj.huisletter,
@@ -310,7 +315,12 @@ SELECT
     (row_number() OVER ())::integer AS ObjectID,
     lp.sc_identif        AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+        WHEN addrobj.fk_6wpl_identif IS NOT NULL
+        -- opzoeken want in andere woonplaats
+        THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+        ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -383,7 +393,12 @@ SELECT
     (row_number() OVER ())::integer AS ObjectID,
     sp.sc_identif        AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+        WHEN addrobj.fk_6wpl_identif IS NOT NULL
+        -- opzoeken want in andere woonplaats
+        THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+        ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -460,7 +475,12 @@ SELECT
     (row_number() OVER ())::integer AS ObjectID,
     vbo.sc_identif       AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+        WHEN addrobj.fk_6wpl_identif IS NOT NULL
+        -- opzoeken want in andere woonplaats
+        THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+        ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -537,7 +557,12 @@ CREATE VIEW
 SELECT
     lpa.sc_identif       AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+        WHEN addrobj.fk_6wpl_identif IS NOT NULL
+        -- opzoeken want in andere woonplaats
+        THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+        ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -612,7 +637,12 @@ CREATE VIEW
 SELECT
     spl.sc_identif       AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+        WHEN addrobj.fk_6wpl_identif IS NOT NULL
+        -- opzoeken want in andere woonplaats
+        THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+        ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,

--- a/datamodel/extra_scripts/sqlserver/106_bag_views.sql
+++ b/datamodel/extra_scripts/sqlserver/106_bag_views.sql
@@ -43,7 +43,12 @@ SELECT
     vbo.sc_identif              AS fid,
     fkpand.fk_nn_rh_pnd_identif AS pand_id,
     gem.naam                    AS gemeente,
-    wp.naam                     AS woonplaats,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                         AS woonplaats,
     geor.naam_openb_rmte        AS straatnaam,
     addrobj.huinummer           AS huisnummer,
     addrobj.huisletter,
@@ -325,7 +330,12 @@ SELECT
     CAST(ROW_NUMBER() over(ORDER BY lp.sc_identif) AS INT) AS ObjectID,
     lp.sc_identif        AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -400,7 +410,12 @@ SELECT
     CAST(ROW_NUMBER() over(ORDER BY sp.sc_identif) AS INT) AS ObjectID,
     sp.sc_identif        AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -479,7 +494,12 @@ SELECT
     CAST(ROW_NUMBER() over(ORDER BY vbo.sc_identif) AS INT) AS ObjectID,
     vbo.sc_identif       AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -558,7 +578,12 @@ CREATE VIEW
 SELECT
     lpa.sc_identif       AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -635,7 +660,12 @@ CREATE VIEW
 SELECT
     spl.sc_identif       AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,

--- a/datamodel/generated_scripts/datamodel_oracle.sql
+++ b/datamodel/generated_scripts/datamodel_oracle.sql
@@ -1,7 +1,7 @@
 --
 -- BRMO RSGB script voor oracle
 -- Applicatie versie: 1.4.0-SNAPSHOT
--- Gegenereerd op 2016-11-01T16:19:50.124+01:00
+-- Gegenereerd op 2016-11-04T10:26:31.066+01:00
 --
 
 
@@ -3871,7 +3871,12 @@ SELECT
     VBO.SC_IDENTIF              AS FID,
     FKPAND.FK_NN_RH_PND_IDENTIF AS PAND_ID,
     GEM.NAAM                    AS GEMEENTE,
-    WP.NAAM                     AS WOONPLAATS,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM           
+    END                         AS WOONPLAATS,
     GEOR.NAAM_OPENB_RMTE        AS STRAATNAAM,
     ADDROBJ.HUINUMMER           AS HUISNUMMER,
     ADDROBJ.HUISLETTER,
@@ -4139,7 +4144,12 @@ SELECT
     CAST(ROWNUM AS INTEGER) AS OBJECTID,
     LP.SC_IDENTIF           AS FID,
     GEM.NAAM                AS GEMEENTE,
-    WP.NAAM                 AS WOONPLAATS,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM           
+    END                     AS WOONPLAATS,
     GEOR.NAAM_OPENB_RMTE    AS STRAATNAAM,
     ADDROBJ.HUINUMMER       AS HUISNUMMER,
     ADDROBJ.HUISLETTER,
@@ -4212,7 +4222,12 @@ SELECT
     CAST(ROWNUM AS INTEGER) AS OBJECTID,
     SP.SC_IDENTIF           AS FID,
     GEM.NAAM                AS GEMEENTE,
-    WP.NAAM                 AS WOONPLAATS,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM           
+    END                     AS WOONPLAATS,
     GEOR.NAAM_OPENB_RMTE    AS STRAATNAAM,
     ADDROBJ.HUINUMMER       AS HUISNUMMER,
     ADDROBJ.HUISLETTER,
@@ -4289,7 +4304,12 @@ SELECT
     CAST(ROWNUM AS INTEGER) AS OBJECTID,
     VBO.SC_IDENTIF          AS FID,
     GEM.NAAM                AS GEMEENTE,
-    WP.NAAM                 AS WOONPLAATS,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM           
+    END                     AS WOONPLAATS,
     GEOR.NAAM_OPENB_RMTE    AS STRAATNAAM,
     ADDROBJ.HUINUMMER       AS HUISNUMMER,
     ADDROBJ.HUISLETTER,
@@ -4366,7 +4386,12 @@ CREATE  OR REPLACE VIEW
 SELECT
     LPA.SC_IDENTIF       AS FID,
     GEM.NAAM             AS GEMEENTE,
-    WP.NAAM              AS WOONPLAATS,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM           
+    END                  AS WOONPLAATS,
     GEOR.NAAM_OPENB_RMTE AS STRAATNAAM,
     ADDROBJ.HUINUMMER    AS HUISNUMMER,
     ADDROBJ.HUISLETTER,
@@ -4441,7 +4466,12 @@ CREATE OR REPLACE VIEW
 SELECT
     SPL.SC_IDENTIF       AS FID,
     GEM.NAAM             AS GEMEENTE,
-    WP.NAAM              AS WOONPLAATS,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM           
+    END                  AS WOONPLAATS,
     GEOR.NAAM_OPENB_RMTE AS STRAATNAAM,
     ADDROBJ.HUINUMMER    AS HUISNUMMER,
     ADDROBJ.HUISLETTER,
@@ -4554,7 +4584,8 @@ CREATE OR REPLACE VIEW
             CENTROIDE AS THE_GEOM
         FROM
             V_ADRES_STANDPLAATS
-    ) QRY;-- Script: 107_brk_views.sql
+    ) QRY;
+-- Script: 107_brk_views.sql
 
 
 create view v_map_kad_perceel as

--- a/datamodel/generated_scripts/datamodel_postgresql.sql
+++ b/datamodel/generated_scripts/datamodel_postgresql.sql
@@ -1,7 +1,7 @@
 --
 -- BRMO RSGB script voor postgresql
 -- Applicatie versie: 1.4.0-SNAPSHOT
--- Gegenereerd op 2016-11-01T16:19:49.755+01:00
+-- Gegenereerd op 2016-11-04T10:26:30.423+01:00
 --
 
 create table sbi_activiteit(
@@ -3555,7 +3555,12 @@ SELECT
     vbo.sc_identif              AS fid,
     fkpand.fk_nn_rh_pnd_identif AS pand_id,
     gem.naam                    AS gemeente,
-    wp.naam                     AS woonplaats,
+    CASE
+        WHEN addrobj.fk_6wpl_identif IS NOT NULL
+        -- opzoeken want in andere woonplaats
+        THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+        ELSE wp.naam           
+    END                         AS woonplaats,
     geor.naam_openb_rmte        AS straatnaam,
     addrobj.huinummer           AS huisnummer,
     addrobj.huisletter,
@@ -3823,7 +3828,12 @@ SELECT
     (row_number() OVER ())::integer AS ObjectID,
     lp.sc_identif        AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+        WHEN addrobj.fk_6wpl_identif IS NOT NULL
+        -- opzoeken want in andere woonplaats
+        THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+        ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -3896,7 +3906,12 @@ SELECT
     (row_number() OVER ())::integer AS ObjectID,
     sp.sc_identif        AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+        WHEN addrobj.fk_6wpl_identif IS NOT NULL
+        -- opzoeken want in andere woonplaats
+        THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+        ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -3973,7 +3988,12 @@ SELECT
     (row_number() OVER ())::integer AS ObjectID,
     vbo.sc_identif       AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+        WHEN addrobj.fk_6wpl_identif IS NOT NULL
+        -- opzoeken want in andere woonplaats
+        THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+        ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -4050,7 +4070,12 @@ CREATE VIEW
 SELECT
     lpa.sc_identif       AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+        WHEN addrobj.fk_6wpl_identif IS NOT NULL
+        -- opzoeken want in andere woonplaats
+        THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+        ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -4125,7 +4150,12 @@ CREATE VIEW
 SELECT
     spl.sc_identif       AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+        WHEN addrobj.fk_6wpl_identif IS NOT NULL
+        -- opzoeken want in andere woonplaats
+        THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+        ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -4238,7 +4268,8 @@ SELECT
             centroide AS the_geom
         FROM
             v_adres_standplaats
-    ) qry;-- Script: 107_brk_views.sql
+    ) qry;
+-- Script: 107_brk_views.sql
 
 
 create view v_map_kad_perceel as

--- a/datamodel/generated_scripts/datamodel_sqlserver.sql
+++ b/datamodel/generated_scripts/datamodel_sqlserver.sql
@@ -1,7 +1,7 @@
 --
 -- BRMO RSGB script voor sqlserver
 -- Applicatie versie: 1.4.0-SNAPSHOT
--- Gegenereerd op 2016-11-01T16:19:50.514+01:00
+-- Gegenereerd op 2016-11-04T10:26:31.368+01:00
 --
 
 create table sbi_activiteit(
@@ -2464,7 +2464,12 @@ SELECT
     vbo.sc_identif              AS fid,
     fkpand.fk_nn_rh_pnd_identif AS pand_id,
     gem.naam                    AS gemeente,
-    wp.naam                     AS woonplaats,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                         AS woonplaats,
     geor.naam_openb_rmte        AS straatnaam,
     addrobj.huinummer           AS huisnummer,
     addrobj.huisletter,
@@ -2746,7 +2751,12 @@ SELECT
     CAST(ROW_NUMBER() over(ORDER BY lp.sc_identif) AS INT) AS ObjectID,
     lp.sc_identif        AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -2821,7 +2831,12 @@ SELECT
     CAST(ROW_NUMBER() over(ORDER BY sp.sc_identif) AS INT) AS ObjectID,
     sp.sc_identif        AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -2900,7 +2915,12 @@ SELECT
     CAST(ROW_NUMBER() over(ORDER BY vbo.sc_identif) AS INT) AS ObjectID,
     vbo.sc_identif       AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -2979,7 +2999,12 @@ CREATE VIEW
 SELECT
     lpa.sc_identif       AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -3056,7 +3081,12 @@ CREATE VIEW
 SELECT
     spl.sc_identif       AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,

--- a/datamodel/upgrade_scripts/1.3.6-1.4.0/oracle/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.3.6-1.4.0/oracle/rsgb.sql
@@ -1,8 +1,8 @@
 --
 -- upgrade RSGB datamodel van 1.3.6 naar 1.4.0 (Oracle)
 --
--- Als er gebruik wordt gemaakt van Geotools (Flamingo)/Geoserver dan 
---   ook de inserts van de GT_PK_METADATA en GEOMETRY_COLUMNS uitvoeren 
+-- Als er gebruik wordt gemaakt van Geotools (Flamingo)/Geoserver dan
+--   ook de inserts van de GT_PK_METADATA en GEOMETRY_COLUMNS uitvoeren
 --   na aanpassen (onderaan in dit bestand).
 --
 -- merge van de nieuwe waarden voor Aard Recht codelijst (issue#234)
@@ -17,7 +17,7 @@ WHEN NOT MATCHED THEN INSERT (aand, omschr) VALUES ('24','Zakelijk recht (als be
 MERGE INTO aard_verkregen_recht USING dual ON (aand='23')
 WHEN MATCHED THEN UPDATE SET omschr_aard_verkregenr_recht='Opstalrecht Nutsvoorzieningen op gedeelte van perceel'
 WHEN NOT MATCHED THEN INSERT (aand, omschr_aard_verkregenr_recht) VALUES ('23','Opstalrecht Nutsvoorzieningen op gedeelte van perceel');
-  
+
 MERGE INTO aard_verkregen_recht USING dual ON (aand='24')
 WHEN MATCHED THEN UPDATE SET omschr_aard_verkregenr_recht='Zakelijk recht als bedoeld in artikel 5, lid 3, onder b, van de Belemmeringenwet Privaatrecht op gedeelte van perceel'
 WHEN NOT MATCHED THEN INSERT (aand, omschr_aard_verkregenr_recht) VALUES ('24','Zakelijk recht als bedoeld in artikel 5, lid 3, onder b, van de Belemmeringenwet Privaatrecht op gedeelte van perceel');
@@ -25,8 +25,8 @@ WHEN NOT MATCHED THEN INSERT (aand, omschr_aard_verkregenr_recht) VALUES ('24','
 -- toevoegen van een ObjectID aan kadaster views ten behoeve van arcgis
 
 -- view om vlakken kaart te maken met percelen die 1 of meerdere appartementen hebben
-CREATE OR REPLACE VIEW v_bd_kad_perceel_met_app_vlak AS 
- SELECT 
+CREATE OR REPLACE VIEW v_bd_kad_perceel_met_app_vlak AS
+ SELECT
     CAST(ROWNUM AS INTEGER) AS objectid,
     v.perceel_identif,
     kp.sc_kad_identif,
@@ -42,7 +42,7 @@ CREATE OR REPLACE VIEW v_bd_kad_perceel_met_app_vlak AS
    FROM v_bd_kad_perceel_with_app_re v
      JOIN kad_perceel kp ON v.perceel_identif = kp.sc_kad_identif;
 
-DELETE FROM USER_SDO_GEOM_METADATA WHERE TABLE_NAME='V_BD_KAD_PERCEEL_MET_APP_VLAK' AND  COLUMN_NAME='BEGRENZING_PERCEEL';     
+DELETE FROM USER_SDO_GEOM_METADATA WHERE TABLE_NAME='V_BD_KAD_PERCEEL_MET_APP_VLAK' AND  COLUMN_NAME='BEGRENZING_PERCEEL';
 INSERT INTO USER_SDO_GEOM_METADATA VALUES('V_BD_KAD_PERCEEL_MET_APP_VLAK', 'BEGRENZING_PERCEEL', MDSYS.SDO_DIM_ARRAY(MDSYS.SDO_DIM_ELEMENT('X', 12000, 280000, .1),MDSYS.SDO_DIM_ELEMENT('Y', 304000, 620000, .1)), 28992);
 
 CREATE OR REPLACE VIEW v_bd_app_re_bij_perceel
@@ -60,7 +60,7 @@ CREATE OR REPLACE VIEW v_bd_app_re_bij_perceel
   ON v.perceel_identif = kp.sc_kad_identif
   JOIN app_re ar
   ON v.app_re_identif = ar.sc_kad_identif;
-     
+
 CREATE OR REPLACE VIEW v_map_kad_perceel
                                  AS
   SELECT CAST(ROWNUM AS INTEGER) AS objectid,
@@ -185,7 +185,7 @@ CREATE OR REPLACE VIEW v_bd_app_re_and_kad_perceel
 
 
 DROP MATERIALIZED VIEW VM_KAD_EIGENARENKAART;
-CREATE MATERIALIZED VIEW VM_KAD_EIGENARENKAART ( OBJECTID, KADASTER_IDENTIFICATIE, TYPE, ZAKELIJK_RECHT_IDENTIFICATIE, AANDEEL_TELLER, AANDEEL_NOEMER, AARD_RECHT_AAND, ZAKELIJK_RECHT_OMSCHRIJVING, AANKOOPDATUM, SOORT_EIGENAAR, GESLACHTSNAAM, VOORVOEGSEL, VOORNAMEN, GESLACHT, PERCEEL_ZAK_RECHT_NAAM, PERSOON_IDENTIFICATIE, WOONADRES, GEBOORTEDATUM, GEBOORTEPLAATS, OVERLIJDENSDATUM, NAAM_NIET_NATUURLIJK_PERSOON, RECHTSVORM, STATUTAIRE_ZETEL, KVK_NUMMER, KA_APPARTEMENTSINDEX, KA_DEELPERCEELNUMMER, KA_PERCEELNUMMER, KA_KAD_GEMEENTECODE, KA_SECTIE, BEGRENZING_PERCEEL ) 
+CREATE MATERIALIZED VIEW VM_KAD_EIGENARENKAART ( OBJECTID, KADASTER_IDENTIFICATIE, TYPE, ZAKELIJK_RECHT_IDENTIFICATIE, AANDEEL_TELLER, AANDEEL_NOEMER, AARD_RECHT_AAND, ZAKELIJK_RECHT_OMSCHRIJVING, AANKOOPDATUM, SOORT_EIGENAAR, GESLACHTSNAAM, VOORVOEGSEL, VOORNAMEN, GESLACHT, PERCEEL_ZAK_RECHT_NAAM, PERSOON_IDENTIFICATIE, WOONADRES, GEBOORTEDATUM, GEBOORTEPLAATS, OVERLIJDENSDATUM, NAAM_NIET_NATUURLIJK_PERSOON, RECHTSVORM, STATUTAIRE_ZETEL, KVK_NUMMER, KA_APPARTEMENTSINDEX, KA_DEELPERCEELNUMMER, KA_PERCEELNUMMER, KA_KAD_GEMEENTECODE, KA_SECTIE, BEGRENZING_PERCEEL )
                                  AS
   SELECT CAST(ROWNUM AS INTEGER) AS objectid,
     p.kadaster_identificatie     AS kadaster_identificatie,
@@ -285,7 +285,12 @@ SELECT
     VBO.SC_IDENTIF              AS FID,
     FKPAND.FK_NN_RH_PND_IDENTIF AS PAND_ID,
     GEM.NAAM                    AS GEMEENTE,
-    WP.NAAM                     AS WOONPLAATS,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM
+    END                         AS WOONPLAATS,
     GEOR.NAAM_OPENB_RMTE        AS STRAATNAAM,
     ADDROBJ.HUINUMMER           AS HUISNUMMER,
     ADDROBJ.HUISLETTER,
@@ -533,7 +538,7 @@ ON
 -------------------------------------------------
 /*
 LIGPLAATS MET HOOFDADRES
-*/		
+*/
 CREATE OR REPLACE VIEW
     V_LIGPLAATS_ALLES
     (
@@ -553,7 +558,12 @@ SELECT
     CAST(ROWNUM AS INTEGER) AS OBJECTID,
     LP.SC_IDENTIF           AS FID,
     GEM.NAAM                AS GEMEENTE,
-    WP.NAAM                 AS WOONPLAATS,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM
+    END                     AS WOONPLAATS,
     GEOR.NAAM_OPENB_RMTE    AS STRAATNAAM,
     ADDROBJ.HUINUMMER       AS HUISNUMMER,
     ADDROBJ.HUISLETTER,
@@ -600,13 +610,13 @@ WHERE
         AND (
                 GEM.DATUM_EINDE_GELDH IS NULL))
     AND (
-            BT.DATUM_EINDE_GELDH IS NULL));	
+            BT.DATUM_EINDE_GELDH IS NULL));
 -------------------------------------------------
 -- V_STANDPLAATS_ALLES
 -------------------------------------------------
 /*
 STANDPLAATS MET HOOFDADRES
-*/		
+*/
 CREATE OR REPLACE VIEW
     V_STANDPLAATS_ALLES
     (
@@ -626,7 +636,12 @@ SELECT
     CAST(ROWNUM AS INTEGER) AS OBJECTID,
     SP.SC_IDENTIF           AS FID,
     GEM.NAAM                AS GEMEENTE,
-    WP.NAAM                 AS WOONPLAATS,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM
+    END                     AS WOONPLAATS,
     GEOR.NAAM_OPENB_RMTE    AS STRAATNAAM,
     ADDROBJ.HUINUMMER       AS HUISNUMMER,
     ADDROBJ.HUISLETTER,
@@ -673,13 +688,13 @@ WHERE
         AND (
                 GEM.DATUM_EINDE_GELDH IS NULL))
     AND (
-            BT.DATUM_EINDE_GELDH IS NULL));			
+            BT.DATUM_EINDE_GELDH IS NULL));
 -------------------------------------------------
 -- V_ADRES
 -------------------------------------------------
 /*
 VOLLEDIGE ADRESSENLIJST
-STANDPLAATS EN LIGPLAATS VIA BENOEMD_TERREIN, 
+STANDPLAATS EN LIGPLAATS VIA BENOEMD_TERREIN,
 WAARBIJ CENTROIDE VAN POLYGON WORDT GENOMEN
 PLUS VERBLIJFSOBJECT VIA PUNT OBJECT VAN GEBOUWD_OBJ
 */
@@ -703,7 +718,12 @@ SELECT
     CAST(ROWNUM AS INTEGER) AS OBJECTID,
     VBO.SC_IDENTIF          AS FID,
     GEM.NAAM                AS GEMEENTE,
-    WP.NAAM                 AS WOONPLAATS,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM
+    END                     AS WOONPLAATS,
     GEOR.NAAM_OPENB_RMTE    AS STRAATNAAM,
     ADDROBJ.HUINUMMER       AS HUISNUMMER,
     ADDROBJ.HUISLETTER,
@@ -759,6 +779,167 @@ WHERE
 AND (
         VBO.STATUS = 'Verblijfsobject in gebruik (niet ingemeten)'
     OR  VBO.STATUS = 'Verblijfsobject in gebruik');
+
+-------------------------------------------------
+-- V_ADRES_LIGPLAATS
+-------------------------------------------------
+CREATE OR REPLACE VIEW
+    V_ADRES_LIGPLAATS
+    (
+        FID,
+        GEMEENTE,
+        WOONPLAATS,
+        STRAATNAAM,
+        HUISNUMMER,
+        HUISLETTER,
+        HUISNUMMER_TOEV,
+        POSTCODE,
+        STATUS,
+        THE_GEOM,
+        CENTROIDE
+    ) AS
+SELECT
+    LPA.SC_IDENTIF       AS FID,
+    GEM.NAAM             AS GEMEENTE,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM
+    END                  AS WOONPLAATS,
+    GEOR.NAAM_OPENB_RMTE AS STRAATNAAM,
+    ADDROBJ.HUINUMMER    AS HUISNUMMER,
+    ADDROBJ.HUISLETTER,
+    ADDROBJ.HUINUMMERTOEVOEGING AS HUISNUMMER_TOEV,
+    ADDROBJ.POSTCODE,
+    LPA.STATUS,
+    BENTER.GEOM AS THE_GEOM,
+    SDO_GEOM.SDO_CENTROID(BENTER.GEOM,2)
+FROM
+    LIGPLAATS LPA
+JOIN
+    BENOEMD_TERREIN BENTER
+ON
+    (
+        BENTER.SC_IDENTIF = LPA.SC_IDENTIF )
+LEFT JOIN
+    LIGPLAATS_NUMMERAAND LNA
+ON
+    (
+        LNA.FK_NN_LH_LPL_SC_IDENTIF = LPA.SC_IDENTIF )
+LEFT JOIN
+    NUMMERAAND NA
+ON
+    (
+        NA.SC_IDENTIF = LPA.FK_4NRA_SC_IDENTIF )
+LEFT JOIN
+    ADDRESSEERB_OBJ_AAND ADDROBJ
+ON
+    (
+        ADDROBJ.IDENTIF = NA.SC_IDENTIF )
+JOIN
+    GEM_OPENB_RMTE GEOR
+ON
+    (
+        GEOR.IDENTIFCODE = ADDROBJ.FK_7OPR_IDENTIFCODE )
+LEFT JOIN
+    OPENB_RMTE_WNPLTS ORWP
+ON
+    (
+        GEOR.IDENTIFCODE = ORWP.FK_NN_LH_OPR_IDENTIFCODE)
+LEFT JOIN
+    WNPLTS WP
+ON
+    (
+        ORWP.FK_NN_RH_WPL_IDENTIF = WP.IDENTIF)
+LEFT JOIN
+    GEMEENTE GEM
+ON
+    (
+        WP.FK_7GEM_CODE = GEM.CODE )
+WHERE
+    NA.STATUS = 'Naamgeving uitgegeven'
+AND LPA.STATUS = 'Plaats aangewezen';
+-------------------------------------------------
+-- V_ADRES_STANDPLAATS
+-------------------------------------------------
+CREATE OR REPLACE VIEW
+    V_ADRES_STANDPLAATS
+    (
+        FID,
+        GEMEENTE,
+        WOONPLAATS,
+        STRAATNAAM,
+        HUISNUMMER,
+        HUISLETTER,
+        HUISNUMMER_TOEV,
+        POSTCODE,
+        STATUS,
+        THE_GEOM,
+        CENTROIDE
+    ) AS
+SELECT
+    SPL.SC_IDENTIF       AS FID,
+    GEM.NAAM             AS GEMEENTE,
+    CASE
+         WHEN ADDROBJ.FK_6WPL_IDENTIF IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (SELECT NAAM FROM WNPLTS WHERE IDENTIF = FK_6WPL_IDENTIF)
+         ELSE WP.NAAM
+    END                  AS WOONPLAATS,
+    GEOR.NAAM_OPENB_RMTE AS STRAATNAAM,
+    ADDROBJ.HUINUMMER    AS HUISNUMMER,
+    ADDROBJ.HUISLETTER,
+    ADDROBJ.HUINUMMERTOEVOEGING AS HUISNUMMER_TOEV,
+    ADDROBJ.POSTCODE,
+    SPL.STATUS,
+    BENTER.GEOM AS THE_GEOM,
+    SDO_GEOM.SDO_CENTROID(BENTER.GEOM,2)
+FROM
+    STANDPLAATS SPL
+JOIN
+    BENOEMD_TERREIN BENTER
+ON
+    (
+        BENTER.SC_IDENTIF = SPL.SC_IDENTIF )
+LEFT JOIN
+    STANDPLAATS_NUMMERAAND SNA
+ON
+    (
+        SNA.FK_NN_LH_SPL_SC_IDENTIF = SPL.SC_IDENTIF )
+LEFT JOIN
+    NUMMERAAND NA
+ON
+    (
+        NA.SC_IDENTIF = SPL.FK_4NRA_SC_IDENTIF)
+LEFT JOIN
+    ADDRESSEERB_OBJ_AAND ADDROBJ
+ON
+    (
+        ADDROBJ.IDENTIF = NA.SC_IDENTIF )
+JOIN
+    GEM_OPENB_RMTE GEOR
+ON
+    (
+        GEOR.IDENTIFCODE = ADDROBJ.FK_7OPR_IDENTIFCODE )
+LEFT JOIN
+    OPENB_RMTE_WNPLTS ORWP
+ON
+    (
+        GEOR.IDENTIFCODE = ORWP.FK_NN_LH_OPR_IDENTIFCODE)
+LEFT JOIN
+    WNPLTS WP
+ON
+    (
+        ORWP.FK_NN_RH_WPL_IDENTIF = WP.IDENTIF)
+LEFT JOIN
+    GEMEENTE GEM
+ON
+    (
+        WP.FK_7GEM_CODE = GEM.CODE )
+WHERE
+    NA.STATUS = 'Naamgeving uitgegeven'
+AND SPL.STATUS = 'Plaats aangewezen';
 
 -------------------------------------------------
 -- V_ADRES_TOTAAL
@@ -824,17 +1005,17 @@ CREATE OR REPLACE VIEW
 -- optioneel: bijwerken Geotools / geoserver metadata tabellen, zie ook utility scripts:
 --    402_create_geotools_geometrycolumns_metatable.sql
 --    403_create_geotools_primarykey_metatable.sql
--- in directory brmo/datamodel/utility_scripts/oracle/ 
--- (let op de schemanaam 'RSGB' in onderstaande inserts moet mogelijk aangepast worden) en mogelijk zitten 
+-- in directory brmo/datamodel/utility_scripts/oracle/
+-- (let op de schemanaam 'RSGB' in onderstaande inserts moet mogelijk aangepast worden) en mogelijk zitten
 --   er al records voor betreffende views in de tabel, in dat geval deze eerste verwijderen.
--- 
+--
 -- INSERT INTO GT_PK_METADATA VALUES ('RSGB', 'V_BD_KAD_PERCEEL_MET_APP_VLAK', 'OBJECTID', NULL, 'assigned', NULL);
--- INSERT INTO GEOMETRY_COLUMNS (F_TABLE_SCHEMA, F_TABLE_NAME, F_GEOMETRY_COLUMN, COORD_DIMENSION, SRID, TYPE) 
+-- INSERT INTO GEOMETRY_COLUMNS (F_TABLE_SCHEMA, F_TABLE_NAME, F_GEOMETRY_COLUMN, COORD_DIMENSION, SRID, TYPE)
 --     VALUES ('RSGB', 'V_BD_KAD_PERCEEL_MET_APP_VLAK', 'BEGRENZING_PERCEEL', 2, 28992, 'MULTIPOLYGON');
 
 -- INSERT INTO GT_PK_METADATA VALUES ('RSGB', 'V_KAD_PERCEEL_ZR_ADRESSEN', 'OBJECTID', NULL, 'assigned', NULL);
 -- INSERT INTO GT_PK_METADATA VALUES ('RSGB', 'V_BD_APP_RE_AND_KAD_PERCEEL', 'OBJECTID', NULL, 'assigned', NULL);
--- INSERT INTO GEOMETRY_COLUMNS (F_TABLE_SCHEMA, F_TABLE_NAME, F_GEOMETRY_COLUMN, COORD_DIMENSION, SRID, TYPE) 
+-- INSERT INTO GEOMETRY_COLUMNS (F_TABLE_SCHEMA, F_TABLE_NAME, F_GEOMETRY_COLUMN, COORD_DIMENSION, SRID, TYPE)
 --    VALUES ('RSGB', 'VM_KAD_EIGENARENKAART', 'BEGRENZING_PERCEEL', 2, 28992, 'MULTIPOLYGON');
 -- INSERT INTO GT_PK_METADATA VALUES ('RSGB', 'VM_KAD_EIGENARENKAART', 'OBJECTID', NULL, 'assigned', NULL);
 

--- a/datamodel/upgrade_scripts/1.3.6-1.4.0/postgresql/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.3.6-1.4.0/postgresql/rsgb.sql
@@ -1,8 +1,8 @@
 --
 -- upgrade RSGB datamodel van 1.3.6 naar 1.4.0 (PostgreSQL)
--- 
--- Als er gebruik wordt gemaakt van Geotools (Flamingo)/Geoserver dan 
---   ook de inserts van de gt_pk_metadata uitvoeren na aanpassen 
+--
+-- Als er gebruik wordt gemaakt van Geotools (Flamingo)/Geoserver dan
+--   ook de inserts van de gt_pk_metadata uitvoeren na aanpassen
 --   (regel 339~347 hieronder).
 --
 -- upsert van de nieuwe waarden voor Aard Recht codelijst (issue#234)
@@ -11,16 +11,16 @@ WITH new_values (id, txt) AS (VALUES
         ('24','Zakelijk recht (als bedoeld in artikel 5, lid 3, onder b)')
     ), upsert AS (
         UPDATE aard_recht_verkort m SET omschr = nv.txt
-        FROM new_values nv WHERE  m.aand = nv.id RETURNING m.* 
+        FROM new_values nv WHERE  m.aand = nv.id RETURNING m.*
     )
 INSERT INTO aard_recht_verkort (aand, omschr) SELECT id, txt FROM new_values WHERE NOT EXISTS (SELECT 1 FROM upsert up WHERE up.aand = new_values.id);
-                  
+
 WITH new_values (id, txt) AS (VALUES
         ('23','Opstalrecht Nutsvoorzieningen op gedeelte van perceel'),
         ('24','Zakelijk recht als bedoeld in artikel 5, lid 3, onder b, van de Belemmeringenwet Privaatrecht op gedeelte van perceel')
     ), upsert AS (
         UPDATE aard_verkregen_recht m SET omschr_aard_verkregenr_recht = nv.txt
-        FROM new_values nv WHERE  m.aand = nv.id RETURNING m.* 
+        FROM new_values nv WHERE  m.aand = nv.id RETURNING m.*
     )
 INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) SELECT id, txt FROM new_values WHERE NOT EXISTS (SELECT 1 FROM upsert up WHERE up.aand = new_values.id);
 --
@@ -35,8 +35,8 @@ DROP VIEW IF EXISTS v_kad_eigenarenkaart;
 DROP VIEW IF EXISTS v_bd_app_re_and_kad_perceel;
 
 -- view om vlakken kaart te maken met percelen die 1 of meerdere appartementen hebben
-CREATE OR REPLACE VIEW v_bd_kad_perceel_met_app_vlak AS 
- SELECT 
+CREATE OR REPLACE VIEW v_bd_kad_perceel_met_app_vlak AS
+ SELECT
     (row_number() OVER ())::integer AS ObjectID,
     v.perceel_identif,
     kp.sc_kad_identif,
@@ -400,7 +400,7 @@ SELECT
         WHEN addrobj.fk_6wpl_identif IS NOT NULL
         -- opzoeken want in andere woonplaats
         THEN  (select naam from wnplts where identif=fk_6wpl_identif)
-        ELSE wp.naam           
+        ELSE wp.naam
     END                         AS woonplaats,
     geor.naam_openb_rmte        AS straatnaam,
     addrobj.huinummer           AS huisnummer,
@@ -657,7 +657,7 @@ ON
 -------------------------------------------------
 /*
 ligplaats met hoofdadres
-*/		
+*/
 CREATE OR REPLACE VIEW
     v_ligplaats_alles
     (
@@ -681,8 +681,8 @@ SELECT
         WHEN addrobj.fk_6wpl_identif IS NOT NULL
         -- opzoeken want in andere woonplaats
         THEN  (select naam from wnplts where identif=fk_6wpl_identif)
-        ELSE wp.naam           
-    END
+        ELSE wp.naam
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -729,14 +729,14 @@ WHERE
         AND (
                 gem.datum_einde_geldh IS NULL))
     AND (
-            bt.datum_einde_geldh IS NULL));	
-            
+            bt.datum_einde_geldh IS NULL));
+
 -------------------------------------------------
 -- v_standplaats_alles
 -------------------------------------------------
 /*
 standplaats met hoofdadres
-*/		
+*/
 CREATE OR REPLACE VIEW
     v_standplaats_alles
     (
@@ -760,8 +760,8 @@ SELECT
         WHEN addrobj.fk_6wpl_identif IS NOT NULL
         -- opzoeken want in andere woonplaats
         THEN  (select naam from wnplts where identif=fk_6wpl_identif)
-        ELSE wp.naam           
-    END  
+        ELSE wp.naam
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -808,14 +808,14 @@ WHERE
         AND (
                 gem.datum_einde_geldh IS NULL))
     AND (
-            bt.datum_einde_geldh IS NULL));		
+            bt.datum_einde_geldh IS NULL));
 
 -------------------------------------------------
 -- v_adres
 -------------------------------------------------
 /*
 volledige adressenlijst
-standplaats en ligplaats via benoemd_terrein, 
+standplaats en ligplaats via benoemd_terrein,
 waarbij centroide van polygon wordt genomen
 plus verblijfsobject via punt object van gebouwd_obj
 */
@@ -843,8 +843,8 @@ SELECT
         WHEN addrobj.fk_6wpl_identif IS NOT NULL
         -- opzoeken want in andere woonplaats
         THEN  (select naam from wnplts where identif=fk_6wpl_identif)
-        ELSE wp.naam           
-    END  
+        ELSE wp.naam
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -927,7 +927,7 @@ SELECT
         WHEN addrobj.fk_6wpl_identif IS NOT NULL
         -- opzoeken want in andere woonplaats
         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
-        ELSE wp.naam           
+        ELSE wp.naam
     END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
@@ -1007,7 +1007,7 @@ SELECT
         WHEN addrobj.fk_6wpl_identif IS NOT NULL
         -- opzoeken want in andere woonplaats
         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
-        ELSE wp.naam           
+        ELSE wp.naam
     END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
@@ -1080,7 +1080,7 @@ CREATE VIEW
         woonplaats,
         the_geom
     ) AS
-SELECT 
+SELECT
     (row_number() OVER ())::integer AS ObjectID,
     qry.*
     FROM (
@@ -1123,12 +1123,12 @@ SELECT
         FROM
             v_adres_standplaats
     ) qry;
-    
+
 
 -- optioneel: bijwerken Geotools / geoserver metadata tabellen, zie ook utility scripts:
 --    403_create_geotools_primarykey_metatable.sql
--- in directory brmo/datamodel/utility_scripts/postgresql/ 
--- (let op de schemanaam 'brmo_rsgb' in onderstaande inserts moet mogelijk aangepast worden) en mogelijk zitten 
+-- in directory brmo/datamodel/utility_scripts/postgresql/
+-- (let op de schemanaam 'brmo_rsgb' in onderstaande inserts moet mogelijk aangepast worden) en mogelijk zitten
 --   er al records voor betreffende views in de tabel, in dat geval deze eerst verwijderen.
 --
 -- INSERT INTO gt_pk_metadata VALUES ('brmo_rsgb', 'v_kad_perceel_zr_adressen', 'objectid', NULL, 'assigned', NULL);

--- a/datamodel/upgrade_scripts/1.3.6-1.4.0/sqlserver/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.3.6-1.4.0/sqlserver/rsgb.sql
@@ -3,7 +3,7 @@
 --
 -- merge van de nieuwe waarden voor Aard Recht codelijst (issue#234)
 MERGE INTO aard_recht_verkort t USING (
-    VALUES 
+    VALUES
         ('23','Opstalrecht Nutsvoorzieningen op gedeelte van perceel'),
         ('24','Zakelijk recht (als bedoeld in artikel 5, lid 3, onder b)')
     ) AS src (code,txt) ON t.aand = src.code
@@ -11,7 +11,7 @@ WHEN MATCHED THEN UPDATE SET omschr = src.txt
 WHEN NOT MATCHED THEN INSERT (aand,omschr) VALUES (src.code, src.txt);
 
 MERGE INTO aard_verkregen_recht t USING (
-    VALUES 
+    VALUES
         ('23','Opstalrecht Nutsvoorzieningen op gedeelte van perceel'),
         ('24','Zakelijk recht als bedoeld in artikel 5, lid 3, onder b, van de Belemmeringenwet Privaatrecht op gedeelte van perceel')
     ) AS src (code,txt) ON t.aand = src.code
@@ -22,8 +22,8 @@ WHEN NOT MATCHED THEN INSERT (aand,omschr_aard_verkregenr_recht) VALUES (src.cod
 
 -- view om vlakken kaart te maken met percelen die 1 of meerdere appartementen hebben
 GO
-CREATE VIEW v_bd_kad_perceel_met_app_vlak AS 
- SELECT 
+CREATE VIEW v_bd_kad_perceel_met_app_vlak AS
+ SELECT
     CAST(ROW_NUMBER() over(ORDER BY kp.sc_kad_identif) AS INT) AS ObjectID,
     v.perceel_identif,
     kp.sc_kad_identif,
@@ -38,11 +38,11 @@ CREATE VIEW v_bd_kad_perceel_met_app_vlak AS
     kp.begrenzing_perceel
    FROM v_bd_kad_perceel_with_app_re v
      JOIN kad_perceel kp ON v.perceel_identif = kp.sc_kad_identif;
-     
+
 GO
 
-ALTER VIEW v_bd_app_re_bij_perceel AS 
- SELECT 
+ALTER VIEW v_bd_app_re_bij_perceel AS
+ SELECT
     CAST(ROW_NUMBER() over(ORDER BY ar.sc_kad_identif) AS INT) AS ObjectID,
     ar.sc_kad_identif,
     ar.fk_2nnp_sc_identif,
@@ -73,7 +73,7 @@ join kad_onrrnd_zk z on (z.kad_identif = p.sc_kad_identif);
 GO
 
 ALTER view v_kad_perceel_in_eigendom as
-select 
+select
     CAST(ROW_NUMBER() over(ORDER BY p.sc_kad_identif) AS INT) AS ObjectID,
     p.begrenzing_perceel,
     p.sc_kad_identif,
@@ -96,8 +96,8 @@ select
         p.sc_kad_identif,
         p.begrenzing_perceel,
         p.ka_sectie + ' ' + p.ka_perceelnummer AS aanduiding,
-        p.grootte_perceel,   
-        p_adr.kad_bag_koppeling_benobj,             
+        p.grootte_perceel,
+        p_adr.kad_bag_koppeling_benobj,
         p_adr.straat,
         p_adr.huisnummer,
         p_adr.huisletter,
@@ -109,8 +109,8 @@ join v_kad_perceel_adres p_adr on (p_adr.sc_kad_identif = p.sc_kad_identif);
 
 GO
 
-ALTER view v_kad_perceel_zr_adressen as 
-select 
+ALTER view v_kad_perceel_zr_adressen as
+select
   CAST(ROW_NUMBER() over(ORDER BY kp.sc_kad_identif) AS INT) AS ObjectID,
   kp.SC_KAD_IDENTIF,
   kp.BEGRENZING_PERCEEL,
@@ -291,7 +291,7 @@ SELECT
          WHEN addrobj.fk_6wpl_identif IS NOT NULL
          -- opzoeken want in andere woonplaats
          THEN  (select naam from wnplts where identif = fk_6wpl_identif)
-         ELSE wp.naam           
+         ELSE wp.naam
     END                         AS woonplaats,
     geor.naam_openb_rmte        AS straatnaam,
     addrobj.huinummer           AS huisnummer,
@@ -578,7 +578,7 @@ SELECT
          WHEN addrobj.fk_6wpl_identif IS NOT NULL
          -- opzoeken want in andere woonplaats
          THEN  (select naam from wnplts where identif = fk_6wpl_identif)
-         ELSE wp.naam           
+         ELSE wp.naam
     END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
@@ -626,7 +626,7 @@ WHERE
         AND (
                 gem.datum_einde_geldh IS NULL))
     AND (
-            bt.datum_einde_geldh IS NULL));	
+            bt.datum_einde_geldh IS NULL));
 -------------------------------------------------
 -- v_standplaats_alles
 -------------------------------------------------
@@ -658,7 +658,7 @@ SELECT
          WHEN addrobj.fk_6wpl_identif IS NOT NULL
          -- opzoeken want in andere woonplaats
          THEN  (select naam from wnplts where identif = fk_6wpl_identif)
-         ELSE wp.naam           
+         ELSE wp.naam
     END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
@@ -706,13 +706,13 @@ WHERE
         AND (
                 gem.datum_einde_geldh IS NULL))
     AND (
-            bt.datum_einde_geldh IS NULL));			
+            bt.datum_einde_geldh IS NULL));
 -------------------------------------------------
 -- v_adres
 -------------------------------------------------
 /*
 volledige adressenlijst
-standplaats en ligplaats via benoemd_terrein, 
+standplaats en ligplaats via benoemd_terrein,
 waarbij centroide van polygon wordt genomen
 plus verblijfsobject via punt object van gebouwd_obj
 */
@@ -742,7 +742,7 @@ SELECT
          WHEN addrobj.fk_6wpl_identif IS NOT NULL
          -- opzoeken want in andere woonplaats
          THEN  (select naam from wnplts where identif = fk_6wpl_identif)
-         ELSE wp.naam           
+         ELSE wp.naam
     END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
@@ -828,7 +828,7 @@ SELECT
          WHEN addrobj.fk_6wpl_identif IS NOT NULL
          -- opzoeken want in andere woonplaats
          THEN  (select naam from wnplts where identif = fk_6wpl_identif)
-         ELSE wp.naam           
+         ELSE wp.naam
     END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
@@ -910,7 +910,7 @@ SELECT
          WHEN addrobj.fk_6wpl_identif IS NOT NULL
          -- opzoeken want in andere woonplaats
          THEN  (select naam from wnplts where identif = fk_6wpl_identif)
-         ELSE wp.naam           
+         ELSE wp.naam
     END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,

--- a/datamodel/upgrade_scripts/1.3.6-1.4.0/sqlserver/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.3.6-1.4.0/sqlserver/rsgb.sql
@@ -287,7 +287,12 @@ SELECT
     vbo.sc_identif              AS fid,
     fkpand.fk_nn_rh_pnd_identif AS pand_id,
     gem.naam                    AS gemeente,
-    wp.naam                     AS woonplaats,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                         AS woonplaats,
     geor.naam_openb_rmte        AS straatnaam,
     addrobj.huinummer           AS huisnummer,
     addrobj.huisletter,
@@ -569,7 +574,12 @@ SELECT
     CAST(ROW_NUMBER() over(ORDER BY lp.sc_identif) AS INT) AS ObjectID,
     lp.sc_identif        AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -644,7 +654,12 @@ SELECT
     CAST(ROW_NUMBER() over(ORDER BY sp.sc_identif) AS INT) AS ObjectID,
     sp.sc_identif        AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -723,7 +738,12 @@ SELECT
     CAST(ROW_NUMBER() over(ORDER BY vbo.sc_identif) AS INT) AS ObjectID,
     vbo.sc_identif       AS fid,
     gem.naam             AS gemeente,
-    wp.naam              AS woonplaats,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                  AS woonplaats,
     geor.naam_openb_rmte AS straatnaam,
     addrobj.huinummer    AS huisnummer,
     addrobj.huisletter,
@@ -780,6 +800,171 @@ AND (
         vbo.status = 'Verblijfsobject in gebruik (niet ingemeten)'
     OR  vbo.status = 'Verblijfsobject in gebruik');
 
+
+-------------------------------------------------
+-- v_adres_ligplaats
+-------------------------------------------------
+GO
+
+ALTER VIEW
+    v_adres_ligplaats
+    (
+        fid,
+        gemeente,
+        woonplaats,
+        straatnaam,
+        huisnummer,
+        huisletter,
+        huisnummer_toev,
+        postcode,
+        status,
+        the_geom,
+        centroide
+    ) AS
+SELECT
+    lpa.sc_identif       AS fid,
+    gem.naam             AS gemeente,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                  AS woonplaats,
+    geor.naam_openb_rmte AS straatnaam,
+    addrobj.huinummer    AS huisnummer,
+    addrobj.huisletter,
+    addrobj.huinummertoevoeging AS huisnummer_toev,
+    addrobj.postcode,
+    lpa.status,
+    benter.geom AS the_geom,
+    benter.geom.STCentroid()
+FROM
+    ligplaats lpa
+JOIN
+    benoemd_terrein benter
+ON
+    (
+        benter.sc_identif = lpa.sc_identif )
+LEFT JOIN
+    ligplaats_nummeraand lna
+ON
+    (
+        lna.fk_nn_lh_lpl_sc_identif = lpa.sc_identif )
+LEFT JOIN
+    nummeraand na
+ON
+    (
+        na.sc_identif = lpa.fk_4nra_sc_identif )
+LEFT JOIN
+    addresseerb_obj_aand addrobj
+ON
+    (
+        addrobj.identif = na.sc_identif )
+JOIN
+    gem_openb_rmte geor
+ON
+    (
+        geor.identifcode = addrobj.fk_7opr_identifcode )
+LEFT JOIN
+    openb_rmte_wnplts orwp
+ON
+    (
+        geor.identifcode = orwp.fk_nn_lh_opr_identifcode)
+LEFT JOIN
+    wnplts wp
+ON
+    (
+        orwp.fk_nn_rh_wpl_identif = wp.identif)
+LEFT JOIN
+    gemeente gem
+ON
+    (
+        wp.fk_7gem_code = gem.code )
+WHERE
+    na.status = 'Naamgeving uitgegeven'
+AND lpa.status = 'Plaats aangewezen';
+-------------------------------------------------
+-- v_adres_standplaats
+-------------------------------------------------
+GO
+
+ALTER VIEW
+    v_adres_standplaats
+    (
+        fid,
+        gemeente,
+        woonplaats,
+        straatnaam,
+        huisnummer,
+        huisletter,
+        huisnummer_toev,
+        postcode,
+        status,
+        the_geom,
+        centroide
+    ) AS
+SELECT
+    spl.sc_identif       AS fid,
+    gem.naam             AS gemeente,
+    CASE
+         WHEN addrobj.fk_6wpl_identif IS NOT NULL
+         -- opzoeken want in andere woonplaats
+         THEN  (select naam from wnplts where identif = fk_6wpl_identif)
+         ELSE wp.naam           
+    END                  AS woonplaats,
+    geor.naam_openb_rmte AS straatnaam,
+    addrobj.huinummer    AS huisnummer,
+    addrobj.huisletter,
+    addrobj.huinummertoevoeging AS huisnummer_toev,
+    addrobj.postcode,
+    spl.status,
+    benter.geom AS the_geom,
+    benter.geom.STCentroid()
+FROM
+    standplaats spl
+JOIN
+    benoemd_terrein benter
+ON
+    (
+        benter.sc_identif = spl.sc_identif )
+LEFT JOIN
+    standplaats_nummeraand sna
+ON
+    (
+        sna.fk_nn_lh_spl_sc_identif = spl.sc_identif )
+LEFT JOIN
+    nummeraand na
+ON
+    (
+        na.sc_identif = spl.fk_4nra_sc_identif )
+LEFT JOIN
+    addresseerb_obj_aand addrobj
+ON
+    (
+        addrobj.identif = na.sc_identif )
+JOIN
+    gem_openb_rmte geor
+ON
+    (
+        geor.identifcode = addrobj.fk_7opr_identifcode )
+LEFT JOIN
+    openb_rmte_wnplts orwp
+ON
+    (
+        geor.identifcode = orwp.fk_nn_lh_opr_identifcode)
+LEFT JOIN
+    wnplts wp
+ON
+    (
+        orwp.fk_nn_rh_wpl_identif = wp.identif)
+LEFT JOIN
+    gemeente gem
+ON
+    (
+        wp.fk_7gem_code = gem.code )
+WHERE
+    na.status = 'Naamgeving uitgegeven'
+AND spl.status = 'Plaats aangewezen';
 
 -------------------------------------------------
 -- v_adres_totaal


### PR DESCRIPTION
In een recente BAG (september) gaat het om 1693 nummeraanduidingen van de 9352032 in totaal

Aanpassen BAG views + upgrade script voor:

  - [x] PostgreSQL
  - [x] MS SQL server
  - [x] Oracle
  
Aan te passen views: 
- [x] v_verblijfsobject_alles
- [x] v_ligplaats_alles
- [x] v_standplaats_alles
- [x] v_adres
- [x] v_adres_ligplaats
- [x] v_adres_standplaats



close #137

