### PR TITLE
stop met gebruik Joda time lib

### DIFF
--- a/brmo-loader/pom.xml
+++ b/brmo-loader/pom.xml
@@ -97,10 +97,6 @@
             <artifactId>gt-jdbc-sqlserver</artifactId>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.geolatte</groupId>
             <artifactId>geolatte-geom</artifactId>
         </dependency>

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/entity/BagBericht.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/entity/BagBericht.java
@@ -1,6 +1,8 @@
 package nl.b3p.brmo.loader.entity;
 
 import java.io.StringReader;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -11,7 +13,6 @@ import javax.xml.xpath.XPathFactory;
 import nl.b3p.brmo.loader.xml.BagXMLReader;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.joda.time.DateTime;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
@@ -112,9 +113,9 @@ public class BagBericht extends Bericht {
             return;
         }
 
-        //gebruik joda omdat er microseconden in bron staan
-        DateTime date = new DateTime(d);
-        Date date2 = new Date(date.getMillis());
+        LocalDateTime date = LocalDateTime.parse(d);
+        Date date2 = Date.from(date.atZone(ZoneId.systemDefault()).toInstant());
+
         setDatum(date2);
     }
 

--- a/brmo-loader/src/test/java/nl/b3p/brmo/loader/xml/BagXMLReaderTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/brmo/loader/xml/BagXMLReaderTest.java
@@ -1,12 +1,13 @@
 package nl.b3p.brmo.loader.xml;
 
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import nl.b3p.brmo.loader.entity.BagBericht;
 import org.apache.commons.io.input.CloseShieldInputStream;
-import org.joda.time.DateTime;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
@@ -70,9 +71,8 @@ public class BagXMLReaderTest {
         assertEquals(mutSmallXmlNieuwCount, total);
         assertEquals("PND:1901100000021963", bag.getObjectRef());
         
-        //gebruik joda omdat er microseconden in de bron staan
-        DateTime d = new DateTime("2015-01-01T07:30:51.843495");
-        Date d2 = new Date(d.getMillis());
+        LocalDateTime d = LocalDateTime.parse("2015-01-01T07:30:51.843495");
+        Date d2 = Date.from(d.atZone(ZoneId.systemDefault()).toInstant());
         assertEquals(d2, bag.getDatum());
         assertEquals(new Integer(0), bag.getVolgordeNummer());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -312,11 +312,6 @@
                 <artifactId>json</artifactId>
                 <version>20160810</version>
             </dependency>
-            <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>2.9.6</version>
-            </dependency>
             <!-- test dependencies -->
             <dependency>
                 <groupId>com.h2database</groupId>


### PR DESCRIPTION
gebruik in plaats daarvan de Java 8 java.time API


close #264