### PR TITLE
Optie om aantal te verwerken standberichten te beperken

### DIFF
--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/BrmoFramework.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/BrmoFramework.java
@@ -135,6 +135,12 @@ public class BrmoFramework {
         }
     }
 
+    public void setLimitStandBerichtenToTransform(Integer limitStandBerichtenToTransform) {
+        if (stagingProxy != null) {
+            stagingProxy.setLimitStandBerichtenToTransform(limitStandBerichtenToTransform);
+        }
+    }
+
     public void setOrderBerichten(boolean orderBerichten) {
         this.orderBerichten = orderBerichten;
     }

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/jdbc/GeometryJdbcConverter.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/jdbc/GeometryJdbcConverter.java
@@ -22,6 +22,7 @@ public abstract class GeometryJdbcConverter {
     public abstract String getGeomTypeName();
     public abstract boolean isDuplicateKeyViolationMessage(String message);
     public abstract String buildPaginationSql(String sql, int offset, int limit);
+    public abstract StringBuilder buildLimitSql(StringBuilder sql, int limit);
     public abstract boolean useSavepoints();
     public abstract boolean isPmdKnownBroken();
 

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/jdbc/MssqlJdbcConverter.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/jdbc/MssqlJdbcConverter.java
@@ -101,6 +101,12 @@ public class MssqlJdbcConverter extends GeometryJdbcConverter {
     }
 
     @Override
+    public StringBuilder buildLimitSql(StringBuilder sql, int limit) {
+        String s = buildPaginationSql(sql.toString(), 0, limit);
+        return new StringBuilder(s);
+    }
+
+    @Override
     public boolean useSavepoints() {
         return false;
     }

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/jdbc/OracleJdbcConverter.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/jdbc/OracleJdbcConverter.java
@@ -100,6 +100,13 @@ public class OracleJdbcConverter extends GeometryJdbcConverter {
     }
 
     @Override
+    public StringBuilder buildLimitSql(StringBuilder sql, int limit) {
+        // NB #buildPaginationSql is niet bruikbaar voor een insert+select
+        sql.append(" FETCH FIRST ").append(limit).append(" ROWS ONLY");
+        return sql;
+    }
+
+    @Override
     public boolean useSavepoints() {
         return false;
     }

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/jdbc/PostgisJdbcConverter.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/jdbc/PostgisJdbcConverter.java
@@ -58,6 +58,12 @@ public class PostgisJdbcConverter extends GeometryJdbcConverter {
     }
 
     @Override
+    public StringBuilder buildLimitSql(StringBuilder sql, int limit) {
+        String s = buildPaginationSql(sql.toString(), 0, limit);
+        return new StringBuilder(s);
+    }
+
+    @Override
     public boolean useSavepoints() {
         return true;
     }

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/TransformActionBean.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/TransformActionBean.java
@@ -47,6 +47,8 @@ public class TransformActionBean implements ActionBean, ProgressUpdateListener {
 
     private String exceptionStacktrace;
 
+    private long standBerichtenVerwerkingsLimiet;
+
     @Before
     public void before() {
         start = new Date();
@@ -107,7 +109,8 @@ public class TransformActionBean implements ActionBean, ProgressUpdateListener {
             if (maxBerichten != null) {
                 brmo.setLimitStandBerichtenToTransform(Integer.parseInt(maxBerichten));
                 log.info("Maximum aantal stand berichten voor transformatie batch ingesteld op: " + maxBerichten
-                        + " Mogelijk dient stand transformatie meerder keren gestart te worden.");
+                        + ". Mogelijk dient stand transformatie meerdere keren gestart te worden.");
+                this.standBerichtenVerwerkingsLimiet = Integer.parseInt(maxBerichten);
             }
             Thread t = null;
             switch(mode) {
@@ -255,6 +258,14 @@ public class TransformActionBean implements ActionBean, ProgressUpdateListener {
     public void setExceptionStacktrace(String exceptionStacktrace) {
         this.exceptionStacktrace = exceptionStacktrace;
     }
-    // </editor-fold>
 
+    public long getStandBerichtenVerwerkingsLimiet() {
+        return standBerichtenVerwerkingsLimiet;
+    }
+
+    public void setStandBerichtenVerwerkingsLimiet(long standBerichtenVerwerkingsLimiet) {
+        this.standBerichtenVerwerkingsLimiet = standBerichtenVerwerkingsLimiet;
+    }
+
+    // </editor-fold>
 }

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/TransformActionBean.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/TransformActionBean.java
@@ -102,7 +102,13 @@ public class TransformActionBean implements ActionBean, ProgressUpdateListener {
             if (errorState != null) {
                 brmo.setErrorState(errorState);
             }
-            
+
+            String maxBerichten = getContext().getServletContext().getInitParameter("stand.transform.max");
+            if (maxBerichten != null) {
+                brmo.setLimitStandBerichtenToTransform(Integer.parseInt(maxBerichten));
+                log.info("Maximum aantal stand berichten voor transformatie batch ingesteld op: " + maxBerichten
+                        + " Mogelijk dient stand transformatie meerder keren gestart te worden.");
+            }
             Thread t = null;
             switch(mode) {
                 case BY_IDS:

--- a/brmo-service/src/main/webapp/WEB-INF/jsp/transform/transform.jsp
+++ b/brmo-service/src/main/webapp/WEB-INF/jsp/transform/transform.jsp
@@ -43,8 +43,15 @@
                     <c:otherwise>
                         ${actionBean.total}
                     </c:otherwise>
-            </c:choose><br>
-                Verwerkt: ${actionBean.processed}
+            </c:choose>
+
+            <c:if test="${actionBean.standBerichtenVerwerkingsLimiet > 0 }">
+                (Het maximum aantal <b>stand</b> berichten dat in één run verwerkt kan worden is: ${actionBean.standBerichtenVerwerkingsLimiet}.
+                <c:if test="${actionBean.total eq actionBean.standBerichtenVerwerkingsLimiet }">
+                    <br/>De stand transformatie dient mogelijk nog eens gestart te worden voor een volgende batch.
+                </c:if>)
+            </c:if>
+            <br>Verwerkt: ${actionBean.processed}
         </p>
         <p>
             <stripes:link href="/javasimon-console" target="_blank">Performance monitoring console</stripes:link>

--- a/brmo-service/src/main/webapp/WEB-INF/web.xml
+++ b/brmo-service/src/main/webapp/WEB-INF/web.xml
@@ -20,6 +20,11 @@
         <param-name>error.state</param-name>
         <param-value>ignore</param-value>
     </context-param>
+    <context-param>
+        <description>Maximum aantal te verwerken stand berichten per transformatie run, gebruik een waarde kleiner of gelijk aan 0 om uit te schakelen</description>
+        <param-name>stand.transform.max</param-name>
+        <param-value>1000000</param-value>
+    </context-param>
     <filter>
         <display-name>Stripes Filter</display-name>
         <filter-name>StripesFilter</filter-name>


### PR DESCRIPTION
Met name bij BAG van heel NL soms een probleem dat de batch met te transformeren stand berichten van bijvoorbeeld nummeraanduiding (~10 miljoen records)  te groot wordt om in een keer te transformeren. De default is 1.000.000