### PR TITLE
gebruik brmo framework om bag mutaties in staging te laden

### DIFF
--- a/brmo-loader/src/test/java/nl/b3p/BAGXMLToStagingIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/BAGXMLToStagingIntegrationTest.java
@@ -50,7 +50,7 @@ public class BAGXMLToStagingIntegrationTest extends AbstractDatabaseIntegrationT
             {"bag", "/nl/b3p/brmo/loader/xml/0197LIG01072014-01072014-000001.xml", 0, 1},
             {"bag", "/nl/b3p/brmo/loader/xml/0197STA01072014-01072014-000001.xml", 2, 1},
             {"bag", "/nl/b3p/brmo/loader/xml/9999MUT02012015-03012015.zip", 25718, 6},
-            {"bag", "/GH-275/OPR-1884300000000464.xml", 4, 1}
+            {/*bestand heeft 4 berichten voor object, maar we houden alleen de laatste mutatie in staging*/"bag", "/GH-275/OPR-1884300000000464.xml", 1, 1}
         });
     }
 

--- a/brmo-loader/src/test/java/nl/b3p/BAGXMLToStagingIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/BAGXMLToStagingIntegrationTest.java
@@ -49,7 +49,8 @@ public class BAGXMLToStagingIntegrationTest extends AbstractDatabaseIntegrationT
             // {"type","filename", aantalBerichten, aantalLaadProcessen},
             {"bag", "/nl/b3p/brmo/loader/xml/0197LIG01072014-01072014-000001.xml", 0, 1},
             {"bag", "/nl/b3p/brmo/loader/xml/0197STA01072014-01072014-000001.xml", 2, 1},
-            {"bag", "/nl/b3p/brmo/loader/xml/9999MUT02012015-03012015.zip", 25718, 6}
+            {"bag", "/nl/b3p/brmo/loader/xml/9999MUT02012015-03012015.zip", 25718, 6},
+            {"bag", "/GH-275/OPR-1884300000000464.xml", 4, 1}
         });
     }
 

--- a/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/editwebdirscannerproces.jsp
+++ b/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/editwebdirscannerproces.jsp
@@ -1,26 +1,23 @@
 <%@include file="/WEB-INF/taglibs.jsp" %>
 <table>
     <tr>
-        <td><stripes:label name="">Label</stripes:label></td>
+        <td><stripes:label name="">label</stripes:label></td>
         <td><stripes:text name="config['label']"/></td>
     </tr>
     <tr>
-        <td><stripes:label name="">Scan directory URL</stripes:label></td>
+        <td><stripes:label name="">scan directory URL</stripes:label></td>
         <td><stripes:text name="config['scandirectory']" value="http://mirror.openstreetmap.nl/bag/mutatie/?order=d" style="width: 30em;"/></td>
     </tr>
     <tr>
-        <td><stripes:label name="">Archief directory (om opgehaalde .zip files te bewaren)</stripes:label></td>
-        <td><stripes:text name="config['archiefdirectory']" /></td>
+        <td><stripes:label name="">archief directory (om opgehaalde .zip files te bewaren)</stripes:label></td>
+    <td><stripes:text name="config['archiefdirectory']" /></td>
     </tr>
     <tr>
         <td><stripes:label name="">css path expressie</stripes:label></td>
         <td><stripes:text name="config['csspath']" value="td:nth-child(2) > a[href]" /></td>
     </tr>
     <tr>
-        <td><stripes:label name="">Planning <a href="http://cronmaker.com" target="_blank">(cron expressie)</a></stripes:label></td>
-        <td>
-            <stripes:text name="proces.cronExpressie"/>
-            <brmo:formatCron cronExpression="${actionBean.proces.cronExpressie}" />
-        </td>
+        <td><stripes:label name="">planning <a href="http://cronmaker.com" target="_blank">(cron expressie)</a></stripes:label></td>
+        <td><stripes:text name="proces.cronExpressie"/><brmo:formatCron cronExpression="${actionBean.proces.cronExpressie}"/></td>
     </tr>
 </table>

--- a/brmo-service/src/test/resources/GH-275/OPR-1884300000000464.xml
+++ b/brmo-service/src/test/resources/GH-275/OPR-1884300000000464.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+dit is een extract uit http://files.b3p.nl/brmo/bag/9999MUT08032016-08042016.zip/9999MUT08032016-08042016-000001.xml 
+voor object OPR:1884300000000464 ter illustratie van het probleem van verwerken van mutaties 
+verwerking mislukt omdat een object meerdere malen in de brondata voorkomt met identieke timestamp waardoor insert in 
+de bericht tabel mislukt met melding:
+
+org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "idx_bericht_refiddatumnr"
+  Detail: Key (object_ref, datum, volgordenummer)=(OPR:1884300000000464, 2016-03-09 15:30:12, 0) already exists. 
+
+-->
+<mb:BAG-Mutaties-Deelbestand-LVC xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:mb="http://www.kadaster.nl/schemas/bag-verstrekkingen/extract-deelbestand-mutaties-lvc/v20090901" xmlns:selecties-extract="http://www.kadaster.nl/schemas/bag-verstrekkingen/extract-selecties/v20090901" xmlns:bagtype="http://www.kadaster.nl/schemas/imbag/imbag-types/v20090901" xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:product_LVC="http://www.kadaster.nl/schemas/bag-verstrekkingen/extract-producten-lvc/v20090901" xmlns:bag_LVC="http://www.kadaster.nl/schemas/imbag/lvc/v20090901" xmlns:nen5825="http://www.kadaster.nl/schemas/imbag/nen5825/v20090901" xsi:schemaLocation="http://www.kadaster.nl/schemas/bag-verstrekkingen/extract-deelbestand-mutaties-lvc/v20090901 http://www.kadaster.nl/schemas/bag-verstrekkingen/extract-deelbestand-mutaties-lvc/v20090901/BagvsExtractDeelbestandMutatieLvc-1.4.xsd">
+  <mb:antwoord>
+    <mb:vraag>
+      <selecties-extract:Gebied-Registratief>
+        <selecties-extract:Gebied-NLD>
+          <selecties-extract:GebiedIdentificatie>9999</selecties-extract:GebiedIdentificatie>
+          <selecties-extract:GebiedNaam>Nederland</selecties-extract:GebiedNaam>
+          <selecties-extract:gebiedTypeNederland>1</selecties-extract:gebiedTypeNederland>
+        </selecties-extract:Gebied-NLD>
+      </selecties-extract:Gebied-Registratief>
+      <selecties-extract:Mutatieperiode>
+        <selecties-extract:MutatiedatumVanaf>2016-03-08</selecties-extract:MutatiedatumVanaf>
+        <selecties-extract:MutatiedatumTot>2016-04-08</selecties-extract:MutatiedatumTot>
+      </selecties-extract:Mutatieperiode>
+    </mb:vraag>
+    <mb:producten>
+<!-- nieuw om 2016-03-09T15:30:12.000951 -->
+      <product_LVC:Mutatie-product>
+        <product_LVC:Verwerking>
+          <product_LVC:TijdstipVerwerking>2016-03-09T15:30:12.000951</product_LVC:TijdstipVerwerking>
+          <product_LVC:ObjectType>OPR</product_LVC:ObjectType>
+          <product_LVC:VolgnrVerwerking>0</product_LVC:VolgnrVerwerking>
+        </product_LVC:Verwerking>
+        <product_LVC:Nieuw>
+          <bag_LVC:OpenbareRuimte>
+            <bag_LVC:identificatie>1884300000000464</bag_LVC:identificatie>
+            <bag_LVC:aanduidingRecordInactief>N</bag_LVC:aanduidingRecordInactief>
+            <bag_LVC:aanduidingRecordCorrectie>0</bag_LVC:aanduidingRecordCorrectie>
+            <bag_LVC:openbareRuimteNaam>oeverloos</bag_LVC:openbareRuimteNaam>
+            <bag_LVC:officieel>N</bag_LVC:officieel>
+            <bag_LVC:tijdvakgeldigheid>
+              <bagtype:begindatumTijdvakGeldigheid>2016030900100001</bagtype:begindatumTijdvakGeldigheid>
+            </bag_LVC:tijdvakgeldigheid>
+            <bag_LVC:inOnderzoek>N</bag_LVC:inOnderzoek>
+            <bag_LVC:openbareRuimteType>Weg</bag_LVC:openbareRuimteType>
+            <bag_LVC:bron>
+              <bagtype:documentdatum>20160309</bagtype:documentdatum>
+              <bagtype:documentnummer>16.06132</bagtype:documentnummer>
+            </bag_LVC:bron>
+            <bag_LVC:openbareruimteStatus>Naamgeving uitgegeven</bag_LVC:openbareruimteStatus>
+            <bag_LVC:gerelateerdeWoonplaats>
+              <bag_LVC:identificatie>3042</bag_LVC:identificatie>
+            </bag_LVC:gerelateerdeWoonplaats>
+          </bag_LVC:OpenbareRuimte>
+        </product_LVC:Nieuw>
+      </product_LVC:Mutatie-product>
+<!-- nieuw om 2016-03-09T15:30:12.000997 -->
+      <product_LVC:Mutatie-product>
+        <product_LVC:Verwerking>
+          <product_LVC:TijdstipVerwerking>2016-03-09T15:30:12.000997</product_LVC:TijdstipVerwerking>
+          <product_LVC:ObjectType>OPR</product_LVC:ObjectType>
+          <product_LVC:VolgnrVerwerking>0</product_LVC:VolgnrVerwerking>
+        </product_LVC:Verwerking>
+        <product_LVC:Nieuw>
+          <bag_LVC:OpenbareRuimte>
+            <bag_LVC:identificatie>1884300000000464</bag_LVC:identificatie>
+            <bag_LVC:aanduidingRecordInactief>N</bag_LVC:aanduidingRecordInactief>
+            <bag_LVC:aanduidingRecordCorrectie>0</bag_LVC:aanduidingRecordCorrectie>
+            <bag_LVC:openbareRuimteNaam>Oeverloos</bag_LVC:openbareRuimteNaam>
+            <bag_LVC:officieel>N</bag_LVC:officieel>
+            <bag_LVC:tijdvakgeldigheid>
+              <bagtype:begindatumTijdvakGeldigheid>2016030900100002</bagtype:begindatumTijdvakGeldigheid>
+            </bag_LVC:tijdvakgeldigheid>
+            <bag_LVC:inOnderzoek>N</bag_LVC:inOnderzoek>
+            <bag_LVC:openbareRuimteType>Weg</bag_LVC:openbareRuimteType>
+            <bag_LVC:bron>
+              <bagtype:documentdatum>20160309</bagtype:documentdatum>
+              <bagtype:documentnummer>16.06248</bagtype:documentnummer>
+            </bag_LVC:bron>
+            <bag_LVC:openbareruimteStatus>Naamgeving uitgegeven</bag_LVC:openbareruimteStatus>
+            <bag_LVC:gerelateerdeWoonplaats>
+              <bag_LVC:identificatie>3042</bag_LVC:identificatie>
+            </bag_LVC:gerelateerdeWoonplaats>
+          </bag_LVC:OpenbareRuimte>
+        </product_LVC:Nieuw>
+      </product_LVC:Mutatie-product>
+<!-- geldigheid aanpassing om 2016-03-09T15:30:12.000997 -->
+      <product_LVC:Mutatie-product>
+        <product_LVC:Verwerking>
+          <product_LVC:TijdstipVerwerking>2016-03-09T15:30:12.000997</product_LVC:TijdstipVerwerking>
+          <product_LVC:ObjectType>OPR</product_LVC:ObjectType>
+          <product_LVC:VolgnrVerwerking>1</product_LVC:VolgnrVerwerking>
+        </product_LVC:Verwerking>
+        <product_LVC:Origineel>
+          <bag_LVC:OpenbareRuimte>
+            <bag_LVC:identificatie>1884300000000464</bag_LVC:identificatie>
+            <bag_LVC:aanduidingRecordInactief>N</bag_LVC:aanduidingRecordInactief>
+            <bag_LVC:aanduidingRecordCorrectie>0</bag_LVC:aanduidingRecordCorrectie>
+            <bag_LVC:openbareRuimteNaam>oeverloos</bag_LVC:openbareRuimteNaam>
+            <bag_LVC:officieel>N</bag_LVC:officieel>
+            <bag_LVC:tijdvakgeldigheid>
+              <bagtype:begindatumTijdvakGeldigheid>2016030900100001</bagtype:begindatumTijdvakGeldigheid>
+            </bag_LVC:tijdvakgeldigheid>
+            <bag_LVC:inOnderzoek>N</bag_LVC:inOnderzoek>
+            <bag_LVC:openbareRuimteType>Weg</bag_LVC:openbareRuimteType>
+            <bag_LVC:bron>
+              <bagtype:documentdatum>20160309</bagtype:documentdatum>
+              <bagtype:documentnummer>16.06132</bagtype:documentnummer>
+            </bag_LVC:bron>
+            <bag_LVC:openbareruimteStatus>Naamgeving uitgegeven</bag_LVC:openbareruimteStatus>
+            <bag_LVC:gerelateerdeWoonplaats>
+              <bag_LVC:identificatie>3042</bag_LVC:identificatie>
+            </bag_LVC:gerelateerdeWoonplaats>
+          </bag_LVC:OpenbareRuimte>
+        </product_LVC:Origineel>
+        <product_LVC:Wijziging>
+          <bag_LVC:OpenbareRuimte>
+            <bag_LVC:identificatie>1884300000000464</bag_LVC:identificatie>
+            <bag_LVC:aanduidingRecordInactief>N</bag_LVC:aanduidingRecordInactief>
+            <bag_LVC:aanduidingRecordCorrectie>0</bag_LVC:aanduidingRecordCorrectie>
+            <bag_LVC:openbareRuimteNaam>oeverloos</bag_LVC:openbareRuimteNaam>
+            <bag_LVC:officieel>N</bag_LVC:officieel>
+            <bag_LVC:tijdvakgeldigheid>
+              <bagtype:begindatumTijdvakGeldigheid>2016030900100001</bagtype:begindatumTijdvakGeldigheid>
+               <bagtype:einddatumTijdvakGeldigheid>2016030900100002</bagtype:einddatumTijdvakGeldigheid>
+            </bag_LVC:tijdvakgeldigheid>
+            <bag_LVC:inOnderzoek>N</bag_LVC:inOnderzoek>
+            <bag_LVC:openbareRuimteType>Weg</bag_LVC:openbareRuimteType>
+            <bag_LVC:bron>
+              <bagtype:documentdatum>20160309</bagtype:documentdatum>
+              <bagtype:documentnummer>16.06132</bagtype:documentnummer>
+            </bag_LVC:bron>
+            <bag_LVC:openbareruimteStatus>Naamgeving uitgegeven</bag_LVC:openbareruimteStatus>
+            <bag_LVC:gerelateerdeWoonplaats>
+              <bag_LVC:identificatie>3042</bag_LVC:identificatie>
+            </bag_LVC:gerelateerdeWoonplaats>
+          </bag_LVC:OpenbareRuimte>
+        </product_LVC:Wijziging>
+      </product_LVC:Mutatie-product>
+<!-- geldigheid aanpassing om 2016-03-09T15:30:12.000997 -->
+      <product_LVC:Mutatie-product>
+        <product_LVC:Verwerking>
+          <product_LVC:TijdstipVerwerking>2016-03-09T15:30:12.000997</product_LVC:TijdstipVerwerking>
+          <product_LVC:ObjectType>OPR</product_LVC:ObjectType>
+          <product_LVC:VolgnrVerwerking>1</product_LVC:VolgnrVerwerking>
+        </product_LVC:Verwerking>
+        <product_LVC:Origineel>
+          <bag_LVC:OpenbareRuimte>
+            <bag_LVC:identificatie>1884300000000464</bag_LVC:identificatie>
+            <bag_LVC:aanduidingRecordInactief>N</bag_LVC:aanduidingRecordInactief>
+            <bag_LVC:aanduidingRecordCorrectie>0</bag_LVC:aanduidingRecordCorrectie>
+            <bag_LVC:openbareRuimteNaam>oeverloos</bag_LVC:openbareRuimteNaam>
+            <bag_LVC:officieel>N</bag_LVC:officieel>
+            <bag_LVC:tijdvakgeldigheid>
+              <bagtype:begindatumTijdvakGeldigheid>2016030900100001</bagtype:begindatumTijdvakGeldigheid>
+            </bag_LVC:tijdvakgeldigheid>
+            <bag_LVC:inOnderzoek>N</bag_LVC:inOnderzoek>
+            <bag_LVC:openbareRuimteType>Weg</bag_LVC:openbareRuimteType>
+            <bag_LVC:bron>
+              <bagtype:documentdatum>20160309</bagtype:documentdatum>
+              <bagtype:documentnummer>16.06132</bagtype:documentnummer>
+            </bag_LVC:bron>
+            <bag_LVC:openbareruimteStatus>Naamgeving uitgegeven</bag_LVC:openbareruimteStatus>
+            <bag_LVC:gerelateerdeWoonplaats>
+              <bag_LVC:identificatie>3042</bag_LVC:identificatie>
+            </bag_LVC:gerelateerdeWoonplaats>
+          </bag_LVC:OpenbareRuimte>
+        </product_LVC:Origineel>
+        <product_LVC:Wijziging>
+          <bag_LVC:OpenbareRuimte>
+            <bag_LVC:identificatie>1884300000000464</bag_LVC:identificatie>
+            <bag_LVC:aanduidingRecordInactief>N</bag_LVC:aanduidingRecordInactief>
+            <bag_LVC:aanduidingRecordCorrectie>0</bag_LVC:aanduidingRecordCorrectie>
+            <bag_LVC:openbareRuimteNaam>oeverloos</bag_LVC:openbareRuimteNaam>
+            <bag_LVC:officieel>N</bag_LVC:officieel>
+            <bag_LVC:tijdvakgeldigheid>
+              <bagtype:begindatumTijdvakGeldigheid>2016030900100001</bagtype:begindatumTijdvakGeldigheid>
+              <bagtype:einddatumTijdvakGeldigheid>2016030900100002</bagtype:einddatumTijdvakGeldigheid>
+            </bag_LVC:tijdvakgeldigheid>
+            <bag_LVC:inOnderzoek>N</bag_LVC:inOnderzoek>
+            <bag_LVC:openbareRuimteType>Weg</bag_LVC:openbareRuimteType>
+            <bag_LVC:bron>
+              <bagtype:documentdatum>20160309</bagtype:documentdatum>
+              <bagtype:documentnummer>16.06132</bagtype:documentnummer>
+            </bag_LVC:bron>
+            <bag_LVC:openbareruimteStatus>Naamgeving uitgegeven</bag_LVC:openbareruimteStatus>
+            <bag_LVC:gerelateerdeWoonplaats>
+              <bag_LVC:identificatie>3042</bag_LVC:identificatie>
+            </bag_LVC:gerelateerdeWoonplaats>
+          </bag_LVC:OpenbareRuimte>
+        </product_LVC:Wijziging>
+      </product_LVC:Mutatie-product>
+      
+    </mb:producten>
+  </mb:antwoord>
+</mb:BAG-Mutaties-Deelbestand-LVC>


### PR DESCRIPTION
en niet meer hibernate. 

Gevolg hiervan is wel dat alle zipfiles steeds opnieuw opgehaald moeten worden om te bepalen of een laadproces al is verwerkt; eerder was er een laadproces per zipfile, nu een laadproces per xml bestand uit een zipfile; aan de buitenkant van de zipfile is niet te zien of, hoeveel en welke xml bestanden er in zitten, dat kan pas als het bestand is geopend.

qua performance kan het dan zinvol zijn om "oude" maandelijkse mutatie bestanden per jaar te archiveren op de download server; dan blijft dit binnen de perken.

close #275