### PR TITLE
upgrade jsoup 1.10.1 to 1.10.2

### DIFF
--- a/brmo-service/pom.xml
+++ b/brmo-service/pom.xml
@@ -142,7 +142,6 @@
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
-            <version>8.0.39</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -500,7 +500,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.6.1</version>
                     <configuration>
                         <source>${java.version}</source>
                         <target>${java.version}</target>
@@ -666,7 +666,7 @@
                 <plugin>
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>
-                    <version>2.2.1</version>
+                    <version>2.2.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.10.1</version>
+                <version>1.10.2</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.ws</groupId>
@@ -349,6 +349,13 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>4.5.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <!-- voor jndi context in een brmo-service integration test -->
+                <groupId>org.apache.tomcat</groupId>
+                <artifactId>tomcat-catalina</artifactId>
+                <version>8.0.39</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
- upgrade jsoup 1.10.1 to 1.10.2, release notes: https://jsoup.org/news/release-1.10.2
- upgrade maven compiler en git-commit-id plugins