### PR TITLE
Gebruik referentie implementatie van SOAP runtime (en niet Glassfish)

### DIFF
--- a/brmo-dist/assembly.xml
+++ b/brmo-dist/assembly.xml
@@ -70,13 +70,6 @@
             </includes>
         </fileSet>
         <fileSet>
-            <directory>../${project.basedir}/brmo-soap/target/</directory>
-            <outputDirectory>wars</outputDirectory>
-            <includes>
-                <include>**/TOMCAT-soaplibs.zip</include>
-            </includes>
-        </fileSet>
-        <fileSet>
             <directory>../${project.basedir}/</directory>
             <outputDirectory/>
             <includes>

--- a/brmo-service/pom.xml
+++ b/brmo-service/pom.xml
@@ -331,8 +331,7 @@
                             <systemPropertyVariables>
                                 <database.properties.file>postgres.properties</database.properties.file>
                             </systemPropertyVariables>
-                            <rerunFailingTestsCount>1</rerunFailingTestsCount>
-                            <argLine>-XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
+                            <rerunFailingTestsCount>0</rerunFailingTestsCount>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -437,7 +436,6 @@
                             </systemPropertyVariables>
                             <rerunFailingTestsCount>1</rerunFailingTestsCount>
                             <excludedGroups>nl.b3p.brmo.test.util.database.OracleDriverBasedFailures</excludedGroups>
-                            <argLine>-XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/brmo-service/src/test/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsActionBeanIntegrationTest.java
+++ b/brmo-service/src/test/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsActionBeanIntegrationTest.java
@@ -44,7 +44,9 @@ import org.junit.runners.Parameterized;
  * testcases voor GH issue 260; herhalen van brk verwijder berichten. Draaien
  * met:
  * {@code mvn -Dit.test=AdvancedFunctionsActionBeanIntegrationTest -Dtest.onlyITs=true verify -Poracle > target/oracle.log}
- * voor bijvoorbeeld Oracle.
+ * voor bijvoorbeeld Oracle of
+ * {@code mvn -Dit.test=AdvancedFunctionsActionBeanIntegrationTest -Dtest.onlyITs=true verify -Ppostgresql > target/postgresql.log}
+ * voor PostgreSQL.
  *
  * <strong>Deze test werkt niet met de jTDS driver omdat die geen
  * {@code PreparedStatement.setNull(int, int, String)} methode heeft

--- a/brmo-soap/pom.xml
+++ b/brmo-soap/pom.xml
@@ -17,34 +17,9 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.metro</groupId>
-            <artifactId>webservices-tools</artifactId>
-            <version>${glassfish.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.metro</groupId>
-            <artifactId>webservices-rt</artifactId>
-            <version>${glassfish.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.metro</groupId>
-            <artifactId>webservices-extra</artifactId>
-            <version>${glassfish.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.metro</groupId>
-            <artifactId>webservices-api</artifactId>
-            <version>${glassfish.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.metro</groupId>
-            <artifactId>webservices-extra-api</artifactId>
-            <version>${glassfish.version}</version>
-            <scope>provided</scope>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>jaxws-rt</artifactId>
+            <version>2.2.10</version>
         </dependency>
         <dependency>
             <groupId>com.vividsolutions</groupId>
@@ -131,40 +106,6 @@
                                     <type>jar</type>
                                 </artifactItem>
                             </artifactItems>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>copy-glassfish-dependencies</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeGroupIds>org.glassfish.metro</includeGroupIds>
-                            <outputDirectory>${project.build.directory}/TOMCAT-soaplibs/shared/lib</outputDirectory>
-                            <stripVersion>true</stripVersion>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>distro-assembly</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <configuration>
-                            <descriptors>
-                                <descriptor>assembly.xml</descriptor>
-                            </descriptors>
-                            <attach>false</attach>
-                            <finalName>TOMCAT</finalName>
-                            <formats>
-                                <format>zip</format>
-                            </formats>
                         </configuration>
                     </execution>
                 </executions>

--- a/brmo-soap/pom.xml
+++ b/brmo-soap/pom.xml
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>jaxws-rt</artifactId>
-            <version>2.2.10</version>
         </dependency>
         <dependency>
             <groupId>com.vividsolutions</groupId>


### PR DESCRIPTION
Oplossing voor #318 en #320 door referentie implementatie te gebruiken voor de brmo-soap en deze niet in tomcat bootclasspath onder te brengen maar uit de webapp te te gebruiken.

- [x] extra duidelijke upgrade notitie maken

close #318
close #320 