### PR TITLE
Upgrade van een aantal libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,14 +49,14 @@
         <netbeans.hint.jdkPlatform>JDK_${java.version}</netbeans.hint.jdkPlatform>
         <netbeans.hint.license>default_1</netbeans.hint.license>
         <hibernate.version>3.6.10.Final</hibernate.version>
-        <geotools.version>17.0</geotools.version>
-        <postgresql.jdbc.version>42.0.0</postgresql.jdbc.version>
+        <geotools.version>17.1</geotools.version>
+        <postgresql.jdbc.version>42.1.1</postgresql.jdbc.version>
         <postgresql.postgis-jdbc.version>2.2.1</postgresql.postgis-jdbc.version>
         <oracle.jdbc.groupId>com.oracle</oracle.jdbc.groupId>
         <oracle.jdbc.version>12.2.0.1.0</oracle.jdbc.version>
         <oracle.jdbc.artifactId>ojdbc8</oracle.jdbc.artifactId>
         <sqlserver.jtds.version>1.3.1</sqlserver.jtds.version>
-        <javasimon.version>4.1.2</javasimon.version>
+        <javasimon.version>4.1.3</javasimon.version>
         <quartz.version>2.3.0</quartz.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -314,7 +314,7 @@
             <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
-                <version>20160810</version>
+                <version>20170516</version>
             </dependency>
             <!-- test dependencies -->
             <dependency>
@@ -357,13 +357,13 @@
                 <!-- voor jndi context in een brmo-service integration test -->
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-catalina</artifactId>
-                <version>8.0.43</version>
+                <version>8.0.44</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-dbcp</artifactId>
-                <version>8.0.43</version>
+                <version>8.0.44</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
@@ -520,7 +520,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.0.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -573,7 +573,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Upgrade van onderstaande libraries

  - GeoTools; 17.0 -> 17.1 (https://geotoolsnews.blogspot.nl/2017/05/geotools-171-released.html)
  - Simon; 4.1.2 -> 4.1.3 (https://github.com/virgo47/javasimon/blob/master/docs/History.md)
  - PostgreSQL driver; 42.0.0 -> 42.1.1 (https://jdbc.postgresql.org/documentation/changelog.html#version_42.1.1)
  - Tomcat libs; 8.0.43 -> 8.0.44 (https://tomcat.apache.org/tomcat-8.0-doc/changelog.html)
  - Json; 20160810 -> 20170516 (https://github.com/stleary/JSON-java/releases/tag/20170516)

Een deel van deze libraries wordt alleen gebruikt voor de unit- en integratie tests.

En nu we er toch zijn ook de volgende maven plugins bijwerken

  - maven-dependency-plugin; 3.0.0 -> 3.0.1
  - maven-war-plugin; 3.0.0 -> 3.1.0