### PR TITLE
Maak dump van bag berichten uit gds2 mogelijk met debug logging

### DIFF
--- a/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/GDS2OphalenProces.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/GDS2OphalenProces.java
@@ -10,6 +10,8 @@ import nl.b3p.brmo.persistence.staging.LaadProces;
 import com.sun.xml.ws.developer.JAXWSProperties;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -80,6 +82,7 @@ import nl.kadaster.schemas.gds2.service.afgifte_bestandenlijstopvragen.v20130701
 import nl.logius.digikoppeling.gb._2010._10.DataReference;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.CloseShieldInputStream;
+import org.apache.commons.io.input.TeeInputStream;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -501,6 +504,13 @@ public class GDS2OphalenProces extends AbstractExecutableProces {
                     ((HttpsURLConnection) connection).setSSLSocketFactory(context.getSocketFactory());
                 }
                 input = (InputStream) connection.getContent();
+                if (log.isDebugEnabled()) {
+                    // dump zip bestand naar /tmp/ voordat de xml wordt geparsed
+                    File dump = File.createTempFile(a.getBestand().getBestandsnaam() + "_id-" + a.getAfgifteID(), ".zip");
+                    log.debug("Dump BAG mutaties zip naar: " + dump.getAbsolutePath());
+                    FileOutputStream archiveFile = new FileOutputStream(dump);
+                    input = new TeeInputStream(input, archiveFile, true);
+                }
                 break;
             } catch (Exception e) {
                 attempt++;
@@ -615,7 +625,7 @@ public class GDS2OphalenProces extends AbstractExecutableProces {
 
         if (log.isDebugEnabled()) {
             // dump xml bestand naar /tmp/ voordat de xml wordt geparsed
-            String fName = "/tmp/" + lp.getBestand_naam() + ".xml";
+            String fName = File.createTempFile(lp.getBestand_naam(), ".xml").getAbsolutePath();
             log.debug("Dump xml bericht naar: " + fName);
             IOUtils.write(b.getBr_orgineel_xml(), new FileWriter(fName));
         }

--- a/brmo-service/src/main/webapp/WEB-INF/classes/log4j.properties
+++ b/brmo-service/src/main/webapp/WEB-INF/classes/log4j.properties
@@ -4,6 +4,7 @@ logFile=brmo-service.log
 log4j.rootLogger=INFO,file,GDS2urls
 log4j.logger.nl.b3p=INFO
 log4j.logger.nl.b3p.soap=INFO
+log4j.logger.nl.b3p.brmo.service.scanner.GDS2OphalenProces=INFO
 
 # hibernate logging
 # see https://docs.jboss.org/hibernate/core/3.6/reference/en-US/html/session-configuration.html#configuration-logging
@@ -39,8 +40,6 @@ log4j.appender.file.append = true
 log4j.appender.file.maxBackupIndex = 10
 
 # aparte logfile met GDS2 urls
-log4j.logger.nl.b3p.brmo.service.scanner.GDS2OphalenProces=INFO
-
 logFileGDS2=gds2-urls-brmo-service.log
 log4j.appender.GDS2urls=org.apache.log4j.RollingFileAppender
 log4j.appender.GDS2urls.file=${logFilePath}/${logFileGDS2}


### PR DESCRIPTION
Als logging op DEBUG wordt gezet voor de GDS2 klasse dan komen de downloads in de temp derectory terecht, meestal is dat de temp directory van de applicatie server (in geval tomcat <tomcat-base>/temp  
de directory moet bestaan