### PR TITLE
verzamelde dependency upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@
 mvn.log
 rel-prepare.log
 rel-perform.log
+dependency-updates.log
+plugin-updates.log
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <netbeans.hint.license>default_1</netbeans.hint.license>
         <hibernate.version>3.6.10.Final</hibernate.version>
         <geotools.version>17.1</geotools.version>
-        <postgresql.jdbc.version>42.1.1</postgresql.jdbc.version>
+        <postgresql.jdbc.version>42.1.3</postgresql.jdbc.version>
         <postgresql.postgis-jdbc.version>2.2.1</postgresql.postgis-jdbc.version>
         <oracle.jdbc.groupId>com.oracle</oracle.jdbc.groupId>
         <oracle.jdbc.version>12.2.0.1.0</oracle.jdbc.version>
@@ -66,7 +66,7 @@
         de schema's voor posgresql en oracle worden niet automatisch aangemaakt.
         -->
         <test.persistence.unit>brmo.persistence.h2</test.persistence.unit>
-        <test.h2.version>1.4.195</test.h2.version>
+        <test.h2.version>1.4.196</test.h2.version>
         <test.onlyITs>false</test.onlyITs>
         <maven.surefire.version>2.20</maven.surefire.version>
     </properties>
@@ -108,17 +108,17 @@
             <dependency>
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
-                <version>1.3.1</version>
+                <version>1.4</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.5</version>
+                <version>3.6</version>
             </dependency>
             <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
-                <version>1.3.2</version>
+                <version>1.3.3</version>
             </dependency>
 
             <!-- spatial -->
@@ -181,7 +181,7 @@
             <dependency>
                 <groupId>org.geolatte</groupId>
                 <artifactId>geolatte-geom</artifactId>
-                <version>1.0.6</version>
+                <version>1.1.0</version>
             </dependency>
             <!-- database en persistence -->
             <dependency>
@@ -192,7 +192,7 @@
             <dependency>
                 <groupId>commons-dbutils</groupId>
                 <artifactId>commons-dbutils</artifactId>
-                <version>1.6</version>
+                <version>1.7</version>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>
@@ -264,7 +264,7 @@
                 <!-- de volledige mail api dient door de servlet container te worden geleverd. -->
                 <groupId>javax.mail</groupId>
                 <artifactId>javax.mail-api</artifactId>
-                <version>1.5.6</version>
+                <version>1.6.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -309,7 +309,7 @@
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>
-                <version>1.10.2</version>
+                <version>1.10.3</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.ws</groupId>
@@ -362,13 +362,13 @@
                 <!-- voor jndi context in een brmo-service integration test -->
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-catalina</artifactId>
-                <version>8.0.44</version>
+                <version>8.0.45</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-dbcp</artifactId>
-                <version>8.0.44</version>
+                <version>8.0.45</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Upgrade onderstaande libraries:

  - commons-dbutil (1.6 -> 1.7) release notes: https://commons.apache.org/proper/commons-dbutils/changes-report.html#a1.7
  - commons-fileupload (1.3.2 -> 1.3.3) release notes: https://commons.apache.org/proper/commons-fileupload/changes-report.html#a1.3.3 (FIX [CVE-2016-1000031](https://nvd.nist.gov/vuln/detail/CVE-2016-1000031) )
  - javax.mail-api (1.5.6 -> 1.6.0) release notes: https://github.com/javaee/javamail/releases/tag/JAVAMAIL-1_6_0
  - commons-lang3 (3.5 -> 3.6) release notes: https://commons.apache.org/proper/commons-lang/release-notes/RELEASE-NOTES-3.6.txt
  - commons-cli (1.3.1 -> 1.4) release notes: https://commons.apache.org/proper/commons-cli/changes-report.html#a1.4
  - jsoup (1.10.2 -> 1.10.3) release notes: https://jsoup.org/news/release-1.10.3
  - geolatte-geom (1.0.6 -> 1.1.0)
  - postgresql (42.1.1 -> 42.1.3) release notes: https://jdbc.postgresql.org/documentation/changelog.html#version_42.1.3
  - tomcat-catalina en tomcat-dbcp (8.0.44 -> 8.0.45)