### PR TITLE
Maak aantal quartz threads configureerbaar middels context parameter

### DIFF
--- a/brmo-service/src/main/java/nl/b3p/brmo/service/jobs/AutomatischProcesJob.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/jobs/AutomatischProcesJob.java
@@ -6,7 +6,6 @@ package nl.b3p.brmo.service.jobs;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Date;
-import javax.persistence.EntityManager;
 import nl.b3p.brmo.loader.util.BrmoException;
 import nl.b3p.brmo.persistence.staging.AutomatischProces;
 import nl.b3p.brmo.service.scanner.AbstractExecutableProces;

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/jobs/GeplandeTakenInit.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/jobs/GeplandeTakenInit.java
@@ -101,7 +101,7 @@ public class GeplandeTakenInit implements Servlet {
         if (threadCount != null) {
             if (Integer.parseInt(threadCount) > 1) {
                 log.warn("Instellen van quartz threadcount op niet-default waarde van " + threadCount
-                        + "Gebruiker moet zorg dragen dat er geen overlappende transformatieprocessen van eenzelfde soort zijn.");
+                        + " Gebruiker moet zorg dragen dat er geen overlappende transformatie- of GDS2 processen van eenzelfde soort zijn.");
                 props.put("org.quartz.threadPool.threadCount", threadCount);
             }
         } else {

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/jobs/GeplandeTakenInit.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/jobs/GeplandeTakenInit.java
@@ -97,10 +97,20 @@ public class GeplandeTakenInit implements Servlet {
     private void setupQuartz() throws SchedulerException {
         Properties props = new Properties();
         props.put("org.quartz.scheduler.instanceName", SCHEDULER_NAME);
-        props.put("org.quartz.threadPool.threadCount", "1");
+        String threadCount = this.getServletConfig().getServletContext().getInitParameter("quartz.threadCount");
+        if (threadCount != null) {
+            if (Integer.parseInt(threadCount) > 1) {
+                log.warn("Instellen van quartz threadcount op niet-default waarde van " + threadCount
+                        + "Gebruiker moet zorg dragen dat er geen overlappende transformatieprocessen van eenzelfde soort zijn.");
+                props.put("org.quartz.threadPool.threadCount", threadCount);
+            }
+        } else {
+            props.put("org.quartz.threadPool.threadCount", "1");
+        }
         props.put("org.quartz.scheduler.interruptJobsOnShutdownWithWait", "true");
         props.put("org.quartz.jobStore.class", "org.quartz.simpl.RAMJobStore");
         props.put("org.quartz.scheduler.skipUpdateCheck", "true");
+        log.debug("Start quartz scheduler met de opties: " + props);
 
         StdSchedulerFactory factory = new StdSchedulerFactory(props);
         scheduler = factory.getScheduler();
@@ -113,8 +123,7 @@ public class GeplandeTakenInit implements Servlet {
         CriteriaQuery<AutomatischProces> cq = cb.createQuery(AutomatischProces.class);
         Root<AutomatischProces> from = cq.from(AutomatischProces.class);
         cq.where(cb.isNotNull(from.get("cronExpressie")));
-        List<AutomatischProces> procList = entityManager.
-                createQuery(cq).getResultList();
+        List<AutomatischProces> procList = entityManager.createQuery(cq).getResultList();
 
         for (AutomatischProces p : procList) {
             addJobDetails(scheduler, p);

--- a/brmo-service/src/main/webapp/WEB-INF/web.xml
+++ b/brmo-service/src/main/webapp/WEB-INF/web.xml
@@ -30,6 +30,11 @@
         <param-name>stand.transform.max</param-name>
         <param-value>1000000</param-value>
     </context-param>
+    <context-param>
+        <description>Aantal uitvoerende threads voor ingeplande taken. Default 1, bij hogere waarden dient de gebruiker er voor te zorgen dat er geen in de tijd overlappende transformatie processen van eenzelfde type, bijvoorbeeld berichten, lopen.</description>
+        <param-name>quartz.threadCount</param-name>
+        <param-value>3</param-value>
+    </context-param>
     <filter>
         <display-name>Stripes Filter</display-name>
         <filter-name>StripesFilter</filter-name>

--- a/brmo-service/src/main/webapp/WEB-INF/web.xml
+++ b/brmo-service/src/main/webapp/WEB-INF/web.xml
@@ -31,9 +31,11 @@
         <param-value>1000000</param-value>
     </context-param>
     <context-param>
-        <description>Aantal uitvoerende threads voor ingeplande taken. Default 1, bij hogere waarden dient de gebruiker er voor te zorgen dat er geen in de tijd overlappende transformatie processen van eenzelfde type, bijvoorbeeld berichten, lopen.</description>
+        <description>Aantal uitvoerende threads voor ingeplande taken. Default waarde is 1, bij hogere waarden dient de gebruiker er voor te zorgen dat er geen
+            in de tijd overlappende transformatie of GDS2 processen van eenzelfde type, bijvoorbeeld berichten, lopen.
+            Het verhogen is met name zinvol voor BGT light download processen.</description>
         <param-name>quartz.threadCount</param-name>
-        <param-value>3</param-value>
+        <param-value>1</param-value>
     </context-param>
     <filter>
         <display-name>Stripes Filter</display-name>


### PR DESCRIPTION
De default waarde is 1 en garandeert dat er geen jobs concurrent draaien, de optie kan hoger ingesteld worden om jobs concurrent te draaien, de gebruiker is in dat geval verantwoordelijk voor juiste inplanning zodat er geen jobs lopen die elkaar in de weg zitten, bijvoorbeeld transformatie processen of GDS2 download processen van 1 soort.

close #354