### PR TITLE
Sluit ongebruikte, transitieve tomcat libs uit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,14 +89,10 @@ timestamps {
             }
 
             stage('OWASP Dependency Check') {
-                // if (env.BRANCH_NAME == 'master') {
                 echo "Uitvoeren OWASP dependency check"
                 dependencyCheckAnalyzer datadir: '', hintsFile: '', includeCsvReports: false, includeHtmlReports: true, includeJsonReports: false, isAutoupdateDisabled: false, outdir: '', scanpath: '**/brmo-*.jar,**/brmo-*.war,**/brmo-*.zip', skipOnScmChange: false, skipOnUpstreamChange: false, suppressionFile: '', zipExtensions: ''
 
                 dependencyCheckPublisher canComputeNew: false, defaultEncoding: '', healthy: '85', pattern: '**/dependency-check-report.xml', shouldDetectModules: true, unHealthy: ''
-                //} else {
-                //    echo "Overslaan OWASP dependency check voor deze branch"
-                //}
             }
         }
     }

--- a/brmo-commandline/pom.xml
+++ b/brmo-commandline/pom.xml
@@ -11,8 +11,9 @@
     <name>BRMO commandline</name>
     <description>BRMO commandline tool.</description>
     <properties>
-        <!-- de oracle driver uitsluiten -->
-        <exclude.groupid.inpackage>${oracle.jdbc.groupId}</exclude.groupid.inpackage>
+        <!-- de oracle driver van zip file uitsluiten-->
+        <exclude.groupIds.fromPackaging>${oracle.jdbc.groupId}</exclude.groupIds.fromPackaging>
+        <include.scope.inPackaging>runtime</include.scope.inPackaging>
     </properties>
     <dependencies>
         <dependency>
@@ -145,10 +146,10 @@
                         </goals>
                         <configuration>
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                            <excludeGroupIds>${exclude.groupid.inpackage}</excludeGroupIds>
-                            <excludeClassifiers>test</excludeClassifiers>
+                            <excludeGroupIds>${exclude.groupIds.fromPackaging}</excludeGroupIds>
+                            <includeScope>${include.scope.inPackaging}</includeScope>
                             <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>true</overWriteSnapshots>
+                            <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
                         </configuration>
                     </execution>
@@ -286,7 +287,7 @@
             <id>oracle</id>
             <properties>
                 <!-- voor oracle profiel wel de driver insluiten -->
-                <exclude.groupid.inpackage />
+                <exclude.groupIds.fromPackaging/>
             </properties>
             <dependencies>
                 <dependency>

--- a/brmo-commandline/pom.xml
+++ b/brmo-commandline/pom.xml
@@ -29,6 +29,44 @@
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-jsp-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-juli</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-annotations-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-jni</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-coyote</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-util</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tomcat</groupId>
+                    <artifactId>tomcat-util-scan</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -108,6 +146,7 @@
                         <configuration>
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
                             <excludeGroupIds>${exclude.groupid.inpackage}</excludeGroupIds>
+                            <excludeClassifiers>test</excludeClassifiers>
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>true</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>

--- a/brmo-stufbg204/pom.xml
+++ b/brmo-stufbg204/pom.xml
@@ -132,7 +132,7 @@
                 </executions>
                 <configuration>
                     <xnocompile>true</xnocompile>
-                    <verbose>true</verbose>
+                    <verbose>false</verbose>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
voor de `tomcat-api-8.0.46.jar` staan een aantal CWE's open die verder geen impact hebben voor ons maar wel in de automatische scan naar boven komen.