### PR TITLE
update maven plugins en dependencies

### DIFF
--- a/bgt-gml-loader/pom.xml
+++ b/bgt-gml-loader/pom.xml
@@ -163,7 +163,7 @@
                     <dependency>
                         <groupId>net.sf.saxon</groupId>
                         <artifactId>Saxon-HE</artifactId>
-                        <version>9.7.0-15</version>
+                        <version>9.8.0-5</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/datamodel/pom.xml
+++ b/datamodel/pom.xml
@@ -169,7 +169,7 @@
                     <dependency>
                         <groupId>net.sf.saxon</groupId>
                         <artifactId>Saxon-HE</artifactId>
-                        <version>9.7.0-7</version>
+                        <version>9.8.0-5</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/datamodel/rsgbsst2.xsl
+++ b/datamodel/rsgbsst2.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:uml="http://www.omg.org/spec/UML/20110701" xmlns:xmi="http://www.omg.org/spec/XMI/20110701" xmlns:thecustomprofile="http://www.sparxsystems.com/profiles/thecustomprofile/1.0" xmlns:RGB="http://www.sparxsystems.com/profiles/RGB/1.0">
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:uml="http://www.omg.org/spec/UML/20110701" xmlns:xmi="http://www.omg.org/spec/XMI/20110701" xmlns:thecustomprofile="http://www.sparxsystems.com/profiles/thecustomprofile/1.0" xmlns:RGB="http://www.sparxsystems.com/profiles/RGB/1.0">
 	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
 	<xsl:template match="/xmi:XMI">
 		<xsl:element name="RSGB">

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.5</version>
+                <version>2.6</version>
             </dependency>
             <dependency>
                 <groupId>commons-cli</groupId>
@@ -191,7 +191,7 @@
             <dependency>
                 <groupId>org.geolatte</groupId>
                 <artifactId>geolatte-geom</artifactId>
-                <version>1.1.0</version>
+                <version>1.2.0</version>
             </dependency>
             <!-- database en persistence -->
             <dependency>
@@ -329,7 +329,7 @@
             <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
-                <version>20170516</version>
+                <version>20171018</version>
             </dependency>
             <!-- test dependencies -->
             <dependency>
@@ -372,13 +372,13 @@
                 <!-- voor jndi context in een brmo-service integration test -->
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-catalina</artifactId>
-                <version>8.0.46</version>
+                <version>8.0.47</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-dbcp</artifactId>
-                <version>8.0.46</version>
+                <version>8.0.47</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependencyManagement>
         <!--
         voor een update controle gebruik je het volgende maven commando:
-        mvn -U org.codehaus.mojo:versions-maven-plugin:2.4:display-dependency-updates > dependency-updates.log
+        mvn -U org.codehaus.mojo:versions-maven-plugin:2.5:display-dependency-updates > dependency-updates.log
         -->
         <dependencies>
             <!-- logging libs -->
@@ -416,21 +416,6 @@
     </distributionManagement>
     <repositories>
         <repository>
-            <id>Boundless</id>
-            <name>Boundless Maven Repository</name>
-            <url>http://repo.boundlessgeo.com/main/</url>
-        </repository>
-        <repository>
-            <id>GeoSolutions</id>
-            <name>GeoSolutions Maven Repository</name>
-            <url>http://maven.geo-solutions.it/</url>
-        </repository>
-        <repository>
-            <id>OSGeo</id>
-            <name>Open Source Geospatial Foundation Repository</name>
-            <url>http://download.osgeo.org/webdav/geotools/</url>
-        </repository>
-        <repository>
             <id>B3Partners</id>
             <name>Releases hosted by B3Partners</name>
             <url>http://repo.b3p.nl/nexus/content/groups/public/</url>
@@ -458,7 +443,7 @@
             <plugins>
                 <!--
                 voor een update controle gebruik je het volgende maven commando:
-                mvn -U org.codehaus.mojo:versions-maven-plugin:2.4:display-plugin-updates -T1 > plugin-updates.log
+                mvn -U org.codehaus.mojo:versions-maven-plugin:2.5:display-plugin-updates -T1 > plugin-updates.log
                 -->
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -583,12 +568,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.4</version>
+                    <version>3.0.0-M1</version>
                     <configuration>
                         <stylesheet>java</stylesheet>
                         <doclet>org.umlgraph.doclet.UmlGraphDoc</doclet>
@@ -697,7 +682,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>2.5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -707,7 +692,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jvnet.jax-ws-commons</groupId>


### PR DESCRIPTION
maven plugin updates en dependency updates voor patch release:

- update commons-io:commons-io (2.5 -> 2.6)
- update org.geolatte:geolatte-geom (1.1.0 -> 1.2.0)
- update org.apache.tomcat:tomcat-dbcp en org.apache.tomcat:tomcat-catalina (8.0.46 -> 8.0.47)
- update org.json:json (20170516 -> 20171018)
