### PR TITLE
Update servlet, jstl en jsp api's voor Tomcat 7

### DIFF
--- a/brmo-service/pom.xml
+++ b/brmo-service/pom.xml
@@ -47,12 +47,12 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>jstl</groupId>
-            <artifactId>jstl</artifactId>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>javax.servlet.jsp.jstl</artifactId>
         </dependency>
         <dependency>
             <groupId>nl.b3p</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@
                 <version>1.7.25</version>
             </dependency>
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.25</version>
+            </dependency>
+            <dependency>
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
                 <version>1.2.17</version>
@@ -298,18 +303,6 @@
                 <version>0.5.0</version>
             </dependency>
             <dependency>
-                <groupId>javax</groupId>
-                <artifactId>javaee-web-api</artifactId>
-                <version>7.0</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>javax</groupId>
-                <artifactId>javaee-endorsed-api</artifactId>
-                <version>7.0</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
                 <groupId>javax.activation</groupId>
                 <artifactId>activation</artifactId>
                 <version>1.1.1</version>
@@ -322,15 +315,45 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>servlet-api</artifactId>
-                <version>2.5</version>
+                <groupId>javax</groupId>
+                <artifactId>javaee-web-api</artifactId>
+                <version>7.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>jstl</groupId>
-                <artifactId>jstl</artifactId>
-                <version>1.2</version>
+                <groupId>javax</groupId>
+                <artifactId>javaee-endorsed-api</artifactId>
+                <version>7.0</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.servlet</groupId>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>3.0.1</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.servlet.jsp</groupId>
+                <artifactId>jsp-api</artifactId>
+                <version>2.2</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.web</groupId>
+                <artifactId>javax.servlet.jsp.jstl</artifactId>
+                <version>1.2.4</version>
+                 <exclusions>
+                    <exclusion>
+                        <!-- sleept servlet api 2.5 mee, maar we willen 3.x gebruiken -->
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>servlet-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- sleept jsp api 2.1 mee, maar we willen 2.2 gebruiken -->
+                        <groupId>javax.servlet.jsp</groupId>
+                        <artifactId>jsp-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- simon monitoring -->
             <dependency>


### PR DESCRIPTION
Tomcat 6 heeft op 31 December 2016 "End of Life" status gekregen (zie: [End of life for Apache Tomcat 6.0.x](https://tomcat.apache.org/tomcat-60-eol.html)), de minimum benodigde Tomcat versie is met ingang van deze versie 7.0.x.

Tomcat 7 heeft de volgende API spec versies:
- Servlet spec versie 3.0
- JSP spec versie 2.2
- EL spec versie 2.2
- Websocket versie 1.1
  
oplossing van CVE-2015-0254