### PR TITLE
Update GeoTools & PostgreSQL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <netbeans.hint.license>gpl30</netbeans.hint.license>
         <hibernate.version>3.6.10.Final</hibernate.version>
-        <geotools.version>18.1</geotools.version>
-        <postgresql.jdbc.version>42.1.4</postgresql.jdbc.version>
+        <geotools.version>18.2</geotools.version>
+        <postgresql.jdbc.version>42.2.0</postgresql.jdbc.version>
         <postgresql.postgis-jdbc.version>2.2.1</postgresql.postgis-jdbc.version>
         <oracle.jdbc.artifactId>ojdbc8</oracle.jdbc.artifactId>
         <oracle.jdbc.groupId>com.oracle</oracle.jdbc.groupId>
@@ -865,7 +865,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.7.9</version>
+                    <version>0.8.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
- update GeoTools (18.1 -> 18.2) [release notes](https://osgeo-org.atlassian.net/secure/ReleaseNote.jspa?projectId=10001&version=16708)
- update PostgreSQL driver (42.1.4 -> 42.2.0) [release notes](https://jdbc.postgresql.org/documentation/changelog.html#version_42.2.0)