### PR TITLE
Update naar GeoTools 19

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Djava.awt.headless=true
+-Djava.awt.headless=true --add-modules=java.xml.bind --add-modules=java.activation -XX:+IgnoreUnrecognizedVMOptions

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ jdk:
 matrix:
   fast_finish: true
   allow_failures:
-    - oraclejdk9
+    - jdk: oraclejdk9
   include:
   - jdk: oraclejdk8
     # EOL September 2018

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,12 @@ addons:
 jdk:
   - oraclejdk8
   - openjdk8
+  - oraclejdk9
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - oraclejdk9
   include:
   - jdk: oraclejdk8
     # EOL September 2018
@@ -101,7 +104,7 @@ before_script:
 
 script:
   # run unit tests voor alle modules
-  - travis_wait 20 mvn -e test -B -Ppostgresql -pl '!brmo-dist' -Dtest.onlyITs=false
+  - travis_wait 20 mvn --settings .travis/settings.xml -T4.2C -e test -B -Ppostgresql,standard-with-extra-repos -pl '!brmo-dist' -Dtest.onlyITs=false 
   # run integratie tests voor veschillende modules, per module
   # run integratie tests voor bgt-gml-loader module
   - mvn -e verify -B -Ppostgresql -Dtest.onlyITs=true -pl 'bgt-gml-loader'

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -28,5 +28,114 @@
         </repository>
       </repositories>
     </profile>
+    <profile>
+      <id>standard-with-extra-repos</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+
+      <repositories>
+        <repository>
+          <id>central</id>
+          <name>Central Repository</name>
+          <url>http://repo.maven.apache.org/maven2</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+
+        <repository>
+          <id>sonatype</id>
+          <name>OSS Sonatype repo (releases)</name>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+            <checksumPolicy>warn</checksumPolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+            <checksumPolicy>fail</checksumPolicy>
+          </snapshots>
+          <url>https://oss.sonatype.org/content/repositories/releases/</url>
+        </repository>
+
+        <repository>
+          <id>sonatype-snapshots</id>
+          <name>OSS Sonatype repo (snapshots)</name>
+          <releases>
+            <enabled>false</enabled>
+            <updatePolicy>always</updatePolicy>
+            <checksumPolicy>warn</checksumPolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+            <checksumPolicy>fail</checksumPolicy>
+          </snapshots>
+          <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
+
+        <repository>
+          <id>sonatype-apache</id>
+          <name>Apache repo (releases)</name>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+            <checksumPolicy>warn</checksumPolicy>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+            <checksumPolicy>fail</checksumPolicy>
+          </snapshots>
+          <url>https://repository.apache.org/releases/</url>
+        </repository>
+
+        <repository>
+          <id>apache-snapshots</id>
+          <name>ASF repo (snapshots)</name>
+          <releases>
+            <enabled>false</enabled>
+            <updatePolicy>never</updatePolicy>
+            <checksumPolicy>warn</checksumPolicy>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+            <checksumPolicy>fail</checksumPolicy>
+          </snapshots>
+          <url>https://repository.apache.org/snapshots/</url>
+        </repository>
+
+        <repository>
+          <id>osgeo</id>
+          <name>Open Source Geospatial Foundation Repository</name>
+          <url>http://download.osgeo.org/webdav/geotools/</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+
+        <repository>
+          <id>boundless</id>
+          <name>Boundless Maven Repository</name>
+          <url>https://repo.boundlessgeo.com/main</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+
+      </repositories>
+    </profile>
   </profiles>
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <netbeans.hint.license>gpl30</netbeans.hint.license>
         <hibernate.version>3.6.10.Final</hibernate.version>
-        <geotools.version>19-beta</geotools.version>
+        <geotools.version>19-RC1</geotools.version>
         <postgresql.jdbc.version>42.2.0</postgresql.jdbc.version>
         <postgresql.postgis-jdbc.version>2.2.1</postgresql.postgis-jdbc.version>
         <oracle.jdbc.artifactId>ojdbc8</oracle.jdbc.artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <netbeans.hint.license>gpl30</netbeans.hint.license>
         <hibernate.version>3.6.10.Final</hibernate.version>
-        <geotools.version>19-RC1</geotools.version>
+        <geotools.version>19.0</geotools.version>
         <postgresql.jdbc.version>42.2.0</postgresql.jdbc.version>
         <postgresql.postgis-jdbc.version>2.2.1</postgresql.postgis-jdbc.version>
         <oracle.jdbc.artifactId>ojdbc8</oracle.jdbc.artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,8 +56,8 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <netbeans.hint.license>gpl30</netbeans.hint.license>
         <hibernate.version>3.6.10.Final</hibernate.version>
-        <geotools.version>18.2</geotools.version>
-        <postgresql.jdbc.version>42.2.1</postgresql.jdbc.version>
+        <geotools.version>19-beta</geotools.version>
+        <postgresql.jdbc.version>42.2.0</postgresql.jdbc.version>
         <postgresql.postgis-jdbc.version>2.2.1</postgresql.postgis-jdbc.version>
         <oracle.jdbc.artifactId>ojdbc8</oracle.jdbc.artifactId>
         <oracle.jdbc.groupId>com.oracle</oracle.jdbc.groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
             <dependency>
                 <groupId>nl.b3p</groupId>
                 <artifactId>jdbc-util</artifactId>
-                <version>1.10</version>
+                <version>1.11</version>
             </dependency>
 
             <dependency>
@@ -629,6 +629,7 @@
                         <trimStackTrace>false</trimStackTrace>
                         <useFile>false</useFile>
                         <skipTests>!${test.onlyITs}</skipTests>
+                        <skipITs>!${test.onlyITs}</skipITs>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
Met versie 19 komt de mogelijkheid om Java 9 te gaan gebruiken, blogposts: 
- http://geotoolsnews.blogspot.nl/2018/02/geotools-19-beta-released.html
- http://geotoolsnews.blogspot.nl/2018/03/geotools-19-rc1-released.html

### versies
- [x] GeoTools 19-beta
- [x] GeoTools 19-RC1
- [x] GeoTools 19.0

