### PR TITLE
Override kwetsbare commons-collections:3.1 met 3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,12 @@
             </dependency>
             <!-- database en persistence -->
             <dependency>
+                <!-- override v 3.1 die met hibernate meekomt -->
+                <groupId>commons-collections</groupId>
+                <artifactId>commons-collections</artifactId>
+                <version>3.2.2</version>
+            </dependency>
+            <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-entitymanager</artifactId>
                 <version>${hibernate.version}</version>


### PR DESCRIPTION
zodat er een versie van commons-collections wordt gebruikt waarin onderstaand kwetsbaarheden zijn opgelost:

- [CVE-2017-15708](http://cve.circl.lu/cve/CVE-2017-15708)
- [CVE-2015-6420](http://cve.circl.lu/cve/CVE-2015-6420)
