### PR TITLE
Negeer (onterechte) security scan melding mbt poi-XXXX.3.14.jar

### DIFF
--- a/.mvn/owasp-suppression.xml
+++ b/.mvn/owasp-suppression.xml
@@ -11,15 +11,6 @@
         <cve>CVE-2016-6325</cve>
         <cve>CVE-2017-6056</cve>
     </suppress>
-    <!--
-    <suppress>
-        <notes><![CDATA[
-      Negeer melding mbt postgresql-42.1.4.jar, false positive, CVE heeft betrekking op perl scripts.
-      ]]></notes>
-        <filePath regex="true">.*\bpostgresql-42.1.4\.jar</filePath>
-        <cve>CVE-2017-8806</cve>
-    </suppress>
-    -->
     <suppress>
         <notes><![CDATA[
       Negeer melding mbt postgresql-42.2.2.jar, false positive, CVE heeft betrekking op init scripts.
@@ -41,5 +32,16 @@
       ]]></notes>
         <filePath regex="true">.*\blog4j-1.2.17\.jar</filePath>
         <cve>CVE-2017-5645</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+      Negeer melding mbt poi-XXXX.3.14.jar, deze aanvalsvector (parsen van bepaalde documenten) speelt niet in de BRMO.
+      POI komt mee met een test dependency (org.dbunit:dbunit:2.5.4) en zit dus niet in de producten;
+      de aanvalsvector speelt ook niet in de testcases.
+      Na een upgrade van dbunit zou deze onderdrukking geen probleem meer moeten zijn.
+        ]]></notes>
+        <gav regex="true">^org\.apache\.poi:poi.*:3\.14$</gav>
+        <cve>CVE-2017-12626</cve>
+        <cve>CVE-2017-5644</cve>
     </suppress>
 </suppressions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,7 @@ timestamps {
             stage('OWASP Dependency Check') {
                 echo "Uitvoeren OWASP dependency check"
                 // dependencyCheckAnalyzer datadir: '', hintsFile: '', includeCsvReports: false, includeHtmlReports: true, includeJsonReports: false, isAutoupdateDisabled: false, outdir: '', scanpath: '**/brmo-*.jar,**/brmo-*.war,**/brmo-*.zip', skipOnScmChange: false, skipOnUpstreamChange: false, suppressionFile: '.mvn/owasp-suppression.xml', zipExtensions: ''
-                sh "mvn org.owasp:dependency-check-maven:aggregate -Dformat=XML -DsuppressionFile=./.mvn/owasp-suppression.xml"
+                sh "mvn org.owasp:dependency-check-maven:aggregate -Dformat=ALL -DsuppressionFile=./.mvn/owasp-suppression.xml"
 
                 dependencyCheckPublisher canComputeNew: false, defaultEncoding: '', healthy: '85', pattern: '**/dependency-check-report.xml', shouldDetectModules: true, unHealthy: ''
             }

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,10 @@
         <system>Github</system>
         <url>https://github.com/B3Partners/brmo/issues</url>
     </issueManagement>
+    <ciManagement>
+        <system>Travis-CI</system>
+        <url>https://travis-ci.org/B3Partners/brmo</url>
+    </ciManagement>
     <properties>
         <java.version>1.8</java.version>
         <project.build.sourceVersion>${java.version}</project.build.sourceVersion>


### PR DESCRIPTION
Negeer (onterechte) security scan melding mbt poi-XXXX.3.14.jar, deze aanvalsvector (parsen van bepaalde documenten) speelt niet in de BRMO. POI komt mee met een test dependency (org.dbunit:dbunit:2.5.4) en zit dus niet in de producten; de aanvalsvector speelt ook niet in de testcases.
