### PR TITLE
AppVeyor build matrix aanpassingen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,13 @@ matrix:
   fast_finish: true
   allow_failures:
     # - jdk: oraclejdk9
-    # vanwege timeout
+    # vanwege build timeout (soms)
     - name: "MS SQL server 2017"
   include:
   - name: "Oudste supported PostgreSQL"
     jdk: oraclejdk8
-    # EOL September 2018
+    # final release (==EOL): November 8, 2018
+    # https://www.postgresql.org/support/versioning/
     env: PG_VERSION="9.3"
     addons:
       postgresql: 9.3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ version: "{build}-{branch}"
 clone_folder: c:\projects\brmo
 clone_depth: 5
 skip_tags: true
+max_jobs: 1
 
 init:
   - git config --global core.autocrlf input
@@ -9,37 +10,52 @@ init:
   - cmd: net start %SQL%
 
 environment:
-  # Microsoft SQL Server 2014 Service Pack 2 heeft een EOL van 9-7-2019
+  BGT_ONLY_ITESTS : false
   # Microsoft SQL Server 2016 Service Pack 1 heeft een EOL van 13-7-2021
-  # Microsoft SQL Server 2017 is de jongst-beschikbare release op AppVeyor, maar testen we op Travis-CI (sneller)
+  # Microsoft SQL Server 2017 is de jongst-beschikbare release op AppVeyor, maar testen we op Travis-CI (veel sneller)
+  # Microsoft SQL Server 2014 Service Pack 2 heeft een EOL van 9-7-2019
   matrix:
-    - SQL: MSSQL$SQL2014
-      INSTANCENAME: SQL2014
-      JAVA_HOME: C:\Program Files\Java\jdk1.8.0
     - SQL: MSSQL$SQL2016
       INSTANCENAME: SQL2016
       JAVA_HOME: C:\Program Files\Java\jdk1.8.0
   #  - SQL: MSSQL$SQL2017
   #    INSTANCENAME: SQL2017
   #    JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+    - SQL: MSSQL$SQL2016
+      INSTANCENAME: SQL2016
+      JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+      BGT_ONLY_ITESTS : true
+    - SQL: MSSQL$SQL2014
+      INSTANCENAME: SQL2014
+      JAVA_HOME: C:\Program Files\Java\jdk1.8.0
 
 matrix:
   fast_finish: true
 
 install:
+
+  - ps: |
+      if (!(Test-Path("C:\Users\appveyor\downloads\maven-bin.zip"))) {
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+          (new-object System.Net.WebClient).DownloadFile('https://archive.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.zip', 'C:\Users\appveyor\downloads\maven-bin.zip')
+
+      }
+      [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\Users\appveyor\downloads\maven-bin.zip", "C:\maven")
+  - cmd: SET PATH=C:\maven\apache-maven-3.5.4\bin;%PATH%
   - cmd: echo %PATH%
   - cmd: java -version
+  - cmd: mvn -v
   - cd C:\projects\brmo
   - git lfs pull
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-http-proxy.ps1'))
   - ps: .\.appveyor\set-maven-proxy.ps1
-  # initial build, no testing
+
+# initial build/code generation, no testing
+build_script:
   - mvn install -Dmaven.test.skip=true -B -V -fae -q -Pmssql -pl "!brmo-dist"
 
-build: off
-
-before_test:
 # services worden na install gestart en we hebben gegenereerde sql nodig
+after_build:
   - cmd: echo "aanmaken en opzetten STAGING DB"
   - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -Q "CREATE DATABASE staging" -d "master"
   - dir -w .\brmo-persistence\db\
@@ -79,18 +95,19 @@ test_script:
   # unit tests
   - mvn -e test -B -Pmssql -pl "!brmo-dist"
   # integratie tests
-  # run integratie tests voor bgt-gml-loader module
-  - mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "bgt-gml-loader" -Dmssql.instancename=%INSTANCENAME%
+  # run integratie tests voor bgt-gml-loader module (30min)
+  - if "%BGT_ONLY_ITESTS%"=="true" mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "bgt-gml-loader" -Dmssql.instancename=%INSTANCENAME%
   # run integratie tests voor brmo-loader module
-  - mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-loader" -Dmssql.instancename=%INSTANCENAME%
+  - if "%BGT_ONLY_ITESTS%"=="false" mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-loader" -Dmssql.instancename=%INSTANCENAME%
   # run integratie tests voor brmo-service module
-  - mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-service" -Dmssql.instancename=%INSTANCENAME%
+  - if "%BGT_ONLY_ITESTS%"=="false" mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-service" -Dmssql.instancename=%INSTANCENAME%
   # run integratie tests voor brmo-soap module
-  - mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-soap" -Dmssql.instancename=%INSTANCENAME%
+  - if "%BGT_ONLY_ITESTS%"=="false" mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-soap" -Dmssql.instancename=%INSTANCENAME%
   # run integratie tests voor brmo-stufbg204 module
-  - mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-stufbg204" -Dmssql.instancename=%INSTANCENAME%
+  - if "%BGT_ONLY_ITESTS%"=="false" mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-stufbg204" -Dmssql.instancename=%INSTANCENAME%
   # run integratie tests voor brmo-commandline module
-  - mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-commandline" -Dmssql.instancename=%INSTANCENAME%
+  - if "%BGT_ONLY_ITESTS%"=="false" mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-commandline" -Dmssql.instancename=%INSTANCENAME%
 
 cache:
   - C:\Users\appveyor\.m2\repository -> pom.xml
+  - C:\Users\appveyor\downloads -> appveyor.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,10 +35,9 @@ matrix:
 install:
 
   - ps: |
+      Add-Type -AssemblyName System.IO.Compression.FileSystem
       if (!(Test-Path("C:\Users\appveyor\downloads\maven-bin.zip"))) {
-        Add-Type -AssemblyName System.IO.Compression.FileSystem
           (new-object System.Net.WebClient).DownloadFile('https://archive.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.zip', 'C:\Users\appveyor\downloads\maven-bin.zip')
-
       }
       [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\Users\appveyor\downloads\maven-bin.zip", "C:\maven")
   - cmd: SET PATH=C:\maven\apache-maven-3.5.4\bin;%PATH%

--- a/bgt-gml-loader/src/main/java/nl/b3p/brmo/bgt/util/JDBCDataStoreUtil.java
+++ b/bgt-gml-loader/src/main/java/nl/b3p/brmo/bgt/util/JDBCDataStoreUtil.java
@@ -39,20 +39,20 @@ public class JDBCDataStoreUtil {
             if(isOracle) {
                 sql.append(" PURGE MATERIALIZED VIEW LOG REUSE STORAGE");
             }
-            log.debug("SQL: " + sql.toString());
+            log.trace("SQL: " + sql.toString());
             new QueryRunner(dataStore.getDataSource()).update(sql.toString());
             log.info("Tabel leeggemaakt");
             return true;
         } catch(Exception e) {
             log.debug("Exception bij TRUNCATE", e);
-            log.error("Fout bij TRUNCATE, probeer met DELETE FROM: " + e.getClass() + ": " + e.getMessage());
+            log.warn("Fout bij TRUNCATE, probeer met DELETE FROM: " + e.getClass() + ": " + e.getMessage());
 
             try {
                 StringBuffer sql = new StringBuffer("DELETE FROM ");
                 Method encodeTableName = dataStore.getClass().getDeclaredMethod("encodeTableName", String.class, StringBuffer.class, Hints.class);
                 encodeTableName.setAccessible(true);
                 encodeTableName.invoke(dataStore, typeName, sql, null);
-                log.debug("SQL: " + sql.toString());
+                log.trace("SQL: " + sql.toString());
                 new QueryRunner(dataStore.getDataSource()).update(sql.toString());
                 log.info("Tabel leeggemaakt met DELETE FROM");
                 return true;

--- a/bgt-gml-loader/src/test/java/nl/b3p/brmo/bgt/util/PDOKBGTLightUtilTest.java
+++ b/bgt-gml-loader/src/test/java/nl/b3p/brmo/bgt/util/PDOKBGTLightUtilTest.java
@@ -3,49 +3,50 @@
  */
 package nl.b3p.brmo.bgt.util;
 
+import java.util.Set;
 import java.util.TreeSet;
-import nl.b3p.brmo.loader.gml.TestingBase;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import org.junit.Test;
+
+import org.geotools.factory.GeoTools;
+import org.junit.*;
 
 /**
  * Testcases voor {@link PDOKBGTLightUtil}.
  *
  * @author mprins
  */
-public class PDOKBGTLightUtilTest extends TestingBase {
+public class PDOKBGTLightUtilTest {
 
-    private static final Log LOG = LogFactory.getLog(PDOKBGTLightUtilTest.class);
-
+    @BeforeClass
+    public static void initGeotools() {
+        GeoTools.init();
+    }
     /**
      * offline test.
      */
     @Test
     public void calculateGridIdsOfflineTest() {
-        TreeSet<Integer> ids = (TreeSet) PDOKBGTLightUtil.calculateGridIds(
+        Set<Integer> ids = PDOKBGTLightUtil.calculateGridIds(
                 /* dit vlakt overlap met cel 38725 in het testbestand, maar niet met andere cellen */
                 "POLYGON ((143850 487030, 149760 486760, 149470 490950, 143600 491000, 143850 487030))",
                 PDOKBGTLightUtilTest.class.getResource("/geojson/tileinfo.json").toString()
         );
         assertTrue("Er zit 1 element in de lijst met ids", ids.size() == 1);
-        assertEquals("Het element in de lijst met ids is", 38725, ids.first().intValue());
+        assertEquals("Het element in de lijst met ids is", 38725, ids.iterator().next().intValue());
     }
 
     /**
-     * Online test. deze test faalt als het PKI Overheid moeder certificaten
-     * niet is geinstalleerd; zie:
-     * <a href="https://github.com/B3Partners/brmo/wiki/BGTLightOphaalProces#ssl-fouten">BGTLightOphaalProces
-     * ssl-fouten</a>.
+     * Online test.
      */
     @Test
     public void calculateGridIdsOnlineTest() {
-        TreeSet<Integer> ids = (TreeSet) PDOKBGTLightUtil.calculateGridIds(
+        TreeSet<Integer> ids = (TreeSet<Integer>) PDOKBGTLightUtil.calculateGridIds(
                 /* dit is de geometrie van grid cel 38725 */
                 "POLYGON ((146000 488000, 148000 488000, 148000 490000, 146000 490000, 146000 488000))",
-                "https://www.pdok.nl/download/service/tileinfo.json?dataset=bgt&format=citygml"
+                "http://files.b3p.nl/brmo/bgt/tileinfo.geojson"
         );
         assertTrue("Er zitten 9 elementen in de lijst met ids", ids.size() == 9);
         assertEquals("Het element in de lijst met ids is", 38382, ids.first().intValue());

--- a/bgt-gml-loader/src/test/java/nl/b3p/brmo/loader/gml/BGTGMLLightLoaderIntegrationTest.java
+++ b/bgt-gml-loader/src/test/java/nl/b3p/brmo/loader/gml/BGTGMLLightLoaderIntegrationTest.java
@@ -130,6 +130,7 @@ public class BGTGMLLightLoaderIntegrationTest extends TestingBase {
      */
     @Test
     public void testProcessOutOFTimeGMLFile() throws Exception {
+        // bevat 1 historisch record en 1 toekomstig record
         File gml = new File(BGTGMLLightLoaderIntegrationTest.class.getResource("/gmllight/outoftime/bgt_onbegroeidterreindeel.gml").toURI());
         assertEquals("Aantal geschreven features", 1, ldr.processGMLFile(gml));
     }

--- a/bgt-gml-loader/src/test/java/nl/b3p/brmo/loader/gml/TestingBase.java
+++ b/bgt-gml-loader/src/test/java/nl/b3p/brmo/loader/gml/TestingBase.java
@@ -167,7 +167,7 @@ public abstract class TestingBase {
                 ResultSet res = connection.getMetaData().getTables(null, params.getProperty("schema"), tableName, new String[]{"TABLE"});
                 if (res.next()) {
                     String sql = "DROP TABLE \"" + params.getProperty("schema") + "\".\"" + tableName + "\"";
-                    LOG.info("Droppen tabel: " + tableName + " met sql: " + sql);
+                    LOG.trace("Droppen tabel: " + tableName + " met sql: " + sql);
                     try {
                         connection.createStatement().executeUpdate(sql);
                     } catch (SQLException se) {
@@ -195,7 +195,7 @@ public abstract class TestingBase {
                 ResultSet res = connection.getMetaData().getTables(null, params.getProperty("schema"), tableName, new String[]{"TABLE"});
                 if (res.next()) {
                     String sql = "SELECT COUNT(*) FROM \"" + params.getProperty("schema") + "\".\"" + tableName + "\"";
-                    LOG.info("count tabel: " + tableName + " met sql: " + sql);
+                    LOG.trace("count tabel: " + tableName + " met sql: " + sql);
                     try (ResultSet c = connection.createStatement().executeQuery(sql)) {
                         c.next();
                         counts.put(tableName, c.getLong(1));
@@ -205,7 +205,7 @@ public abstract class TestingBase {
             }
         }
         for (Map.Entry<String, Long> count : counts.entrySet()) {
-            LOG.info("tabel: '" + count.getKey() + "', aantal geteld: " + count.getValue());
+            LOG.info("tabel: '" + count.getKey() + "', aantal features geteld: " + count.getValue());
         }
         return counts;
     }

--- a/bgt-gml-loader/src/test/resources/log4j.xml
+++ b/bgt-gml-loader/src/test/resources/log4j.xml
@@ -25,6 +25,9 @@ LEVELS: debug, info, warn, error, fatal en off, all -->
     <logger name="nl.b3p.brmo.loader.gml">
         <level value="info" />
     </logger>
+    <logger name="nl.b3p.brmo.bgt.util">
+        <level value="warn" />
+    </logger>
     <root>
         <level value="info" />
         <appender-ref ref="consoleAppender" />

--- a/brmo-loader/src/test/java/nl/b3p/GH527NhrToStagingToRsgbIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/GH527NhrToStagingToRsgbIntegrationTest.java
@@ -122,9 +122,9 @@ public class GH527NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseInte
         assumeNotNull("Het test bestand moet er zijn.", GH527NhrToStagingToRsgbIntegrationTest.class.getResource(bestandNaam));
 
         brmo.loadFromFile("nhr", GH527NhrToStagingToRsgbIntegrationTest.class.getResource(bestandNaam).getFile());
-        LOG.debug("klaar met laden van berichten in staging DB.");
+        LOG.info("klaar met laden van berichten in staging DB.");
 
-        LOG.debug("Transformeren berichten naar rsgb DB.");
+        LOG.info("Transformeren berichten naar rsgb DB.");
         Thread t = brmo.toRsgb();
         t.join();
 

--- a/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
@@ -230,7 +230,7 @@ public class NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
         assumeNotNull("Het test bestand moet er zijn.", NhrToStagingToRsgbIntegrationTest.class.getResource(bestandNaam));
 
         brmo.loadFromFile(BESTANDTYPE, NhrToStagingToRsgbIntegrationTest.class.getResource(bestandNaam).getFile());
-        LOG.debug("klaar met laden van berichten in staging DB.");
+        LOG.info("klaar met laden van berichten in staging DB.");
 
         List<Bericht> berichten = brmo.listBerichten();
         List<LaadProces> processen = brmo.listLaadProcessen();
@@ -239,7 +239,7 @@ public class NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
         assertNotNull("De verzameling processen bestaat niet.", processen);
         assertEquals("Het aantal processen is niet als verwacht.", aantalProcessen, processen.size());
 
-        LOG.debug("Transformeren berichten naar rsgb DB.");
+        LOG.info("Transformeren berichten naar rsgb DB.");
         Thread t = brmo.toRsgb();
         t.join();
 

--- a/brmo-loader/src/test/resources/log4j.xml
+++ b/brmo-loader/src/test/resources/log4j.xml
@@ -23,7 +23,7 @@
         <level value="info" />
     </logger>
    <logger name="nl.b3p">
-        <level value="debug" />
+        <level value="info" />
     </logger>
     <logger name="nl.b3p.brmo">
         <level value="info" />


### PR DESCRIPTION
Vanwege timeouts van de build jobs (>1 uur) op AppVeyor jobs uitsplitsen.

- [x] probeer bgt integratie tests als aparte job op AppVeyor te bouwen
- [x] (test) logging aanpassingen 
- [x] gebruik actuele maven versie