### PR TITLE
Bijwerken van gemeente-woonplaats koppeling met de stand van 20181008

### DIFF
--- a/datamodel/pom.xml
+++ b/datamodel/pom.xml
@@ -14,7 +14,7 @@
     <description>Bevat de code voor het genereren van het RSGB datamodel.</description>
     <properties>
         <filename.base.201_update_wnplts_gemcode>201_update_wnplts_gemcode</filename.base.201_update_wnplts_gemcode>
-        <filename.GEM-WPL-zipfile>GEM-WPL-RELATIE-08092018.zip</filename.GEM-WPL-zipfile>
+        <filename.GEM-WPL-zipfile>GEM-WPL-RELATIE-08102018.zip</filename.GEM-WPL-zipfile>
     </properties>
     <build>
         <defaultGoal>process-resources</defaultGoal>
@@ -223,7 +223,7 @@
                 <file>
                     <!-- dit profiel wordt geactiveerd als dit bestand, dat de
                          input voor het proces is, bestaat -->
-                    <exists>${bas$edir}/referentiedata/${filename.GEM-WPL-zipfile}</exists>
+                    <exists>${basedir}/referentiedata/${filename.GEM-WPL-zipfile}</exists>
                 </file>
             </activation>
             <build>

--- a/datamodel/utility_scripts/oracle/201_update_wnplts_gemcode.sql
+++ b/datamodel/utility_scripts/oracle/201_update_wnplts_gemcode.sql
@@ -1,6 +1,6 @@
 -- Update gemeente/woonplaats relatie koppelscript
--- Gegenereerd op: 2018-01-16T17:28:55.268+01:00
--- StandTechnischeDatum van bronbestand: 20180108
+-- Gegenereerd op: 2018-11-06T14:31:45.546+01:00
+-- StandTechnischeDatum van bronbestand: 20181008
 UPDATE wnplts SET fk_7gem_code = 3 WHERE identif = '3386';
 UPDATE wnplts SET fk_7gem_code = 5 WHERE identif = '2829';
 UPDATE wnplts SET fk_7gem_code = 5 WHERE identif = '2830';

--- a/datamodel/utility_scripts/postgresql/201_update_wnplts_gemcode.sql
+++ b/datamodel/utility_scripts/postgresql/201_update_wnplts_gemcode.sql
@@ -1,6 +1,6 @@
 -- Update gemeente/woonplaats relatie koppelscript
--- Gegenereerd op: 2018-01-16T17:28:55.268+01:00
--- StandTechnischeDatum van bronbestand: 20180108
+-- Gegenereerd op: 2018-11-06T14:31:45.546+01:00
+-- StandTechnischeDatum van bronbestand: 20181008
 UPDATE wnplts SET fk_7gem_code = 3 WHERE identif = '3386';
 UPDATE wnplts SET fk_7gem_code = 5 WHERE identif = '2829';
 UPDATE wnplts SET fk_7gem_code = 5 WHERE identif = '2830';

--- a/datamodel/utility_scripts/sqlserver/201_update_wnplts_gemcode.sql
+++ b/datamodel/utility_scripts/sqlserver/201_update_wnplts_gemcode.sql
@@ -1,6 +1,6 @@
 -- Update gemeente/woonplaats relatie koppelscript
--- Gegenereerd op: 2018-01-16T17:28:55.268+01:00
--- StandTechnischeDatum van bronbestand: 20180108
+-- Gegenereerd op: 2018-11-06T14:31:45.546+01:00
+-- StandTechnischeDatum van bronbestand: 20181008
 UPDATE wnplts SET fk_7gem_code = 3 WHERE identif = '3386';
 UPDATE wnplts SET fk_7gem_code = 5 WHERE identif = '2829';
 UPDATE wnplts SET fk_7gem_code = 5 WHERE identif = '2830';


### PR DESCRIPTION
Er lijken geen aanpassingen te zijn in de koppeling (niet onverwacht, immers gemeentelijke herindeling is meestal per 1 januari)