### PR TITLE
Aanpassing van materialized views zodat opbouw sneller gaat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,11 @@ matrix:
     env: 
       - PG_VERSION=""
       - PROFILE="mssql -Dmssql.instancename=''"
+  - name: "database upgrades"
+    jdk: oraclejdk8
+    sudo: required
+    env: 
+      - PROFILE="postgresql -Dupgrade=true"
 
 cache:
   directories:
@@ -97,6 +102,8 @@ before_script:
   - if [ "$PROFILE" == "postgresql" ]; then
        sh ".travis/setup-pgsql.sh";
        sh ".jenkins/data-prepare-topnl.sh";
+    elif  [ "$PROFILE" == "postgresql -Dupgrade=true" ]; then
+       sh ".travis/setup-old-pgsql.sh";
     else
        sh ".travis/setup-mssql.sh";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,15 +112,15 @@ before_script:
 
 script:
   # run unit tests voor alle modules mits actuele postgresql
-  #- if [ "$PROFILE" == "postgresql" ] && [ "$PG_VERSION" != "9.3" ]; then
-  - travis_wait 20 mvn --settings .travis/settings.xml -e test -B -Pstandard-with-extra-repos,$PROFILE -pl '!brmo-dist' -Dtest.onlyITs=false;
-  #  fi
+  - if [ "$PROFILE" != "postgresql -Dupgrade=true" ]; then
+       travis_wait 20 mvn --settings .travis/settings.xml -e test -B -Pstandard-with-extra-repos,$PROFILE -pl '!brmo-dist' -Dtest.onlyITs=false;
+    fi
   # run integratie tests voor veschillende modules, per module
   - if  [ "$PROFILE" == "postgresql -Dupgrade=true" ]; then
-      sh ".travis/execute-upgrades-pgsql.sh staging";
-      sh ".travis/execute-upgrades-pgsql.sh rsgb";
-      sh ".travis/execute-upgrades-pgsql.sh rsgbbgt";
-      mvn -e -B -P$PROFILE -pl 'datamodel' resources:testResources compiler:testCompile surefire:test;
+        .travis/execute-upgrades-pgsql.sh staging;
+        .travis/execute-upgrades-pgsql.sh rsgb;
+        .travis/execute-upgrades-pgsql.sh rsgbbgt;
+        mvn -e -B -P$PROFILE -pl 'datamodel' resources:testResources compiler:testCompile surefire:test;
     fi
   # run integratie tests voor brmo-loader module
   - echo 'integratie tests voor brmo-loader module'

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
   - name: "database upgrades"
     jdk: openjdk8
     env: 
-      - PROFILE="postgresql -Dupgrade=true"
+      - PROFILE="postgresql -Ddatabase.upgrade=true"
 
 cache:
   directories:
@@ -72,7 +72,7 @@ before_install:
   - export PAGER=cat
   - if [ "$PROFILE" == "postgresql" ]; then
        sh ".travis/install-pgsql.sh";
-    elif  [ "$PROFILE" == "postgresql -Dupgrade=true" ]; then
+    elif  [ "$PROFILE" == "postgresql -Ddatabase.upgrade=true" ]; then
        sh ".travis/getlastRelease.sh";
        sh ".travis/install-pgsql.sh";
     else
@@ -104,7 +104,7 @@ before_script:
   - if [ "$PROFILE" == "postgresql" ]; then
        sh ".travis/setup-pgsql.sh";
        sh ".jenkins/data-prepare-topnl.sh";
-    elif  [ "$PROFILE" == "postgresql -Dupgrade=true" ]; then
+    elif  [ "$PROFILE" == "postgresql -Ddatabase.upgrade=true" ]; then
        sh ".travis/setup-old-pgsql.sh";
     else
        sh ".travis/setup-mssql.sh";
@@ -112,11 +112,11 @@ before_script:
 
 script:
   # run unit tests voor alle modules mits actuele postgresql
-  - if [ "$PROFILE" != "postgresql -Dupgrade=true" ]; then
+  - if [ "$PROFILE" != "postgresql -Ddatabase.upgrade=true" ]; then
        travis_wait 20 mvn --settings .travis/settings.xml -e test -B -Pstandard-with-extra-repos,$PROFILE -pl '!brmo-dist' -Dtest.onlyITs=false;
     fi
   # run integratie tests voor veschillende modules, per module
-  - if  [ "$PROFILE" == "postgresql -Dupgrade=true" ]; then
+  - if  [ "$PROFILE" == "postgresql -Ddatabase.upgrade=true" ]; then
         .travis/execute-upgrades-pgsql.sh staging;
         .travis/execute-upgrades-pgsql.sh rsgb;
         .travis/execute-upgrades-pgsql.sh rsgbbgt;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
   postgresql: 9.6
   apt:
     packages:
-      - postgresql-9.6-postgis-2.4
+      - postgresql-9.6-postgis-2.3
       - graphviz
   hostname: travis-brmo
   hosts: travis-brmo
@@ -73,6 +73,7 @@ before_install:
   - if [ "$PROFILE" == "postgresql" ]; then
        sh ".travis/install-pgsql.sh";
     elif  [ "$PROFILE" == "postgresql -Dupgrade=true" ]; then
+       sh ".travis/getlastRelease.sh";
        sh ".travis/install-pgsql.sh";
     else
        sudo service postgresql stop;
@@ -115,6 +116,12 @@ script:
   - travis_wait 20 mvn --settings .travis/settings.xml -e test -B -Pstandard-with-extra-repos,$PROFILE -pl '!brmo-dist' -Dtest.onlyITs=false;
   #  fi
   # run integratie tests voor veschillende modules, per module
+  - if  [ "$PROFILE" == "postgresql -Dupgrade=true" ]; then
+      sh ".travis/execute-upgrades-pgsql.sh staging";
+      sh ".travis/execute-upgrades-pgsql.sh rsgb";
+      sh ".travis/execute-upgrades-pgsql.sh rsgbbgt";
+      mvn -e -B -P$PROFILE -pl 'datamodel' resources:testResources compiler:testCompile surefire:test;
+    fi
   # run integratie tests voor brmo-loader module
   - echo 'integratie tests voor brmo-loader module'
   - travis_wait 40 mvn -e verify -B -P$PROFILE -Dtest.onlyITs=true -pl 'brmo-loader'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
   postgresql: 9.6
   apt:
     packages:
-      - postgresql-9.6-postgis-2.3
+      - postgresql-9.6-postgis-2.4
       - graphviz
   hostname: travis-brmo
   hosts: travis-brmo
@@ -50,8 +50,7 @@ matrix:
       - PG_VERSION=""
       - PROFILE="mssql -Dmssql.instancename=''"
   - name: "database upgrades"
-    jdk: oraclejdk8
-    sudo: required
+    jdk: openjdk8
     env: 
       - PROFILE="postgresql -Dupgrade=true"
 
@@ -73,6 +72,8 @@ before_install:
   - export PAGER=cat
   - if [ "$PROFILE" == "postgresql" ]; then
        sh ".travis/install-pgsql.sh";
+    elif  [ "$PROFILE" == "postgresql -Dupgrade=true" ]; then
+       sh ".travis/install-pgsql.sh";
     else
        sudo service postgresql stop;
        sh ".travis/install-mssql.sh";
@@ -84,7 +85,7 @@ before_install:
 
 install:
   # install all dependencies + artifacts and create any DB scripts without any testing
-  - travis_wait 20 mvn install -Dmaven.test.skip=true -Dtest.onlyITs= -B -V -fae -P$PROFILE,standard-with-extra-repos
+  - travis_wait 20 mvn install -Dmaven.test.skip=true -Dtest.onlyITs= -B -V -fae -Pstandard-with-extra-repos,$PROFILE
   - projectversion=$(grep "<version>.*<.version>" -m1 pom.xml | sed -e "s/^.*<version/<version/" | cut -f2 -d">"| cut -f1 -d"<")
   - echo $projectversion
   - export PROJECTVERSION=$projectversion
@@ -111,7 +112,7 @@ before_script:
 script:
   # run unit tests voor alle modules mits actuele postgresql
   #- if [ "$PROFILE" == "postgresql" ] && [ "$PG_VERSION" != "9.3" ]; then
-  - travis_wait 20 mvn --settings .travis/settings.xml -e test -B -P$PROFILE,standard-with-extra-repos -pl '!brmo-dist' -Dtest.onlyITs=false;
+  - travis_wait 20 mvn --settings .travis/settings.xml -e test -B -Pstandard-with-extra-repos,$PROFILE -pl '!brmo-dist' -Dtest.onlyITs=false;
   #  fi
   # run integratie tests voor veschillende modules, per module
   # run integratie tests voor brmo-loader module

--- a/.travis/execute-upgrades-pgsql.sh
+++ b/.travis/execute-upgrades-pgsql.sh
@@ -8,4 +8,4 @@ PREVRELEASE=$MAJOR.$PREVMINOR
 
 echo "Huidige snapshot:" $CURSNAPSHOT", vorige release: "$PREVRELEASE", komende release: "$NEXTRELEASE
 
-psql -U postgres -d $1 -f ./old/db//upgrade_scripts/$PREVRELEASE-$NEXTRELEASE/postgresql/$1.sql
+psql -U postgres -d $1 -f ./datamodel/upgrade_scripts/$PREVRELEASE-$NEXTRELEASE/postgresql/$1.sql

--- a/.travis/execute-upgrades-pgsql.sh
+++ b/.travis/execute-upgrades-pgsql.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+CURSNAPSHOT=$(grep "<version>.*<.version>" -m1 pom.xml | sed -e "s/^.*<version/<version/" | cut -f2 -d">"| cut -f1 -d"<")
+NEXTRELEASE="${CURSNAPSHOT%-SNAPSHOT}"
+MAJOR="${CURSNAPSHOT%.*}"
+MINOR="${NEXTRELEASE##*.}"
+PREVMINOR=$(($MINOR-1))
+PREVRELEASE=$MAJOR.$PREVMINOR
+
+echo "Huidige snapshot:" $CURSNAPSHOT", vorige release: "$PREVRELEASE", komende release: "$NEXTRELEASE
+
+psql -U postgres -d $1 -f ./old/db//upgrade_scripts/$PREVRELEASE-$NEXTRELEASE/postgresql/$1.sql

--- a/.travis/getlastRelease.sh
+++ b/.travis/getlastRelease.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+CURSNAPSHOT=$(grep "<version>.*<.version>" -m1 pom.xml | sed -e "s/^.*<version/<version/" | cut -f2 -d">"| cut -f1 -d"<")
+
+NEXTRELEASE="${CURSNAPSHOT%-SNAPSHOT}"
+
+MAJOR="${CURSNAPSHOT%.*}"
+
+MINOR="${NEXTRELEASE##*.}"
+
+PREVMINOR=$(($MINOR-1))
+
+PREVRELEASE=$MAJOR.$PREVMINOR
+
+echo "Huidige snapshot:" $CURSNAPSHOT", vorige release: "$PREVRELEASE", komende release: "$NEXTRELEASE
+
+wget -nc --no-verbose --tries=5 --timeout=60 --waitretry=300 --user-agent="" "https://repo.b3p.nl/nexus/repository/releases/nl/b3p/brmo-dist/$PREVRELEASE/brmo-dist-$PREVRELEASE-bin.zip"  --output-document="$HOME/downloads/brmo-dist-old.zip"
+
+unzip -o $HOME/downloads/brmo-dist-old.zip -d ./old *.sql

--- a/.travis/setup-old-pgsql.sh
+++ b/.travis/setup-old-pgsql.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+# set up staging db
+psql -U postgres -d staging -f ./old/db/staging/create-brmo-persistence-postgresql.sql
+psql -U postgres -d staging -f ./old/db/staging/01_create_indexes.sql
+psql -U postgres -d staging -f ./old/db/staging/02_insert_default_user.sql
+psql -U postgres -d staging -f ./old/db/staging/05_create_brmo_metadata_postgresql.sql
+# set up rsgb tabellen
+psql -U postgres -w -q -d rsgb -f ./old/db/rsgb/datamodel_postgresql.sql
+# set up rsgbbgt tabellen
+psql -U postgres -w -q -d rsgbbgt -f ./old/db/rsgbbgt/postgresql/create_rsgb_bgt.sql
+# set up topnl tabellen
+psql -U postgres -w -q -d topnl -f ./old/db/topnl/postgres.sql

--- a/brmo-loader/pom.xml
+++ b/brmo-loader/pom.xml
@@ -197,6 +197,7 @@
                             <systemPropertyVariables>
                                 <database.properties.file>postgis.properties</database.properties.file>
                                 <project.version>${project.version}</project.version>
+                                <database.upgrade>${database.upgrade}</database.upgrade>
                             </systemPropertyVariables>
                             <excludedGroups>nl.b3p.brmo.test.util.database.PostgreSQLDriverBasedFailures</excludedGroups>
                         </configuration>

--- a/brmo-loader/src/test/java/nl/b3p/brmo/loader/BrmoFrameworkIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/brmo/loader/BrmoFrameworkIntegrationTest.java
@@ -26,6 +26,9 @@ public class BrmoFrameworkIntegrationTest extends AbstractDatabaseIntegrationTes
     @BeforeClass
     public static void getEnvironment() {
         currentVersion = System.getProperty("project.version");
+        if ("true".equalsIgnoreCase(System.getProperty("database.upgrade"))) {
+            currentVersion = currentVersion.replace("-SNAPSHOT", "");
+        }
     }
 
     private BrmoFramework brmo;

--- a/datamodel/extra_scripts/oracle/207_brk_views.sql
+++ b/datamodel/extra_scripts/oracle/207_brk_views.sql
@@ -1166,14 +1166,125 @@ ON
             zrr.koz_identif = koz.koz_identif)));
 
 --drop materialized view mb_koz_rechth cascade;
-CREATE MATERIALIZED VIEW mb_koz_rechth 
-BUILD DEFERRED
-REFRESH ON DEMAND
-AS
+CREATE MATERIALIZED VIEW mb_koz_rechth
+    (
+        objectid,
+        koz_identif,
+        begin_geldigheid,
+        type,
+        aanduiding,
+        aanduiding2,
+        sectie,
+        perceelnummer,
+        appartementsindex,
+        gemeentecode,
+        aand_soort_grootte,
+        grootte_perceel,
+        oppervlakte_geom,
+        deelperceelnummer,
+        omschr_deelperceel,
+        verkoop_datum,
+        aard_cultuur_onbebouwd,
+        bedrag,
+        koopjaar,
+        meer_onroerendgoed,
+        valutasoort,
+        loc_omschr,
+        zr_identif,
+        subject_identif,
+        aandeel,
+        omschr_aard_verkregenr_recht,
+        indic_betrokken_in_splitsing,
+        soort,
+        geslachtsnaam,
+        voorvoegsel,
+        voornamen,
+        aand_naamgebruik,
+        geslachtsaand,
+        naam,
+        woonadres,
+        geboortedatum,
+        geboorteplaats,
+        overlijdensdatum,
+        bsn,
+        organisatie_naam,
+        rechtsvorm,
+        statutaire_zetel,
+        rsin,
+        kvk_nummer,
+        gemeente,
+        woonplaats,
+        straatnaam,
+        huisnummer,
+        huisletter,
+        huisnummer_toev,
+        postcode,
+        lon,
+        lat,
+        begrenzing_perceel
+    )
+BUILD DEFERRED REFRESH ON DEMAND AS
 SELECT
-    *
+    CAST(ROWNUM AS INTEGER) AS objectid,
+    koz.koz_identif,
+    koz.begin_geldigheid,
+    koz.type,
+    COALESCE(koz.sectie, '') || ' ' || COALESCE(koz.perceelnummer, '') AS aanduiding,
+    COALESCE(koz.gemeentecode, '') || ' ' || COALESCE(koz.sectie, '') || ' ' || COALESCE(koz.perceelnummer, '') || ' ' || COALESCE(koz.appartementsindex, '') AS aanduiding2,
+    koz.sectie,
+    koz.perceelnummer,
+    koz.appartementsindex,
+    koz.gemeentecode,
+    koz.aand_soort_grootte,
+    koz.grootte_perceel,
+    koz.oppervlakte_geom as oppervlakte_geom,
+    koz.deelperceelnummer,
+    koz.omschr_deelperceel,
+    koz.verkoop_datum,
+    koz.aard_cultuur_onbebouwd,
+    koz.bedrag,
+    koz.koopjaar,
+    koz.meer_onroerendgoed,
+    koz.valutasoort,
+    koz.loc_omschr,
+    zrr.zr_identif,
+    zrr.subject_identif,
+    zrr.aandeel,
+    zrr.omschr_aard_verkregenr_recht,
+    zrr.indic_betrokken_in_splitsing,
+    zrr.soort,
+    zrr.geslachtsnaam,
+    zrr.voorvoegsel,
+    zrr.voornamen,
+    zrr.aand_naamgebruik,
+    zrr.geslachtsaand,
+    zrr.naam,
+    zrr.woonadres,
+    zrr.geboortedatum,
+    zrr.geboorteplaats,
+    zrr.overlijdensdatum,
+    zrr.bsn,
+    zrr.organisatie_naam,
+    zrr.rechtsvorm,
+    zrr.statutaire_zetel,
+    zrr.rsin,
+    zrr.kvk_nummer,
+    koz.gemeente,
+    koz.woonplaats,
+    koz.straatnaam,
+    koz.huisnummer,
+    koz.huisletter,
+    koz.huisnummer_toev,
+    koz.postcode,
+    koz.lon,
+    koz.lat,
+    koz.begrenzing_perceel
 FROM
-    vb_koz_rechth;
+    vb_zr_rechth zrr
+RIGHT JOIN
+    mb_kad_onrrnd_zk_adres koz
+ON
+    zrr.koz_identif = koz.koz_identif;
 CREATE UNIQUE INDEX MB_KOZ_RECHTH_OBJECTID ON MB_KOZ_RECHTH(OBJECTID ASC);
 CREATE INDEX MB_KOZ_RECHTH_IDENTIF ON MB_KOZ_RECHTH(KOZ_IDENTIF ASC);
 INSERT INTO USER_SDO_GEOM_METADATA VALUES ('MB_KOZ_RECHTH', 'BEGRENZING_PERCEEL', MDSYS.SDO_DIM_ARRAY(MDSYS.SDO_DIM_ELEMENT('X', 12000, 280000, .1),MDSYS.SDO_DIM_ELEMENT('Y', 304000, 620000, .1)), 28992);

--- a/datamodel/extra_scripts/postgresql/207_brk_views.sql
+++ b/datamodel/extra_scripts/postgresql/207_brk_views.sql
@@ -1171,10 +1171,65 @@ beschikbare kolommen:
     ;
 --drop materialized view mb_koz_rechth cascade;
 CREATE MATERIALIZED VIEW mb_koz_rechth AS
-SELECT
-    *
-FROM
-    vb_koz_rechth WITH NO DATA;
+ SELECT
+    row_number() OVER()::integer AS objectid,
+    koz.koz_identif,
+    koz.begin_geldigheid,
+    koz.type,
+    (COALESCE(koz.sectie, ''::character varying)::text || ' '::text) || COALESCE(koz.perceelnummer, ''::character varying)::text AS aanduiding,
+    (((((COALESCE(koz.gemeentecode, ''::character varying)::text || ' '::text) || COALESCE(koz.sectie, ''::character varying)::text) || ' '::text) || COALESCE(koz.perceelnummer, ''::character varying)::text) || ' '::text) || COALESCE(koz.appartementsindex, ''::character varying)::text AS aanduiding2,
+    koz.sectie,
+    koz.perceelnummer,
+    koz.appartementsindex,
+    koz.gemeentecode,
+    koz.aand_soort_grootte,
+    koz.grootte_perceel,
+    koz.oppervlakte_geom,
+    koz.deelperceelnummer,
+    koz.omschr_deelperceel,
+    koz.verkoop_datum,
+    koz.aard_cultuur_onbebouwd,
+    koz.bedrag,
+    koz.koopjaar,
+    koz.meer_onroerendgoed,
+    koz.valutasoort,
+    koz.loc_omschr,
+    zrr.zr_identif,
+    zrr.subject_identif,
+    zrr.aandeel,
+    zrr.omschr_aard_verkregenr_recht,
+    zrr.indic_betrokken_in_splitsing,
+    zrr.soort,
+    zrr.geslachtsnaam,
+    zrr.voorvoegsel,
+    zrr.voornamen,
+    zrr.aand_naamgebruik,
+    zrr.geslachtsaand,
+    zrr.naam,
+    zrr.woonadres,
+    zrr.geboortedatum,
+    zrr.geboorteplaats,
+    zrr.overlijdensdatum,
+    zrr.bsn,
+    zrr.organisatie_naam,
+    zrr.rechtsvorm,
+    zrr.statutaire_zetel,
+    zrr.rsin,
+    zrr.kvk_nummer,
+    koz.gemeente,
+    koz.woonplaats,
+    koz.straatnaam,
+    koz.huisnummer,
+    koz.huisletter,
+    koz.huisnummer_toev,
+    koz.postcode,
+    koz.lon,
+    koz.lat,
+    koz.begrenzing_perceel
+   FROM vb_zr_rechth zrr
+     RIGHT JOIN mb_kad_onrrnd_zk_adres koz ON zrr.koz_identif = koz.koz_identif
+WITH NO DATA;
+
 CREATE UNIQUE INDEX mb_koz_rechth_objectid ON mb_koz_rechth USING btree (objectid);
 CREATE INDEX mb_koz_rechth_identif ON mb_koz_rechth USING btree (koz_identif);
 CREATE INDEX mb_koz_rechth_begrenzing_perceel_idx ON mb_koz_rechth USING gist (begrenzing_perceel);

--- a/datamodel/extra_scripts/postgresql/207_brk_views.sql
+++ b/datamodel/extra_scripts/postgresql/207_brk_views.sql
@@ -447,6 +447,25 @@ beschikbare kolommen:
 
 '
     ;
+
+-- DROP MATERIALIZED VIEW mb_util_app_re_kad_perceel cascade;
+CREATE MATERIALIZED VIEW mb_util_app_re_kad_perceel AS
+SELECT
+   u1.app_re_identif,
+   kp.sc_kad_identif AS perceel_identif
+FROM vb_util_app_re_parent u1
+JOIN kad_perceel kp ON u1.parent_identif = kp.sc_kad_identif::text
+GROUP BY u1.app_re_identif, kp.sc_kad_identif;
+
+COMMENT ON VIEW mb_util_app_re_kad_perceel
+IS 'commentaar view mb_util_app_re_kad_perceel:
+utility view, niet bedoeld voor direct gebruik, met lijst van appartementsrechten met bijbehorend grondperceel
+
+beschikbare kolommen:
+* app_re_identif: natuurlijk is van appartementsrecht,
+* perceel_identif: natuurlijk id van grondperceel
+';
+CREATE INDEX mb_util_app_re_kad_perceel_identif ON mb_util_app_re_kad_perceel USING btree (app_re_identif);
     
 --drop view vb_kad_onrrnd_zk_adres cascade;
 CREATE OR REPLACE VIEW
@@ -631,12 +650,78 @@ beschikbare kolommen:
 * begrenzing_perceel: perceelvlak
 '
     ;
---drop materialized view mb_kad_onrrnd_zk_adres cascade;
+DROP MATERIALIZED VIEW mb_kad_onrrnd_zk_adres;
 CREATE MATERIALIZED VIEW mb_kad_onrrnd_zk_adres AS
-SELECT
-    *
-FROM
-    vb_kad_onrrnd_zk_adres WITH NO DATA;
+ SELECT row_number() OVER ()::integer AS objectid,
+    qry.identif AS koz_identif,
+    koz.dat_beg_geldh AS begin_geldigheid,
+    bok.fk_nn_lh_tgo_identif AS benoemdobj_identif,
+    qry.type,
+    (COALESCE(qry.ka_sectie, ''::character varying)::text || ' '::text) || COALESCE(qry.ka_perceelnummer, ''::character varying)::text AS aanduiding,
+    (((((COALESCE(qry.ka_kad_gemeentecode, ''::character varying)::text || ' '::text) || COALESCE(qry.ka_sectie, ''::character varying)::text) || ' '::text) || COALESCE(qry.ka_perceelnummer, ''::character varying)::text) || ' '::text) || COALESCE(qry.ka_appartementsindex, ''::character varying)::text AS aanduiding2,
+    qry.ka_sectie AS sectie,
+    qry.ka_perceelnummer AS perceelnummer,
+    qry.ka_appartementsindex AS appartementsindex,
+    qry.ka_kad_gemeentecode AS gemeentecode,
+    qry.aand_soort_grootte,
+    qry.grootte_perceel,
+    st_area(qry.begrenzing_perceel) AS oppervlakte_geom,
+    qry.ka_deelperceelnummer AS deelperceelnummer,
+    qry.omschr_deelperceel,
+    b.datum AS verkoop_datum,
+    koz.cu_aard_cultuur_onbebouwd AS aard_cultuur_onbebouwd,
+    koz.ks_bedrag AS bedrag,
+    koz.ks_koopjaar AS koopjaar,
+    koz.ks_meer_onroerendgoed AS meer_onroerendgoed,
+    koz.ks_valutasoort AS valutasoort,
+    koz.lo_loc__omschr AS loc_omschr,
+    bola.gemeente,
+    bola.woonplaats,
+    bola.straatnaam,
+    bola.huisnummer,
+    bola.huisletter,
+    bola.huisnummer_toev,
+    bola.postcode,
+    st_x(st_transform(st_setsrid(st_centroid(qry.begrenzing_perceel), 28992), 4326)) AS lon,
+    st_y(st_transform(st_setsrid(st_centroid(qry.begrenzing_perceel), 28992), 4326)) AS lat,
+    qry.begrenzing_perceel
+   FROM ( SELECT p.sc_kad_identif AS identif,
+            'perceel'::character varying(11) AS type,
+            p.ka_sectie,
+            p.ka_perceelnummer,
+            NULL::character varying(4) AS ka_appartementsindex,
+            p.ka_kad_gemeentecode,
+            p.aand_soort_grootte,
+            p.grootte_perceel,
+            p.ka_deelperceelnummer,
+            p.omschr_deelperceel,
+            p.begrenzing_perceel
+           FROM kad_perceel p
+        UNION ALL
+         SELECT ar.sc_kad_identif AS identif,
+            'appartement'::character varying(11) AS type,
+            ar.ka_sectie,
+            ar.ka_perceelnummer,
+            ar.ka_appartementsindex,
+            ar.ka_kad_gemeentecode,
+            NULL::character varying(1) AS aand_soort_grootte,
+            NULL::numeric(8,0) AS grootte_perceel,
+            NULL::character varying(4) AS ka_deelperceelnummer,
+            NULL::character varying(1120) AS omschr_deelperceel,
+            kp.begrenzing_perceel
+           FROM mb_util_app_re_kad_perceel v
+             JOIN kad_perceel kp ON v.perceel_identif = kp.sc_kad_identif
+             JOIN app_re ar ON v.app_re_identif::numeric = ar.sc_kad_identif) qry
+     JOIN kad_onrrnd_zk koz ON koz.kad_identif = qry.identif
+     LEFT JOIN benoemd_obj_kad_onrrnd_zk bok ON bok.fk_nn_rh_koz_kad_identif = qry.identif
+     LEFT JOIN mb_benoemd_obj_adres bola ON bok.fk_nn_lh_tgo_identif::text = bola.benoemdobj_identif::text
+     LEFT JOIN ( SELECT brondocument.ref_id,
+            max(brondocument.datum) AS datum
+           FROM brondocument
+          WHERE brondocument.omschrijving::text = 'Akte van Koop en Verkoop'::text
+          GROUP BY brondocument.ref_id) b ON koz.kad_identif::text = b.ref_id::text
+ WITH NO DATA;
+
 CREATE UNIQUE INDEX mb_kad_onrrnd_zk_adres_objectid ON mb_kad_onrrnd_zk_adres USING btree (objectid);
 CREATE INDEX mb_kad_onrrnd_zk_adres_identif ON mb_kad_onrrnd_zk_adres USING btree (koz_identif);
 CREATE INDEX mb_kad_onrrnd_zk_adres_begrenzing_perceel_idx ON mb_kad_onrrnd_zk_adres USING gist (begrenzing_perceel);
@@ -1278,12 +1363,66 @@ beschikbare kolommen:
 * begrenzing_perceel: perceelvlak
 '
     ;
---drop materialized view mb_avg_koz_rechth cascade;
+--DROP MATERIALIZED VIEW mb_avg_koz_rechth cascade;
 CREATE MATERIALIZED VIEW mb_avg_koz_rechth AS
-SELECT
-    *
-FROM
-    vb_avg_koz_rechth WITH NO DATA;
+ SELECT row_number() OVER ()::integer AS objectid,
+    koz.koz_identif,
+    koz.begin_geldigheid,
+    koz.type,
+    (COALESCE(koz.sectie, ''::character varying)::text || ' '::text) || COALESCE(koz.perceelnummer, ''::character varying)::text AS aanduiding,
+    (((((COALESCE(koz.gemeentecode, ''::character varying)::text || ' '::text) || COALESCE(koz.sectie, ''::character varying)::text) || ' '::text) || COALESCE(koz.perceelnummer, ''::character varying)::text) || ' '::text) || COALESCE(koz.appartementsindex, ''::character varying)::text AS aanduiding2,
+    koz.sectie,
+    koz.perceelnummer,
+    koz.appartementsindex,
+    koz.gemeentecode,
+    koz.aand_soort_grootte,
+    koz.grootte_perceel,
+    koz.oppervlakte_geom,
+    koz.deelperceelnummer,
+    koz.omschr_deelperceel,
+    koz.verkoop_datum,
+    koz.aard_cultuur_onbebouwd,
+    koz.bedrag,
+    koz.koopjaar,
+    koz.meer_onroerendgoed,
+    koz.valutasoort,
+    koz.loc_omschr,
+    zrr.zr_identif,
+    zrr.subject_identif,
+    zrr.aandeel,
+    zrr.omschr_aard_verkregenr_recht,
+    zrr.indic_betrokken_in_splitsing,
+    zrr.soort,
+    zrr.geslachtsnaam,
+    zrr.voorvoegsel,
+    zrr.voornamen,
+    zrr.aand_naamgebruik,
+    zrr.geslachtsaand,
+    zrr.naam,
+    zrr.woonadres,
+    zrr.geboortedatum,
+    zrr.geboorteplaats,
+    zrr.overlijdensdatum,
+    zrr.bsn,
+    zrr.organisatie_naam,
+    zrr.rechtsvorm,
+    zrr.statutaire_zetel,
+    zrr.rsin,
+    zrr.kvk_nummer,
+    koz.gemeente,
+    koz.woonplaats,
+    koz.straatnaam,
+    koz.huisnummer,
+    koz.huisletter,
+    koz.huisnummer_toev,
+    koz.postcode,
+    koz.lon,
+    koz.lat,
+    koz.begrenzing_perceel
+   FROM vb_avg_zr_rechth zrr
+     RIGHT JOIN mb_kad_onrrnd_zk_adres koz ON zrr.koz_identif = koz.koz_identif
+WITH NO DATA;
+
 CREATE UNIQUE INDEX mb_avg_koz_rechth_objectid ON mb_avg_koz_rechth USING btree (objectid);
 CREATE INDEX mb_avg_koz_rechth_identif ON mb_avg_koz_rechth USING btree (koz_identif);
 CREATE INDEX mb_avg_koz_rechth_begrenzing_perceel_idx ON mb_avg_koz_rechth USING gist (begrenzing_perceel);

--- a/datamodel/extra_scripts/postgresql/207_brk_views.sql
+++ b/datamodel/extra_scripts/postgresql/207_brk_views.sql
@@ -457,7 +457,7 @@ FROM vb_util_app_re_parent u1
 JOIN kad_perceel kp ON u1.parent_identif = kp.sc_kad_identif::text
 GROUP BY u1.app_re_identif, kp.sc_kad_identif;
 
-COMMENT ON VIEW mb_util_app_re_kad_perceel
+COMMENT ON MATERIALIZED VIEW mb_util_app_re_kad_perceel
 IS 'commentaar view mb_util_app_re_kad_perceel:
 utility view, niet bedoeld voor direct gebruik, met lijst van appartementsrechten met bijbehorend grondperceel
 beschikbare kolommen:

--- a/datamodel/extra_scripts/postgresql/207_brk_views.sql
+++ b/datamodel/extra_scripts/postgresql/207_brk_views.sql
@@ -460,11 +460,9 @@ GROUP BY u1.app_re_identif, kp.sc_kad_identif;
 COMMENT ON VIEW mb_util_app_re_kad_perceel
 IS 'commentaar view mb_util_app_re_kad_perceel:
 utility view, niet bedoeld voor direct gebruik, met lijst van appartementsrechten met bijbehorend grondperceel
-
 beschikbare kolommen:
-* app_re_identif: natuurlijk is van appartementsrecht,
-* perceel_identif: natuurlijk id van grondperceel
-';
+* app_re_identif: natuurlijk id van appartementsrecht,
+* perceel_identif: natuurlijk id van grondperceel';
 CREATE INDEX mb_util_app_re_kad_perceel_identif ON mb_util_app_re_kad_perceel USING btree (app_re_identif);
     
 --drop view vb_kad_onrrnd_zk_adres cascade;

--- a/datamodel/pom.xml
+++ b/datamodel/pom.xml
@@ -16,6 +16,43 @@
         <filename.base.201_update_wnplts_gemcode>201_update_wnplts_gemcode</filename.base.201_update_wnplts_gemcode>
         <filename.GEM-WPL-zipfile>GEM-WPL-RELATIE-08112018.zip</filename.GEM-WPL-zipfile>
     </properties>
+    <dependencies>
+        <dependency>
+            <groupId>commons-dbcp</groupId>
+            <artifactId>commons-dbcp</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>nl.b3p</groupId>
+            <artifactId>brmo-test-util</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.dbunit</groupId>
+            <artifactId>dbunit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${oracle.jdbc.groupId}</groupId>
+            <artifactId>${oracle.jdbc.artifactId}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.jtds</groupId>
+            <artifactId>jtds</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- <dependency>
+            <groupId>net.postgis</groupId>
+            <artifactId>postgis-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>  -->
+    </dependencies>
     <build>
         <defaultGoal>process-resources</defaultGoal>
         <plugins>
@@ -222,7 +259,7 @@
             <activation>
                 <file>
                     <!-- dit profiel wordt geactiveerd als dit bestand, dat de
-                         input voor het proces is, bestaat -->
+                    input voor het proces is, bestaat -->
                     <exists>${basedir}/referentiedata/${filename.GEM-WPL-zipfile}</exists>
                 </file>
             </activation>

--- a/datamodel/pom.xml
+++ b/datamodel/pom.xml
@@ -375,9 +375,10 @@
         <profile>
             <id>postgresql</id>
             <build>
+                <defaultGoal>testCompile</defaultGoal>
                 <plugins>
                     <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables>
                                 <database.properties.file>postgis.properties</database.properties.file>

--- a/datamodel/pom.xml
+++ b/datamodel/pom.xml
@@ -372,5 +372,21 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>postgresql</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <database.properties.file>postgis.properties</database.properties.file>
+                                <project.version>${project.version}</project.version>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/datamodel/pom.xml
+++ b/datamodel/pom.xml
@@ -383,6 +383,7 @@
                             <systemPropertyVariables>
                                 <database.properties.file>postgis.properties</database.properties.file>
                                 <project.version>${project.version}</project.version>
+                                <database.upgrade>${database.upgrade}</database.upgrade>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/datamodel/src/test/resources/log4j.xml
+++ b/datamodel/src/test/resources/log4j.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration PUBLIC "-//APACHE//DTD LOG4J 1.2//EN" "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+    <appender name="consoleAppender" class="org.apache.log4j.ConsoleAppender">
+        <param name="Threshold" value="all" />
+        <layout class="org.apache.log4j.EnhancedPatternLayout">
+            <param name="ConversionPattern" value="BRMO-DATAMODEL: %5p %d{HH:mm:ss} (%C{1.}#%M:%L) - %m%n" />
+        </layout>
+    </appender>
+    <logger name="org.dbunit.database">
+        <level value="info" />
+    </logger>
+    <logger name="org.dbunit.operation">
+        <level value="info" />
+    </logger>
+    <logger name="org.dbunit.util">
+        <level value="info" />
+    </logger>
+    <logger name="org.dbunit.dataset">
+        <level value="info" />
+    </logger>
+    <logger name="org.dbunit.ext">
+        <level value="info" />
+    </logger>
+   <logger name="nl.b3p.brmo">
+        <level value="info" />
+    </logger>
+    <logger name="nl.b3p.brmo.datamodel">
+        <level value="debug" />
+    </logger>
+    <root>
+        <level value="info" />
+        <appender-ref ref="consoleAppender" />
+    </root>
+</log4j:configuration>

--- a/datamodel/src/test/resources/postgis.properties
+++ b/datamodel/src/test/resources/postgis.properties
@@ -1,0 +1,14 @@
+jdbc.driverClassName=org.postgresql.Driver
+dbtype=postgis
+
+rsgb.url=jdbc:postgresql://127.0.0.1:5432/rsgb
+rsgb.username=rsgb
+rsgb.password=rsgb
+
+staging.url=jdbc:postgresql://localhost:5432/staging
+staging.user=staging
+staging.passwd=staging
+
+rsgbbgt.url=jdbc:postgresql://localhost:5432/rsgbbgt
+rsgbbgt.user=rsgbbgt
+rsgbbgt.passwd=rsgbbgt

--- a/datamodel/src/test/resources/postgis.properties
+++ b/datamodel/src/test/resources/postgis.properties
@@ -6,9 +6,9 @@ rsgb.username=rsgb
 rsgb.password=rsgb
 
 staging.url=jdbc:postgresql://localhost:5432/staging
-staging.user=staging
-staging.passwd=staging
+staging.username=staging
+staging.password=staging
 
 rsgbbgt.url=jdbc:postgresql://localhost:5432/rsgbbgt
-rsgbbgt.user=rsgbbgt
-rsgbbgt.passwd=rsgbbgt
+rsgbbgt.username=rsgbbgt
+rsgbbgt.password=rsgbbgt

--- a/datamodel/upgrade_scripts/1.6.0-1.6.1/postgresql/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.6.0-1.6.1/postgresql/rsgb.sql
@@ -5,6 +5,7 @@
 -- issue #510
 alter table functionaris alter column functionaristypering type character varying(255);
 
+DROP MATERIALIZED VIEW IF EXISTS mb_kad_onrrnd_zk_archief;
 DROP VIEW vb_kad_onrrnd_zk_archief;
 CREATE OR REPLACE VIEW
     vb_kad_onrrnd_zk_archief

--- a/datamodel/upgrade_scripts/1.6.1-1.6.2/oracle/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.6.1-1.6.2/oracle/rsgb.sql
@@ -395,6 +395,194 @@ beschikbare kolommen:
 * lat: coordinaat als WSG84,
 * begrenzing_perceel: perceelvlak';
 
+DROP MATERIALIZED VIEW mb_koz_rechth;
+CREATE MATERIALIZED VIEW mb_koz_rechth
+    (
+        objectid,
+        koz_identif,
+        begin_geldigheid,
+        type,
+        aanduiding,
+        aanduiding2,
+        sectie,
+        perceelnummer,
+        appartementsindex,
+        gemeentecode,
+        aand_soort_grootte,
+        grootte_perceel,
+        oppervlakte_geom,
+        deelperceelnummer,
+        omschr_deelperceel,
+        verkoop_datum,
+        aard_cultuur_onbebouwd,
+        bedrag,
+        koopjaar,
+        meer_onroerendgoed,
+        valutasoort,
+        loc_omschr,
+        zr_identif,
+        subject_identif,
+        aandeel,
+        omschr_aard_verkregenr_recht,
+        indic_betrokken_in_splitsing,
+        soort,
+        geslachtsnaam,
+        voorvoegsel,
+        voornamen,
+        aand_naamgebruik,
+        geslachtsaand,
+        naam,
+        woonadres,
+        geboortedatum,
+        geboorteplaats,
+        overlijdensdatum,
+        bsn,
+        organisatie_naam,
+        rechtsvorm,
+        statutaire_zetel,
+        rsin,
+        kvk_nummer,
+        gemeente,
+        woonplaats,
+        straatnaam,
+        huisnummer,
+        huisletter,
+        huisnummer_toev,
+        postcode,
+        lon,
+        lat,
+        begrenzing_perceel
+    ) 
+BUILD DEFERRED REFRESH ON DEMAND AS
+SELECT
+    CAST(ROWNUM AS INTEGER) AS objectid,
+    koz.koz_identif,
+    koz.begin_geldigheid,
+    koz.type,
+    COALESCE(koz.sectie, '') || ' ' || COALESCE(koz.perceelnummer, '') AS aanduiding,
+    COALESCE(koz.gemeentecode, '') || ' ' || COALESCE(koz.sectie, '') || ' ' || COALESCE(koz.perceelnummer, '') || ' ' || COALESCE(koz.appartementsindex, '') AS aanduiding2,
+    koz.sectie,
+    koz.perceelnummer,
+    koz.appartementsindex,
+    koz.gemeentecode,
+    koz.aand_soort_grootte,
+    koz.grootte_perceel,
+    koz.oppervlakte_geom as oppervlakte_geom,
+    koz.deelperceelnummer,
+    koz.omschr_deelperceel,
+    koz.verkoop_datum,
+    koz.aard_cultuur_onbebouwd,
+    koz.bedrag,
+    koz.koopjaar,
+    koz.meer_onroerendgoed,
+    koz.valutasoort,
+    koz.loc_omschr,
+    zrr.zr_identif,
+    zrr.subject_identif,
+    zrr.aandeel,
+    zrr.omschr_aard_verkregenr_recht,
+    zrr.indic_betrokken_in_splitsing,
+    zrr.soort,
+    zrr.geslachtsnaam,
+    zrr.voorvoegsel,
+    zrr.voornamen,
+    zrr.aand_naamgebruik,
+    zrr.geslachtsaand,
+    zrr.naam,
+    zrr.woonadres,
+    zrr.geboortedatum,
+    zrr.geboorteplaats,
+    zrr.overlijdensdatum,
+    zrr.bsn,
+    zrr.organisatie_naam,
+    zrr.rechtsvorm,
+    zrr.statutaire_zetel,
+    zrr.rsin,
+    zrr.kvk_nummer,
+    koz.gemeente,
+    koz.woonplaats,
+    koz.straatnaam,
+    koz.huisnummer,
+    koz.huisletter,
+    koz.huisnummer_toev,
+    koz.postcode,
+    koz.lon,
+    koz.lat,
+    koz.begrenzing_perceel
+FROM
+    vb_zr_rechth zrr
+RIGHT JOIN
+    mb_kad_onrrnd_zk_adres koz
+ON
+    zrr.koz_identif = koz.koz_identif;
+    
+CREATE UNIQUE INDEX MB_KOZ_RECHTH_OBJECTID ON MB_KOZ_RECHTH(OBJECTID ASC);
+CREATE INDEX MB_KOZ_RECHTH_IDENTIF ON MB_KOZ_RECHTH(KOZ_IDENTIF ASC);
+CREATE INDEX MB_KOZ_RECHTH_BEGR_PRCL_IDX ON MB_KOZ_RECHTH(BEGRENZING_PERCEEL)  INDEXTYPE IS MDSYS.SPATIAL_INDEX;
+
+COMMENT ON MATERIALIZED VIEW mb_koz_rechth
+IS 'commentaar view mb_koz_rechth:
+kadastrale percelen een appartementsrechten met rechten en rechthebbenden en objectid voor geoserver/arcgis
+beschikbare kolommen:
+* objectid: uniek id bruikbaar voor geoserver/arcgis,
+* koz_identif: natuurlijke id van perceel of appartementsrecht      
+* begin_geldigheid: datum wanneer dit object geldig geworden is (ontstaat of bijgewerkt),
+* type: perceel of appartement,
+* aanduiding: sectie perceelnummer,
+* aanduiding2: kadgem sectie perceelnummer appartementsindex,
+* sectie: -,
+* perceelnummer: -,
+* appartementsindex: -,
+* gemeentecode: -,
+* aand_soort_grootte: -,
+* grootte_perceel: -,
+* oppervlakte_geom: oppervlakte berekend uit geometrie, hoort gelijk te zijn aan grootte_perceel,
+* deelperceelnummer: -,
+* omschr_deelperceel: -,
+* verkoop_datum: laatste datum gevonden akten van verkoop,
+* aard_cultuur_onbebouwd: -,
+* bedrag: -,
+* koopjaar: -,
+* meer_onroerendgoed: -,
+* valutasoort: -,
+* loc_omschr: adres buiten BAG om meegegeven,
+* zr_identif: natuurlijk id van zakelijk recht,
+* subject_identif: natuurlijk id van rechthebbende,
+* aandeel: samenvoeging van teller en noemer (1/2),
+* omschr_aard_verkregenr_recht: tekstuele omschrijving aard recht,
+* indic_betrokken_in_splitsing: -,
+* soort: soort subject zoals natuurlijk, niet-natuurlijk enz.  
+* geslachtsnaam: -       
+* voorvoegsel: -     
+* voornamen: -     
+* aand_naamgebruik:        
+- E (= Eigen geslachtsnaam)        
+- N (=Geslachtsnaam echtgenoot/geregistreerd partner na eigen geslachtsnaam)        
+- P (= Geslachtsnaam echtgenoot/geregistreerd partner)        
+- V (= Geslachtsnaam evhtgenoot/geregistreerd partner voor eigen geslachtsnaam)        
+* geslachtsaand: M/V   
+* naam: samengestelde naam bruikbaar voor natuurlijke en niet-natuurlijke subjecten
+* woonadres: meegeleverd adres buiten BAG koppeling om      
+* geboortedatum: -       
+* geboorteplaats: -       
+* overlijdensdatum: -       
+* bsn: -       
+* organisatie_naam: naam niet natuurlijk subject      
+* rechtsvorm: -  
+* statutaire_zetel: -      
+* rsin: -        
+* kvk_nummer: -
+* gemeente: -,
+* woonplaats: -,
+* straatnaam: -,
+* huisnummer: -,
+* huisletter: -,
+* huisnummer_toev: -,
+* postcode: -,
+* lon: coordinaat als WSG84,
+* lon: coordinaat als WSG84,
+* begrenzing_perceel: perceelvlak';
+
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_1.6.1_naar_1.6.2','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';
 -- versienummer update

--- a/datamodel/upgrade_scripts/1.6.1-1.6.2/oracle/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.6.1-1.6.2/oracle/rsgb.sql
@@ -2,6 +2,398 @@
 -- upgrade Oracle RSGB datamodel van 1.6.1 naar 1.6.2 
 --
 
+CREATE MATERIALIZED VIEW mb_util_app_re_kad_perceel
+    BUILD DEFERRED REFRESH ON DEMAND AS
+SELECT
+    u1.app_re_identif,
+    kp.sc_kad_identif AS perceel_identif
+FROM
+    vb_util_app_re_parent u1
+JOIN
+    kad_perceel kp
+ON
+    u1.parent_identif = cast(kp.sc_kad_identif AS CHARACTER VARYING(50))
+GROUP BY
+    u1.app_re_identif,
+    kp.sc_kad_identif;
+    
+COMMENT ON MATERIALIZED VIEW mb_util_app_re_kad_perceel
+IS 'commentaar view mb_util_app_re_kad_perceel:
+utility view, niet bedoeld voor direct gebruik, met lijst van appartementsrechten met bijbehorend grondperceel
+beschikbare kolommen:
+* app_re_identif: natuurlijk id van appartementsrecht,
+* perceel_identif: natuurlijk id van grondperceel';
+CREATE INDEX mb_util_app_re_kad_perceel_id ON mb_util_app_re_kad_perceel(app_re_identif);
+
+DROP MATERIALIZED VIEW mb_kad_onrrnd_zk_adres;
+CREATE MATERIALIZED VIEW mb_kad_onrrnd_zk_adres(
+    objectid,
+    koz_identif,
+    begin_geldigheid,
+    benoemdobj_identif,
+    type,
+    aanduiding,
+    aanduiding2,
+    sectie,
+    perceelnummer,
+    appartementsindex,
+    gemeentecode,
+    aand_soort_grootte,
+    grootte_perceel,
+    oppervlakte_geom,
+    deelperceelnummer,
+    omschr_deelperceel,
+    verkoop_datum,
+    aard_cultuur_onbebouwd,
+    bedrag,
+    koopjaar,
+    meer_onroerendgoed,
+    valutasoort,
+    loc_omschr,
+    gemeente,
+    woonplaats,
+    straatnaam,
+    huisnummer,
+    huisletter,
+    huisnummer_toev,
+    postcode,
+    lon,
+    lat,
+    begrenzing_perceel) 
+BUILD DEFERRED REFRESH ON DEMAND AS
+SELECT
+    CAST(ROWNUM AS INTEGER)  AS objectid,
+    qry.identif              AS koz_identif,
+    koz.dat_beg_geldh        AS begin_geldigheid,
+    bok.fk_nn_lh_tgo_identif AS benoemdobj_identif,
+    qry.type,
+    COALESCE(qry.ka_sectie, '') || ' ' || COALESCE(qry.ka_perceelnummer, '')                                                                                                  AS aanduiding,
+    COALESCE(qry.ka_kad_gemeentecode, '') || ' ' || COALESCE(qry.ka_sectie, '') || ' ' || COALESCE(qry.ka_perceelnummer, '') || ' ' || COALESCE(qry.ka_appartementsindex, '') AS aanduiding2,
+    qry.ka_sectie,
+    qry.ka_perceelnummer,
+    qry.ka_appartementsindex,
+    qry.ka_kad_gemeentecode,
+    qry.aand_soort_grootte,
+    qry.grootte_perceel,
+    CASE
+        WHEN qry.begrenzing_perceel.get_gtype() IS NOT NULL
+        THEN SDO_GEOM.SDO_AREA(qry.BEGRENZING_PERCEEL, 0.1)
+        ELSE NULL
+    END AS oppervlakte_geom,
+    qry.ka_deelperceelnummer,
+    qry.omschr_deelperceel,
+    b.datum,
+    koz.cu_aard_cultuur_onbebouwd,
+    koz.ks_bedrag,
+    koz.ks_koopjaar,
+    koz.ks_meer_onroerendgoed,
+    koz.ks_valutasoort,
+    koz.lo_loc__omschr,
+    bola.gemeente,
+    bola.woonplaats,
+    bola.straatnaam,
+    bola.huisnummer,
+    bola.huisletter,
+    bola.huisnummer_toev,
+    bola.postcode,
+    CASE
+        WHEN qry.begrenzing_perceel.get_gtype() IS NOT NULL
+        THEN SDO_CS.TRANSFORM(SDO_GEOM.SDO_CENTROID(qry.begrenzing_perceel, 0.1), 4326) .sdo_point.x
+        ELSE NULL
+    END AS lon,
+    CASE
+        WHEN qry.begrenzing_perceel.get_gtype() IS NOT NULL
+        THEN SDO_CS.TRANSFORM(SDO_GEOM.SDO_CENTROID(qry.begrenzing_perceel, 0.1), 4326) .sdo_point.y
+    END AS lat,
+    qry.begrenzing_perceel
+FROM
+    (
+        SELECT
+            p.sc_kad_identif AS identif,
+            'perceel'        AS type,
+            p.ka_sectie,
+            p.ka_perceelnummer,
+            CAST(NULL AS CHARACTER VARYING(4)) AS ka_appartementsindex,
+            p.ka_kad_gemeentecode,
+            p.aand_soort_grootte,
+            p.grootte_perceel,
+            p.ka_deelperceelnummer,
+            p.omschr_deelperceel,
+            p.BEGRENZING_PERCEEL AS begrenzing_perceel
+        FROM
+            kad_perceel p
+        UNION ALL
+        SELECT
+            ar.sc_kad_identif AS identif,
+            'appartement'     AS type,
+            ar.ka_sectie,
+            ar.ka_perceelnummer,
+            ar.ka_appartementsindex,
+            ar.ka_kad_gemeentecode,
+            CAST(NULL AS CHARACTER VARYING(1))    AS aand_soort_grootte,
+            CAST(NULL AS NUMERIC(8, 0))           AS grootte_perceel,
+            CAST(NULL AS CHARACTER VARYING(4))    AS ka_deelperceelnummer,
+            CAST(NULL AS CHARACTER VARYING(1120)) AS omschr_deelperceel,
+            kp.BEGRENZING_PERCEEL                 AS begrenzing_perceel
+        FROM
+            mb_util_app_re_kad_perceel v
+        JOIN
+            kad_perceel kp
+        ON
+            CAST(v.perceel_identif AS NUMERIC) = kp.sc_kad_identif
+        JOIN
+            app_re ar
+        ON
+            CAST(v.app_re_identif AS NUMERIC) = ar.sc_kad_identif) qry
+JOIN
+    kad_onrrnd_zk koz
+ON
+    koz.kad_identif = qry.identif
+LEFT JOIN
+    benoemd_obj_kad_onrrnd_zk bok
+ON
+    bok.fk_nn_rh_koz_kad_identif = qry.identif
+LEFT JOIN
+    vb_benoemd_obj_adres bola
+ON
+    bok.fk_nn_lh_tgo_identif = bola.benoemdobj_identif
+LEFT JOIN
+    (
+        SELECT
+            brondocument.ref_id,
+            MAX(brondocument.datum) AS datum
+        FROM
+            brondocument
+        WHERE
+            brondocument.omschrijving = 'Akte van Koop en Verkoop'
+        GROUP BY
+            brondocument.ref_id) b
+ON
+    koz.kad_identif = b.ref_id;
+    
+CREATE UNIQUE INDEX MB_KAD_ONRRND_ZK_ADRES_OBJIDX ON MB_KAD_ONRRND_ZK_ADRES(OBJECTID ASC);
+CREATE INDEX MB_KAD_ONRRND_ZK_ADRES_IDENTIF ON MB_KAD_ONRRND_ZK_ADRES(KOZ_IDENTIF ASC);
+CREATE INDEX MB_KAD_ONRRND_ZK_ADR_BGRGPIDX ON MB_KAD_ONRRND_ZK_ADRES (BEGRENZING_PERCEEL) INDEXTYPE IS MDSYS.SPATIAL_INDEX;
+
+COMMENT ON MATERIALIZED VIEW mb_kad_onrrnd_zk_adres
+IS 'commentaar view mb_kad_onrrnd_zk_adres:
+alle kadastrale onroerende zaken (perceel en appartementsrecht) met opgezochte verkoop datum, objectid voor geoserver/arcgis en BAG adres
+beschikbare kolommen:
+* objectid: uniek id bruikbaar voor geoserver/arcgis,
+* koz_identif: natuurlijke id van perceel of appartementsrecht      
+* begin_geldigheid: datum wanneer dit object geldig geworden is (ontstaat of bijgewerkt),
+* benoemdobj_identif: koppeling met BAG object,
+* type: perceel of appartement,
+* aanduiding: sectie perceelnummer,
+* aanduiding2: kadgem sectie perceelnummer appartementsindex,
+* sectie: -,
+* perceelnummer: -,
+* appartementsindex: -,
+* gemeentecode: -,
+* aand_soort_grootte: -,
+* grootte_perceel: -,
+* oppervlakte_geom: oppervlakte berekend uit geometrie, hoort gelijk te zijn aan grootte_perceel,
+* deelperceelnummer: -,
+* omschr_deelperceel: -,
+* verkoop_datum: laatste datum gevonden akten van verkoop,
+* aard_cultuur_onbebouwd: -,
+* bedrag: -,
+* koopjaar: -,
+* meer_onroerendgoed: -,
+* valutasoort: -,
+* loc_omschr: adres buiten BAG om meegegeven,
+* gemeente: -,
+* woonplaats: -,
+* straatnaam: -,
+* huisnummer: -,
+* huisletter: -,
+* huisnummer_toev: -,
+* postcode: -,
+* lon: coordinaat als WSG84,
+* lon: coordinaat als WSG84,
+* begrenzing_perceel: perceelvlak';
+
+DROP MATERIALIZED VIEW mb_avg_koz_rechth;
+CREATE MATERIALIZED VIEW mb_avg_koz_rechth (
+    objectid,
+    koz_identif,
+    begin_geldigheid,
+    type,
+    aanduiding,
+    aanduiding2,
+    sectie,
+    perceelnummer,
+    appartementsindex,
+    gemeentecode,
+    aand_soort_grootte,
+    grootte_perceel,
+    oppervlakte_geom,
+    deelperceelnummer,
+    omschr_deelperceel,
+    verkoop_datum,
+    aard_cultuur_onbebouwd,
+    bedrag,
+    koopjaar,
+    meer_onroerendgoed,
+    valutasoort,
+    loc_omschr,
+    zr_identif,
+    subject_identif,
+    aandeel,
+    omschr_aard_verkregenr_recht,
+    indic_betrokken_in_splitsing,
+    soort,
+    geslachtsnaam,
+    voorvoegsel,
+    voornamen,
+    aand_naamgebruik,
+    geslachtsaand,
+    naam,
+    woonadres,
+    geboortedatum,
+    geboorteplaats,
+    overlijdensdatum,
+    bsn,
+    organisatie_naam,
+    rechtsvorm,
+    statutaire_zetel,
+    rsin,
+    kvk_nummer,
+    gemeente,
+    woonplaats,
+    straatnaam,
+    huisnummer,
+    huisletter,
+    huisnummer_toev,
+    postcode,
+    lon,
+    lat,
+    begrenzing_perceel
+)
+BUILD DEFERRED REFRESH ON DEMAND AS
+SELECT
+    CAST(ROWNUM AS INTEGER) AS objectid,
+    koz.koz_identif as koz_identif,
+    koz.begin_geldigheid,
+    koz.type,
+    COALESCE(koz.sectie, '') || ' ' || COALESCE(koz.perceelnummer, '') AS aanduiding,
+    COALESCE(koz.gemeentecode, '') || ' ' || COALESCE(koz.sectie, '') || ' ' || COALESCE(koz.perceelnummer, '') || ' ' || COALESCE(koz.appartementsindex, '') AS aanduiding2,
+    koz.sectie,
+    koz.perceelnummer,
+    koz.appartementsindex,
+    koz.gemeentecode,
+    koz.aand_soort_grootte,
+    koz.grootte_perceel,
+    koz.oppervlakte_geom,
+    koz.deelperceelnummer,
+    koz.omschr_deelperceel,
+    koz.verkoop_datum,
+    koz.aard_cultuur_onbebouwd,
+    koz.bedrag,
+    koz.koopjaar,
+    koz.meer_onroerendgoed,
+    koz.valutasoort,
+    koz.loc_omschr,
+    zrr.zr_identif,
+    zrr.subject_identif,
+    zrr.aandeel,
+    zrr.omschr_aard_verkregenr_recht,
+    zrr.indic_betrokken_in_splitsing,
+    zrr.soort,
+    zrr.geslachtsnaam,
+    zrr.voorvoegsel,
+    zrr.voornamen,
+    zrr.aand_naamgebruik,
+    zrr.geslachtsaand,
+    zrr.naam,
+    zrr.woonadres,
+    zrr.geboortedatum,
+    zrr.geboorteplaats,
+    zrr.overlijdensdatum,
+    zrr.bsn,
+    zrr.organisatie_naam,
+    zrr.rechtsvorm,
+    zrr.statutaire_zetel,
+    zrr.rsin,
+    zrr.kvk_nummer,
+    koz.gemeente,
+    koz.woonplaats,
+    koz.straatnaam,
+    koz.huisnummer,
+    koz.huisletter,
+    koz.huisnummer_toev,
+    koz.postcode,
+    koz.lon,
+    koz.lat,
+    koz.begrenzing_perceel
+FROM
+    vb_avg_zr_rechth zrr
+RIGHT JOIN
+    mb_kad_onrrnd_zk_adres koz
+ON  zrr.koz_identif = koz.koz_identif;
+
+CREATE UNIQUE INDEX MB_AVG_KOZ_RECHTH_OBJECTID ON MB_AVG_KOZ_RECHTH(OBJECTID ASC);
+CREATE INDEX MB_AVG_KOZ_RECHTH_IDENTIF ON MB_AVG_KOZ_RECHTH(KOZ_IDENTIF ASC);
+CREATE INDEX MB_AVG_KOZ_RECHTH_BEGR_P_IDX ON MB_AVG_KOZ_RECHTH (BEGRENZING_PERCEEL) INDEXTYPE IS MDSYS.SPATIAL_INDEX;
+
+COMMENT ON MATERIALIZED VIEW mb_avg_koz_rechth
+IS 'commentaar view mb_avg_koz_rechth:
+kadastrale percelen een appartementsrechten met rechten en rechthebbenden geschoond voor avg en objectid voor geoserver/arcgis
+beschikbare kolommen:
+* objectid: uniek id bruikbaar voor geoserver/arcgis,
+* koz_identif: natuurlijke id van perceel of appartementsrecht      
+* begin_geldigheid: datum wanneer dit object geldig geworden is (ontstaat of bijgewerkt),
+* type: perceel of appartement,
+* aanduiding: sectie perceelnummer,
+* aanduiding2: kadgem sectie perceelnummer appartementsindex,
+* sectie: -,
+* perceelnummer: -,
+* appartementsindex: -,
+* gemeentecode: -,
+* aand_soort_grootte: -,
+* grootte_perceel: -,
+* oppervlakte_geom: oppervlakte berekend uit geometrie, hoort gelijk te zijn aan grootte_perceel,
+* deelperceelnummer: -,
+* omschr_deelperceel: -,
+* verkoop_datum: laatste datum gevonden akten van verkoop,
+* aard_cultuur_onbebouwd: -,
+* bedrag: -,
+* koopjaar: -,
+* meer_onroerendgoed: -,
+* valutasoort: -,
+* loc_omschr: adres buiten BAG om meegegeven,
+* zr_identif: natuurlijk id van zakelijk recht,
+* subject_identif: natuurlijk id van rechthebbende,
+* aandeel: samenvoeging van teller en noemer (1/2),
+* omschr_aard_verkregenr_recht: tekstuele omschrijving aard recht,
+* indic_betrokken_in_splitsing: -,
+* soort: soort subject zoals natuurlijk, niet-natuurlijk enz.  
+* geslachtsnaam: NULL (avg)       
+* voorvoegsel: NULL (avg)      
+* voornamen: NULL (avg)       
+* aand_naamgebruik: NULL (avg)         
+* geslachtsaand:NULL (avg)     
+* naam: gelijk aan organisatie_naam
+* woonadres: NULL (avg)        
+* geboortedatum: NULL (avg)        
+* geboorteplaats: NULL (avg)        
+* overlijdensdatum: NULL (avg)        
+* bsn: NULL (avg)         
+* organisatie_naam: naam niet natuurlijk subject      
+* rechtsvorm: -  
+* statutaire_zetel: -      
+* rsin: -        
+* kvk_nummer: -
+* gemeente: -,
+* woonplaats: -,
+* straatnaam: -,
+* huisnummer: -,
+* huisletter: -,
+* huisnummer_toev: -,
+* postcode: -,
+* lon: coordinaat als WSG84,
+* lat: coordinaat als WSG84,
+* begrenzing_perceel: perceelvlak';
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_1.6.1_naar_1.6.2','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/1.6.1-1.6.2/postgresql/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.6.1-1.6.2/postgresql/rsgb.sql
@@ -161,6 +161,70 @@ CREATE UNIQUE INDEX mb_avg_koz_rechth_objectid ON mb_avg_koz_rechth USING btree 
 CREATE INDEX mb_avg_koz_rechth_identif ON mb_avg_koz_rechth USING btree (koz_identif);
 CREATE INDEX mb_avg_koz_rechth_begrenzing_perceel_idx ON mb_avg_koz_rechth USING gist (begrenzing_perceel);
 
+DROP MATERIALIZED VIEW mb_koz_rechth;
+CREATE MATERIALIZED VIEW mb_koz_rechth AS
+ SELECT
+    row_number() OVER()::integer AS objectid,
+    koz.koz_identif,
+    koz.begin_geldigheid,
+    koz.type,
+    (COALESCE(koz.sectie, ''::character varying)::text || ' '::text) || COALESCE(koz.perceelnummer, ''::character varying)::text AS aanduiding,
+    (((((COALESCE(koz.gemeentecode, ''::character varying)::text || ' '::text) || COALESCE(koz.sectie, ''::character varying)::text) || ' '::text) || COALESCE(koz.perceelnummer, ''::character varying)::text) || ' '::text) || COALESCE(koz.appartementsindex, ''::character varying)::text AS aanduiding2,
+    koz.sectie,
+    koz.perceelnummer,
+    koz.appartementsindex,
+    koz.gemeentecode,
+    koz.aand_soort_grootte,
+    koz.grootte_perceel,
+    koz.oppervlakte_geom,
+    koz.deelperceelnummer,
+    koz.omschr_deelperceel,
+    koz.verkoop_datum,
+    koz.aard_cultuur_onbebouwd,
+    koz.bedrag,
+    koz.koopjaar,
+    koz.meer_onroerendgoed,
+    koz.valutasoort,
+    koz.loc_omschr,
+    zrr.zr_identif,
+    zrr.subject_identif,
+    zrr.aandeel,
+    zrr.omschr_aard_verkregenr_recht,
+    zrr.indic_betrokken_in_splitsing,
+    zrr.soort,
+    zrr.geslachtsnaam,
+    zrr.voorvoegsel,
+    zrr.voornamen,
+    zrr.aand_naamgebruik,
+    zrr.geslachtsaand,
+    zrr.naam,
+    zrr.woonadres,
+    zrr.geboortedatum,
+    zrr.geboorteplaats,
+    zrr.overlijdensdatum,
+    zrr.bsn,
+    zrr.organisatie_naam,
+    zrr.rechtsvorm,
+    zrr.statutaire_zetel,
+    zrr.rsin,
+    zrr.kvk_nummer,
+    koz.gemeente,
+    koz.woonplaats,
+    koz.straatnaam,
+    koz.huisnummer,
+    koz.huisletter,
+    koz.huisnummer_toev,
+    koz.postcode,
+    koz.lon,
+    koz.lat,
+    koz.begrenzing_perceel
+   FROM vb_zr_rechth zrr
+     RIGHT JOIN mb_kad_onrrnd_zk_adres koz ON zrr.koz_identif = koz.koz_identif
+WITH NO DATA;
+
+CREATE UNIQUE INDEX mb_koz_rechth_objectid ON mb_koz_rechth USING btree (objectid);
+CREATE INDEX mb_koz_rechth_identif ON mb_koz_rechth USING btree (koz_identif);
+CREATE INDEX mb_koz_rechth_begrenzing_perceel_idx ON mb_koz_rechth USING gist (begrenzing_perceel);
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_1.6.1_naar_1.6.2','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/1.6.1-1.6.2/postgresql/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.6.1-1.6.2/postgresql/rsgb.sql
@@ -14,11 +14,9 @@ WITH NO DATA;
 COMMENT ON VIEW mb_util_app_re_kad_perceel
 IS 'commentaar view mb_util_app_re_kad_perceel:
 utility view, niet bedoeld voor direct gebruik, met lijst van appartementsrechten met bijbehorend grondperceel
-
 beschikbare kolommen:
-* app_re_identif: natuurlijk is van appartementsrecht,
-* perceel_identif: natuurlijk id van grondperceel
-';
+* app_re_identif: natuurlijk id van appartementsrecht,
+* perceel_identif: natuurlijk id van grondperceel';
 CREATE INDEX mb_util_app_re_kad_perceel_identif ON mb_util_app_re_kad_perceel USING btree (app_re_identif);
 
 

--- a/datamodel/upgrade_scripts/1.6.1-1.6.2/postgresql/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.6.1-1.6.2/postgresql/rsgb.sql
@@ -2,6 +2,167 @@
 -- upgrade PostgreSQL RSGB datamodel van 1.6.1 naar 1.6.2 
 --
 
+CREATE MATERIALIZED VIEW mb_util_app_re_kad_perceel AS
+SELECT
+   u1.app_re_identif,
+   kp.sc_kad_identif AS perceel_identif
+FROM vb_util_app_re_parent u1
+JOIN kad_perceel kp ON u1.parent_identif = kp.sc_kad_identif::text
+GROUP BY u1.app_re_identif, kp.sc_kad_identif
+WITH NO DATA;
+
+COMMENT ON VIEW mb_util_app_re_kad_perceel
+IS 'commentaar view mb_util_app_re_kad_perceel:
+utility view, niet bedoeld voor direct gebruik, met lijst van appartementsrechten met bijbehorend grondperceel
+
+beschikbare kolommen:
+* app_re_identif: natuurlijk is van appartementsrecht,
+* perceel_identif: natuurlijk id van grondperceel
+';
+CREATE INDEX mb_util_app_re_kad_perceel_identif ON mb_util_app_re_kad_perceel USING btree (app_re_identif);
+
+
+DROP MATERIALIZED VIEW mb_kad_onrrnd_zk_adres;
+CREATE MATERIALIZED VIEW mb_kad_onrrnd_zk_adres AS
+ SELECT row_number() OVER ()::integer AS objectid,
+    qry.identif AS koz_identif,
+    koz.dat_beg_geldh AS begin_geldigheid,
+    bok.fk_nn_lh_tgo_identif AS benoemdobj_identif,
+    qry.type,
+    (COALESCE(qry.ka_sectie, ''::character varying)::text || ' '::text) || COALESCE(qry.ka_perceelnummer, ''::character varying)::text AS aanduiding,
+    (((((COALESCE(qry.ka_kad_gemeentecode, ''::character varying)::text || ' '::text) || COALESCE(qry.ka_sectie, ''::character varying)::text) || ' '::text) || COALESCE(qry.ka_perceelnummer, ''::character varying)::text) || ' '::text) || COALESCE(qry.ka_appartementsindex, ''::character varying)::text AS aanduiding2,
+    qry.ka_sectie AS sectie,
+    qry.ka_perceelnummer AS perceelnummer,
+    qry.ka_appartementsindex AS appartementsindex,
+    qry.ka_kad_gemeentecode AS gemeentecode,
+    qry.aand_soort_grootte,
+    qry.grootte_perceel,
+    st_area(qry.begrenzing_perceel) AS oppervlakte_geom,
+    qry.ka_deelperceelnummer AS deelperceelnummer,
+    qry.omschr_deelperceel,
+    b.datum AS verkoop_datum,
+    koz.cu_aard_cultuur_onbebouwd AS aard_cultuur_onbebouwd,
+    koz.ks_bedrag AS bedrag,
+    koz.ks_koopjaar AS koopjaar,
+    koz.ks_meer_onroerendgoed AS meer_onroerendgoed,
+    koz.ks_valutasoort AS valutasoort,
+    koz.lo_loc__omschr AS loc_omschr,
+    bola.gemeente,
+    bola.woonplaats,
+    bola.straatnaam,
+    bola.huisnummer,
+    bola.huisletter,
+    bola.huisnummer_toev,
+    bola.postcode,
+    st_x(st_transform(st_setsrid(st_centroid(qry.begrenzing_perceel), 28992), 4326)) AS lon,
+    st_y(st_transform(st_setsrid(st_centroid(qry.begrenzing_perceel), 28992), 4326)) AS lat,
+    qry.begrenzing_perceel
+   FROM ( SELECT p.sc_kad_identif AS identif,
+            'perceel'::character varying(11) AS type,
+            p.ka_sectie,
+            p.ka_perceelnummer,
+            NULL::character varying(4) AS ka_appartementsindex,
+            p.ka_kad_gemeentecode,
+            p.aand_soort_grootte,
+            p.grootte_perceel,
+            p.ka_deelperceelnummer,
+            p.omschr_deelperceel,
+            p.begrenzing_perceel
+           FROM kad_perceel p
+        UNION ALL
+         SELECT ar.sc_kad_identif AS identif,
+            'appartement'::character varying(11) AS type,
+            ar.ka_sectie,
+            ar.ka_perceelnummer,
+            ar.ka_appartementsindex,
+            ar.ka_kad_gemeentecode,
+            NULL::character varying(1) AS aand_soort_grootte,
+            NULL::numeric(8,0) AS grootte_perceel,
+            NULL::character varying(4) AS ka_deelperceelnummer,
+            NULL::character varying(1120) AS omschr_deelperceel,
+            kp.begrenzing_perceel
+           FROM mb_util_app_re_kad_perceel v
+             JOIN kad_perceel kp ON v.perceel_identif = kp.sc_kad_identif
+             JOIN app_re ar ON v.app_re_identif::numeric = ar.sc_kad_identif) qry
+     JOIN kad_onrrnd_zk koz ON koz.kad_identif = qry.identif
+     LEFT JOIN benoemd_obj_kad_onrrnd_zk bok ON bok.fk_nn_rh_koz_kad_identif = qry.identif
+     LEFT JOIN mb_benoemd_obj_adres bola ON bok.fk_nn_lh_tgo_identif::text = bola.benoemdobj_identif::text
+     LEFT JOIN ( SELECT brondocument.ref_id,
+            max(brondocument.datum) AS datum
+           FROM brondocument
+          WHERE brondocument.omschrijving::text = 'Akte van Koop en Verkoop'::text
+          GROUP BY brondocument.ref_id) b ON koz.kad_identif::text = b.ref_id::text
+ WITH NO DATA;
+
+CREATE UNIQUE INDEX mb_kad_onrrnd_zk_adres_objectid ON mb_kad_onrrnd_zk_adres USING btree (objectid);
+CREATE INDEX mb_kad_onrrnd_zk_adres_identif ON mb_kad_onrrnd_zk_adres USING btree (koz_identif);
+CREATE INDEX mb_kad_onrrnd_zk_adres_begrenzing_perceel_idx ON mb_kad_onrrnd_zk_adres USING gist (begrenzing_perceel);
+
+
+DROP MATERIALIZED VIEW mb_avg_koz_rechth;
+CREATE MATERIALIZED VIEW mb_avg_koz_rechth AS
+ SELECT row_number() OVER ()::integer AS objectid,
+    koz.koz_identif,
+    koz.begin_geldigheid,
+    koz.type,
+    (COALESCE(koz.sectie, ''::character varying)::text || ' '::text) || COALESCE(koz.perceelnummer, ''::character varying)::text AS aanduiding,
+    (((((COALESCE(koz.gemeentecode, ''::character varying)::text || ' '::text) || COALESCE(koz.sectie, ''::character varying)::text) || ' '::text) || COALESCE(koz.perceelnummer, ''::character varying)::text) || ' '::text) || COALESCE(koz.appartementsindex, ''::character varying)::text AS aanduiding2,
+    koz.sectie,
+    koz.perceelnummer,
+    koz.appartementsindex,
+    koz.gemeentecode,
+    koz.aand_soort_grootte,
+    koz.grootte_perceel,
+    koz.oppervlakte_geom,
+    koz.deelperceelnummer,
+    koz.omschr_deelperceel,
+    koz.verkoop_datum,
+    koz.aard_cultuur_onbebouwd,
+    koz.bedrag,
+    koz.koopjaar,
+    koz.meer_onroerendgoed,
+    koz.valutasoort,
+    koz.loc_omschr,
+    zrr.zr_identif,
+    zrr.subject_identif,
+    zrr.aandeel,
+    zrr.omschr_aard_verkregenr_recht,
+    zrr.indic_betrokken_in_splitsing,
+    zrr.soort,
+    zrr.geslachtsnaam,
+    zrr.voorvoegsel,
+    zrr.voornamen,
+    zrr.aand_naamgebruik,
+    zrr.geslachtsaand,
+    zrr.naam,
+    zrr.woonadres,
+    zrr.geboortedatum,
+    zrr.geboorteplaats,
+    zrr.overlijdensdatum,
+    zrr.bsn,
+    zrr.organisatie_naam,
+    zrr.rechtsvorm,
+    zrr.statutaire_zetel,
+    zrr.rsin,
+    zrr.kvk_nummer,
+    koz.gemeente,
+    koz.woonplaats,
+    koz.straatnaam,
+    koz.huisnummer,
+    koz.huisletter,
+    koz.huisnummer_toev,
+    koz.postcode,
+    koz.lon,
+    koz.lat,
+    koz.begrenzing_perceel
+   FROM vb_avg_zr_rechth zrr
+     RIGHT JOIN mb_kad_onrrnd_zk_adres koz ON zrr.koz_identif = koz.koz_identif
+WITH NO DATA;
+
+CREATE UNIQUE INDEX mb_avg_koz_rechth_objectid ON mb_avg_koz_rechth USING btree (objectid);
+CREATE INDEX mb_avg_koz_rechth_identif ON mb_avg_koz_rechth USING btree (koz_identif);
+CREATE INDEX mb_avg_koz_rechth_begrenzing_perceel_idx ON mb_avg_koz_rechth USING gist (begrenzing_perceel);
+
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_1.6.1_naar_1.6.2','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/1.6.1-1.6.2/postgresql/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.6.1-1.6.2/postgresql/rsgb.sql
@@ -11,7 +11,7 @@ JOIN kad_perceel kp ON u1.parent_identif = kp.sc_kad_identif::text
 GROUP BY u1.app_re_identif, kp.sc_kad_identif
 WITH NO DATA;
 
-COMMENT ON VIEW mb_util_app_re_kad_perceel
+COMMENT ON MATERIALIZED VIEW mb_util_app_re_kad_perceel
 IS 'commentaar view mb_util_app_re_kad_perceel:
 utility view, niet bedoeld voor direct gebruik, met lijst van appartementsrechten met bijbehorend grondperceel
 beschikbare kolommen:

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,9 @@
         <maven-jxr-plugin.version>3.0.0</maven-jxr-plugin.version>
         <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
         <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>
+        <!-- deze property wordt gebruikt om tijdens tests te bepalen of we met een geupgraded
+        release database werken of een ontwikkel versie -->
+        <database.upgrade/>
     </properties>
     <dependencyManagement>
         <!--


### PR DESCRIPTION
Voegt materialized hulpview `mb_util_app_re_kad_perceel` toe en pas de definities van `mb_avg_koz_rechth` en `mb_kad_onrrnd_zk_adres` aan om de materialized hulp view te gebruiken.

De views moeten in volgorde worden ververst:

1. mb_util_app_re_kad_perceel
2. mb_kad_onrrnd_zk_adres
3. mb_avg_koz_rechth
4. mb_koz_rechth

### aanpassingen views en upgrade procedure
- [x] PostgreSQL
- [x] Oracle
- [ ] ~~MS SQL Server~~ kent geen MV
- [x] wiki pagina: https://github.com/B3Partners/brmo/wiki/basisviews_v2#materialized-views

close #561