### PR TITLE
verplaats spatial operaties naar inner query om ORA-22806 te voorkomen

### DIFF
--- a/.travis/getlastRelease.sh
+++ b/.travis/getlastRelease.sh
@@ -10,7 +10,7 @@ echo "Huidige snapshot:" $CURSNAPSHOT", vorige, te downloaden, release: "$PREVRE
 
 REMOTE_FILE="https://repo.b3p.nl/nexus/repository/releases/nl/b3p/brmo-dist/${PREVRELEASE}/brmo-dist-${PREVRELEASE}-bin.zip"
 LOCAL_FILE="${HOME}/downloads/brmo-dist-old.zip"
-#local_file="/tmp/downloads/brmo-dist-old.zip"
+#LOCAL_FILE="/tmp/downloads/brmo-dist-old.zip"
 
 #modified=$(curl --silent --head $remote_file | awk '/^Last-Modified/{print $0}' | sed 's/^Last-Modified: //')
 #remote_ctime=$(date --date="$modified" +%s)
@@ -21,7 +21,11 @@ LOCAL_FILE="${HOME}/downloads/brmo-dist-old.zip"
 #[ $local_ctime -lt $remote_ctime ] && curl --create-dirs -o $local_file $remote_file
 #wget -N -nc --tries=5 --timeout=60 --waitretry=300 --user-agent="" "https://repo.b3p.nl/nexus/repository/releases/nl/b3p/brmo-dist/$PREVRELEASE/brmo-dist-$PREVRELEASE-bin.zip"  --output-document="/tmp/downloads/brmo-dist-old.zip"
 
-LOCAL_SIZE=$(wc -c < $LOCAL_FILE)
+if [ -f "$LOCAL_FILE" ]; then
+    LOCAL_SIZE=$(wc -c < $LOCAL_FILE)
+else
+    LOCAL_SIZE=0
+fi
 REMOTE_SIZE=$(curl -sI $REMOTE_FILE | awk '/Content-Length/ {sub("\r",""); print $2}')
 
 echo "remote size: "$REMOTE_SIZE", local size: "$LOCAL_SIZE

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ timestamps {
         ]]);
 
     node {
-        withEnv(["JAVA_HOME=${ tool 'JDK8' }", "PATH+MAVEN=${tool 'Maven 3.5.4'}/bin:${env.JAVA_HOME}/bin"]) {
+        withEnv(["JAVA_HOME=${ tool 'JDK8' }", "PATH+MAVEN=${tool 'Maven 3.6.0'}/bin:${env.JAVA_HOME}/bin"]) {
 
             stage('Prepare') {
                 sh "ulimit -a"

--- a/datamodel/upgrade_scripts/1.6.1-1.6.2/oracle/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.6.1-1.6.2/oracle/rsgb.sql
@@ -1,6 +1,7 @@
 -- 
 -- upgrade Oracle RSGB datamodel van 1.6.1 naar 1.6.2 
 --
+WHENEVER SQLERROR EXIT SQL.SQLCODE
 
 -- issue #565
 ALTER TABLE KAD_PERCEEL MODIFY (AAND_SOORT_GROOTTE VARCHAR2(2));

--- a/datamodel/upgrade_scripts/1.6.1-1.6.2/oracle/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.6.1-1.6.2/oracle/rsgb.sql
@@ -30,7 +30,7 @@ beschikbare kolommen:
 CREATE INDEX mb_util_app_re_kad_perceel_id ON mb_util_app_re_kad_perceel(app_re_identif);
 
 DROP MATERIALIZED VIEW mb_kad_onrrnd_zk_adres;
-CREATE MATERIALIZED VIEW mb_kad_onrrnd_zk_adres(
+CREATE MATERIALIZED VIEW mb_kad_onrrnd_zk_adres (
     objectid,
     koz_identif,
     begin_geldigheid,
@@ -63,117 +63,124 @@ CREATE MATERIALIZED VIEW mb_kad_onrrnd_zk_adres(
     postcode,
     lon,
     lat,
-    begrenzing_perceel) 
+    begrenzing_perceel)
 BUILD DEFERRED REFRESH ON DEMAND AS
 SELECT
-    CAST(ROWNUM AS INTEGER)  AS objectid,
-    qry.identif              AS koz_identif,
-    koz.dat_beg_geldh        AS begin_geldigheid,
-    bok.fk_nn_lh_tgo_identif AS benoemdobj_identif,
-    qry.type,
-    COALESCE(qry.ka_sectie, '') || ' ' || COALESCE(qry.ka_perceelnummer, '') AS aanduiding,
-    COALESCE(qry.ka_kad_gemeentecode, '') || ' ' || COALESCE(qry.ka_sectie, '') || ' ' || COALESCE(qry.ka_perceelnummer, '') || ' ' || COALESCE(qry.ka_appartementsindex, '') AS aanduiding2,
-    qry.ka_sectie,
-    qry.ka_perceelnummer,
-    qry.ka_appartementsindex,
-    qry.ka_kad_gemeentecode,
-    qry.aand_soort_grootte,
-    qry.grootte_perceel,
-    CASE
-        WHEN qry.begrenzing_perceel.get_gtype() IS NOT NULL
-        THEN SDO_GEOM.SDO_AREA(qry.BEGRENZING_PERCEEL, 0.1)
-        ELSE NULL
-    END AS oppervlakte_geom,
-    qry.ka_deelperceelnummer,
-    qry.omschr_deelperceel,
-    b.datum,
-    koz.cu_aard_cultuur_onbebouwd,
-    koz.ks_bedrag,
-    koz.ks_koopjaar,
-    koz.ks_meer_onroerendgoed,
-    koz.ks_valutasoort,
-    koz.lo_loc__omschr,
-    bola.gemeente,
-    bola.woonplaats,
-    bola.straatnaam,
-    bola.huisnummer,
-    bola.huisletter,
-    bola.huisnummer_toev,
-    bola.postcode,
-    CASE
-        WHEN qry.begrenzing_perceel.get_gtype() IS NOT NULL
-        THEN SDO_CS.TRANSFORM(SDO_GEOM.SDO_CENTROID(qry.begrenzing_perceel, 0.1), 4326).sdo_point.x
-        ELSE NULL
-    END AS lon,
-    CASE
-        WHEN qry.begrenzing_perceel.get_gtype() IS NOT NULL
-        THEN SDO_CS.TRANSFORM(SDO_GEOM.SDO_CENTROID(qry.begrenzing_perceel, 0.1), 4326).sdo_point.y
-    END AS lat,
-    qry.begrenzing_perceel
-FROM
-    (
-        SELECT
-            p.sc_kad_identif AS identif,
-            'perceel'        AS type,
-            p.ka_sectie,
-            p.ka_perceelnummer,
-            CAST(NULL AS CHARACTER VARYING(4)) AS ka_appartementsindex,
-            p.ka_kad_gemeentecode,
-            p.aand_soort_grootte,
-            p.grootte_perceel,
-            p.ka_deelperceelnummer,
-            p.omschr_deelperceel,
-            p.BEGRENZING_PERCEEL AS begrenzing_perceel
-        FROM
-            kad_perceel p
-        UNION ALL
-        SELECT
-            ar.sc_kad_identif AS identif,
-            'appartement'     AS type,
-            ar.ka_sectie,
-            ar.ka_perceelnummer,
-            ar.ka_appartementsindex,
-            ar.ka_kad_gemeentecode,
-            CAST(NULL AS CHARACTER VARYING(2))    AS aand_soort_grootte,
-            CAST(NULL AS NUMERIC(8, 0))           AS grootte_perceel,
-            CAST(NULL AS CHARACTER VARYING(4))    AS ka_deelperceelnummer,
-            CAST(NULL AS CHARACTER VARYING(1120)) AS omschr_deelperceel,
-            kp.BEGRENZING_PERCEEL                 AS begrenzing_perceel
-        FROM
-            mb_util_app_re_kad_perceel v
-        JOIN
-            kad_perceel kp
-        ON
-            CAST(v.perceel_identif AS NUMERIC) = kp.sc_kad_identif
-        JOIN
-            app_re ar
-        ON
-            CAST(v.app_re_identif AS NUMERIC) = ar.sc_kad_identif) qry
-JOIN
-    kad_onrrnd_zk koz
-ON
-    koz.kad_identif = qry.identif
-LEFT JOIN
-    benoemd_obj_kad_onrrnd_zk bok
-ON
-    bok.fk_nn_rh_koz_kad_identif = qry.identif
-LEFT JOIN
-    vb_benoemd_obj_adres bola
-ON
-    bok.fk_nn_lh_tgo_identif = bola.benoemdobj_identif
-LEFT JOIN
-    (
-        SELECT
-            brondocument.ref_id,
-            MAX(brondocument.datum) AS datum
-        FROM
-            brondocument
-        WHERE
-            brondocument.omschrijving = 'Akte van Koop en Verkoop'
-        GROUP BY
-            brondocument.ref_id) b
-ON
-    koz.kad_identif = b.ref_id;
+        CAST(ROWNUM AS INTEGER) AS objectid,
+        qry.identif                AS koz_identif,
+        koz.dat_beg_geldh          AS begin_geldigheid,
+        bok.fk_nn_lh_tgo_identif   AS benoemdobj_identif,
+        qry.type,
+        coalesce(qry.ka_sectie,'')
+        || ' '
+        || coalesce(qry.ka_perceelnummer,'') AS aanduiding,
+        coalesce(qry.ka_kad_gemeentecode,'')
+        || ' '
+        || coalesce(qry.ka_sectie,'')
+        || ' '
+        || coalesce(qry.ka_perceelnummer,'')
+        || ' '
+        || coalesce(qry.ka_appartementsindex,'') AS aanduiding2,
+        qry.ka_sectie,
+        qry.ka_perceelnummer,
+        qry.ka_appartementsindex,
+        qry.ka_kad_gemeentecode,
+        qry.aand_soort_grootte,
+        qry.grootte_perceel,
+        qry.oppervlakte_geom,
+        qry.ka_deelperceelnummer,
+        qry.omschr_deelperceel,
+        b.datum,
+        koz.cu_aard_cultuur_onbebouwd,
+        koz.ks_bedrag,
+        koz.ks_koopjaar,
+        koz.ks_meer_onroerendgoed,
+        koz.ks_valutasoort,
+        koz.lo_loc__omschr,
+        bola.gemeente,
+        bola.woonplaats,
+        bola.straatnaam,
+        bola.huisnummer,
+        bola.huisletter,
+        bola.huisnummer_toev,
+        bola.postcode,
+        qry.lon,
+        qry.lat,
+        qry.begrenzing_perceel
+    FROM
+        (
+            SELECT
+                p.sc_kad_identif       AS identif,
+                'perceel' AS type,
+                p.ka_sectie,
+                p.ka_perceelnummer,
+                CAST(NULL AS CHARACTER VARYING(4) ) AS ka_appartementsindex,
+                p.ka_kad_gemeentecode,
+                p.aand_soort_grootte,
+                p.grootte_perceel,
+                p.ka_deelperceelnummer,
+                p.omschr_deelperceel,
+                p.begrenzing_perceel   AS begrenzing_perceel,
+                CASE
+                    WHEN p.begrenzing_perceel.get_gtype() IS NOT NULL THEN sdo_geom.sdo_area(p.begrenzing_perceel,0.1)
+                    ELSE NULL
+                END AS oppervlakte_geom,
+                CASE
+                    WHEN p.begrenzing_perceel.get_gtype() IS NOT NULL THEN sdo_cs.transform(sdo_geom.sdo_centroid(p.begrenzing_perceel
+                   ,0.1),4326).sdo_point.x
+                    ELSE NULL
+                END AS lon,
+                CASE
+                    WHEN p.begrenzing_perceel.get_gtype() IS NOT NULL THEN sdo_cs.transform(sdo_geom.sdo_centroid(p.begrenzing_perceel
+                   ,0.1),4326).sdo_point.y
+                END AS lat
+            FROM
+                kad_perceel p
+            UNION ALL
+            SELECT
+                ar.sc_kad_identif       AS identif,
+                'appartement' AS type,
+                ar.ka_sectie,
+                ar.ka_perceelnummer,
+                ar.ka_appartementsindex,
+                ar.ka_kad_gemeentecode,
+                CAST(NULL AS CHARACTER VARYING(2) ) AS aand_soort_grootte,
+                CAST(NULL AS NUMERIC(8,0) ) AS grootte_perceel,
+                CAST(NULL AS CHARACTER VARYING(4) ) AS ka_deelperceelnummer,
+                CAST(NULL AS CHARACTER VARYING(1120) ) AS omschr_deelperceel,
+                kp.begrenzing_perceel   AS begrenzing_perceel,
+                CASE
+                    WHEN kp.begrenzing_perceel.get_gtype() IS NOT NULL THEN sdo_geom.sdo_area(kp.begrenzing_perceel,0.1)
+                    ELSE NULL
+                END AS oppervlakte_geom,
+                CASE
+                    WHEN kp.begrenzing_perceel.get_gtype() IS NOT NULL THEN sdo_cs.transform(sdo_geom.sdo_centroid(kp.begrenzing_perceel
+                   ,0.1),4326).sdo_point.x
+                    ELSE NULL
+                END AS lon,
+                CASE
+                    WHEN kp.begrenzing_perceel.get_gtype() IS NOT NULL THEN sdo_cs.transform(sdo_geom.sdo_centroid(kp.begrenzing_perceel
+                   ,0.1),4326).sdo_point.y
+                END AS lat
+            FROM
+                mb_util_app_re_kad_perceel v
+                JOIN kad_perceel kp ON CAST(v.perceel_identif AS NUMERIC) = kp.sc_kad_identif
+                JOIN app_re ar ON CAST(v.app_re_identif AS NUMERIC) = ar.sc_kad_identif
+        ) qry
+        JOIN kad_onrrnd_zk koz ON ( koz.kad_identif = qry.identif )
+        LEFT JOIN benoemd_obj_kad_onrrnd_zk bok ON ( bok.fk_nn_rh_koz_kad_identif = qry.identif )
+        LEFT JOIN vb_benoemd_obj_adres bola ON ( bok.fk_nn_lh_tgo_identif = bola.benoemdobj_identif )
+        LEFT JOIN (
+            SELECT
+                bd.ref_id,
+                MAX(bd.datum) AS datum
+            FROM
+                brondocument bd
+            WHERE
+                ( ( bd.omschrijving ) = 'Akte van Koop en Verkoop' )
+            GROUP BY
+                bd.ref_id
+        ) b ON ( koz.kad_identif = b.ref_id );
     
 CREATE UNIQUE INDEX MB_KAD_ONRRND_ZK_ADRES_OBJIDX ON MB_KAD_ONRRND_ZK_ADRES(OBJECTID ASC);
 CREATE INDEX MB_KAD_ONRRND_ZK_ADRES_IDENTIF ON MB_KAD_ONRRND_ZK_ADRES(KOZ_IDENTIF ASC);

--- a/datamodel/upgrade_scripts/1.6.2-1.6.3/oracle/rsgb.sql
+++ b/datamodel/upgrade_scripts/1.6.2-1.6.3/oracle/rsgb.sql
@@ -1,7 +1,7 @@
 -- 
 -- upgrade Oracle RSGB datamodel van 1.6.2 naar 1.6.3 
 --
-
+WHENEVER SQLERROR EXIT SQL.SQLCODE
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_1.6.2_naar_1.6.3','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/new-version-upgrades.sh
+++ b/datamodel/upgrade_scripts/new-version-upgrades.sh
@@ -29,6 +29,10 @@ do
       echo Bestand $DIR/$b.sql bestaal al.
     else
       echo -- $'\n'-- upgrade $DB ${b^^} datamodel van $PREVRELEASE naar $NEXTRELEASE $n $'\n'-- > $DIR/$b.sql
+      if [ "$DB" == "Oracle" ]
+      then
+        echo $'\n'  WHENEVER SQLERROR EXIT SQL.SQLCODE
+      fi
       echo $'\n\n'-- onderstaande dienen als laatste stappen van een upgrade uitgevoerd >> $DIR/$b.sql
       if [ "${DB}" == "SQLserver" ]
       then


### PR DESCRIPTION
verplaats spatial operaties van  naar inner query om ORA-22806 te voorkomen

- [x] aanpassen `mb_kad_onrrnd_zk_adres` definitie in 207_brk_views.sql
- [x] aanpassen `mb_kad_onrrnd_zk_adres` definitie in upgrade script
- [x] nieuw installatie archief met de nieuwe `mb_kad_onrrnd_zk_adres` definitie

close #570