### PR TITLE
Revert surefire upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <test.h2.version>1.4.197</test.h2.version>
         <test.hsqldb.version>2.4.1</test.hsqldb.version>
         <test.onlyITs>false</test.onlyITs>
-        <maven.surefire.version>3.0.0-M1</maven.surefire.version>
+        <maven.surefire.version>2.22.1</maven.surefire.version>
         <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
         <versions-maven-plugin.version>2.7</versions-maven-plugin.version>
         <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>


### PR DESCRIPTION
Er zit een bug in surefire 3.0.0-M1 die in Windows opduikt, zie [3.0.0-M1 produces invalid code sources on Windows](https://issues.apache.org/jira/browse/SUREFIRE-1593)

zie 0a41b4b20199af06b151b8b05a1bb63238b64b2b en #564