### PR TITLE
Voeg het nHR soap bericht toe aan nhr bericht

### DIFF
--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/RsgbProxy.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/RsgbProxy.java
@@ -326,7 +326,7 @@ public class RsgbProxy implements Runnable, BerichtenHandler {
         }
         ber.setStatusDatum(new Date());
         try {
-            stagingProxy.updateBericht(ber);
+            stagingProxy.updateBerichtProcessing(ber);
         } catch (SQLException ex) {
             log.error("Kan status niet updaten", ex);
         }

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/entity/Bericht.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/entity/Bericht.java
@@ -154,6 +154,6 @@ public class Bericht {
 
     @Override
     public String toString() {
-        return "Bericht{" + "id=" + id + ", objectRef=" + objectRef + ", datum=" + datum + ", volgordeNummer=" + volgordeNummer + ", soort=" + soort + ", status=" + status + ", jobId=" + jobId + ", statusDatum=" + statusDatum + '}';
+        return "Bericht{" + "id=" + id + ", objectRef=" + objectRef + ", datum=" + datum + ", volgordeNummer=" + volgordeNummer + ", soort=" + soort + ", status=" + status + ", jobId=" + jobId + ", statusDatum=" + statusDatum + " (lengte br origineel=" + (brOrgineelXml == null ? null : brOrgineelXml.length()) + '}';
     }
 }

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
@@ -53,7 +53,7 @@ public class NhrXMLReader extends BrmoXMLReader {
 
     private int volgorde = 0;
 
-    private String brXML = null;
+    private String brOrigXML = null;
 
     public NhrXMLReader(InputStream in) throws Exception {
         initTemplates();
@@ -80,8 +80,8 @@ public class NhrXMLReader extends BrmoXMLReader {
 
         iterator = b.berichten.iterator();
 
-        brXML = bos.toString(StandardCharsets.UTF_8.name());
-        LOG.debug("Originele nHR xml is: \n" + brXML);
+        brOrigXML = bos.toString(StandardCharsets.UTF_8.name());
+        LOG.debug("Originele nHR xml is: \n" + brOrigXML);
 
         init();
     }
@@ -126,8 +126,13 @@ public class NhrXMLReader extends BrmoXMLReader {
         xml.insert(xml.lastIndexOf("</"), bsns);
 
         b.setBrXml(xml.toString());
+
+        // we willen alleen bij het eerst geparsede nhr bericht de originele soap hebben
+        if (volgorde == 0) {
+            b.setBrOrgineelXml(brOrigXML);
+        }
+
         b.setVolgordeNummer(volgorde++);
-        b.setBrOrgineelXml(brXML);
         return b;
     }
 

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
@@ -1,9 +1,7 @@
 package nl.b3p.brmo.loader.xml;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringReader;
-import java.io.StringWriter;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -27,6 +25,7 @@ import nl.b3p.brmo.loader.entity.Bericht;
 import nl.b3p.brmo.loader.entity.NhrBericht;
 import nl.b3p.brmo.loader.entity.NhrBerichten;
 import nl.b3p.brmo.loader.util.BrmoLeegBestandException;
+import org.apache.commons.io.input.TeeInputStream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.w3c.dom.Document;
@@ -35,10 +34,14 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 /**
+ * Deze reader splitst een nHR soap response in berichten.
  *
  * @author Matthijs Laan
+ * @author mprins
  */
 public class NhrXMLReader extends BrmoXMLReader {
+
+    public static final String PREFIX = "nhr.bsn.natPers.";
 
     private static final Log LOG = LogFactory.getLog(NhrXMLReader.class);
 
@@ -46,13 +49,17 @@ public class NhrXMLReader extends BrmoXMLReader {
 
     private static Transformer t;
 
-    Iterator<NhrBericht> iterator;
-    int volgorde = 0;
+    private Iterator<NhrBericht> iterator;
 
-    public static final String PREFIX = "nhr.bsn.natPers.";
+    private int volgorde = 0;
+
+    private String brXML = null;
 
     public NhrXMLReader(InputStream in) throws Exception {
         initTemplates();
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        in = new TeeInputStream(in, bos, true);
 
         // Split input naar multiple berichten
         DOMResult r = new DOMResult();
@@ -69,6 +76,8 @@ public class NhrXMLReader extends BrmoXMLReader {
 
         if(!b.berichten.isEmpty()) {
             setBestandsDatum(b.berichten.get(0).getDatum());
+            brXML = bos.toString(StandardCharsets.UTF_8.name());
+            LOG.debug("Originele nHR xml is: \n" + brXML);
         }
 
         iterator = b.berichten.iterator();
@@ -117,6 +126,7 @@ public class NhrXMLReader extends BrmoXMLReader {
 
         b.setBrXml(xml.toString());
         b.setVolgordeNummer(volgorde++);
+        b.setBrOrgineelXml(brXML);
         return b;
     }
 

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
@@ -76,11 +76,12 @@ public class NhrXMLReader extends BrmoXMLReader {
 
         if(!b.berichten.isEmpty()) {
             setBestandsDatum(b.berichten.get(0).getDatum());
-            brXML = bos.toString(StandardCharsets.UTF_8.name());
-            LOG.debug("Originele nHR xml is: \n" + brXML);
         }
 
         iterator = b.berichten.iterator();
+
+        brXML = bos.toString(StandardCharsets.UTF_8.name());
+        LOG.debug("Originele nHR xml is: \n" + brXML);
 
         init();
     }

--- a/brmo-loader/src/test/java/nl/b3p/GH527NhrToStagingToRsgbIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/GH527NhrToStagingToRsgbIntegrationTest.java
@@ -135,6 +135,12 @@ public class GH527NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseInte
         Thread t = brmo.toRsgb();
         t.join();
 
+        // na de verwerking moet soap payload er ook nog zijn
+        bericht = staging.createDataSet().getTable("bericht");
+        for (int i = 0; i < bericht.getRowCount(); i++) {
+            assertNotNull("BR origineel xml is null na transformatie", bericht.getValue(i, "br_orgineel_xml"));
+        }
+
         checkWaarde("subject", "clazz");
         checkWaarde("subject", "typering");
         checkWaarde("prs", "clazz");

--- a/brmo-loader/src/test/java/nl/b3p/GH527NhrToStagingToRsgbIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/GH527NhrToStagingToRsgbIntegrationTest.java
@@ -125,21 +125,22 @@ public class GH527NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseInte
         brmo.loadFromFile("nhr", GH527NhrToStagingToRsgbIntegrationTest.class.getResource(bestandNaam).getFile(), 1L);
         LOG.info("klaar met laden van berichten in staging DB.");
 
-        ITable bericht = staging.createDataSet().getTable("bericht");
-        for (int i = 0; i < bericht.getRowCount(); i++) {
-            LOG.debug("\n\n" + bericht.getValue(i, "br_orgineel_xml") + "\n\n");
-            assertNotNull("BR origineel xml is null", bericht.getValue(i, "br_orgineel_xml"));
-        }
+        // alleen het eerste bericht heeft br_orgineel_xml, de rest niet
+        ITable bericht = staging.createQueryTable("bericht", "select * from bericht where volgordenummer=0");
+        assertEquals("Er zijn meer of minder dan 1 rij", 1, bericht.getRowCount());
+        LOG.debug("\n\n" + bericht.getValue(0, "br_orgineel_xml") + "\n\n");
+        assertNotNull("BR origineel xml is null", bericht.getValue(0, "br_orgineel_xml"));
+        Object berichtId = bericht.getValue(0, "id");
 
         LOG.info("Transformeren berichten naar rsgb DB.");
         Thread t = brmo.toRsgb();
         t.join();
 
         // na de verwerking moet soap payload er ook nog zijn
-        bericht = staging.createDataSet().getTable("bericht");
-        for (int i = 0; i < bericht.getRowCount(); i++) {
-            assertNotNull("BR origineel xml is null na transformatie", bericht.getValue(i, "br_orgineel_xml"));
-        }
+        bericht = staging.createQueryTable("bericht", "select * from bericht where br_orgineel_xml is not null");
+        assertEquals("Er zijn meer of minder dan 1 rij", 1, bericht.getRowCount());
+        assertNotNull("BR origineel xml is null na transformatie", bericht.getValue(0, "br_orgineel_xml"));
+        assertEquals("bericht met br_orgineel_xml moet hetzelfde id hebben na transformatie", berichtId, bericht.getValue(0, "id"));
 
         checkWaarde("subject", "clazz");
         checkWaarde("subject", "typering");

--- a/brmo-loader/src/test/java/nl/b3p/GH527NhrToStagingToRsgbIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/GH527NhrToStagingToRsgbIntegrationTest.java
@@ -122,8 +122,14 @@ public class GH527NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseInte
         final String bestandNaam = "/nhr-v3/33257455,23052007.anon.xml";
         assumeNotNull("Het test bestand moet er zijn.", GH527NhrToStagingToRsgbIntegrationTest.class.getResource(bestandNaam));
 
-        brmo.loadFromFile("nhr", GH527NhrToStagingToRsgbIntegrationTest.class.getResource(bestandNaam).getFile());
+        brmo.loadFromFile("nhr", GH527NhrToStagingToRsgbIntegrationTest.class.getResource(bestandNaam).getFile(), 1L);
         LOG.info("klaar met laden van berichten in staging DB.");
+
+        ITable bericht = staging.createDataSet().getTable("bericht");
+        for (int i = 0; i < bericht.getRowCount(); i++) {
+            LOG.debug("\n\n" + bericht.getValue(i, "br_orgineel_xml") + "\n\n");
+            assertNotNull("BR origineel xml is null", bericht.getValue(i, "br_orgineel_xml"));
+        }
 
         LOG.info("Transformeren berichten naar rsgb DB.");
         Thread t = brmo.toRsgb();

--- a/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
@@ -229,7 +229,7 @@ public class NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
     public void testNhrXMLToStagingToRsgb() throws Exception {
         assumeNotNull("Het test bestand moet er zijn.", NhrToStagingToRsgbIntegrationTest.class.getResource(bestandNaam));
 
-        brmo.loadFromFile(BESTANDTYPE, NhrToStagingToRsgbIntegrationTest.class.getResource(bestandNaam).getFile());
+        brmo.loadFromFile(BESTANDTYPE, NhrToStagingToRsgbIntegrationTest.class.getResource(bestandNaam).getFile(), 1L);
         LOG.info("klaar met laden van berichten in staging DB.");
 
         List<Bericht> berichten = brmo.listBerichten();
@@ -238,6 +238,12 @@ public class NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
         assertEquals("Het aantal berichten is niet als verwacht.", aantalBerichten, berichten.size());
         assertNotNull("De verzameling processen bestaat niet.", processen);
         assertEquals("Het aantal processen is niet als verwacht.", aantalProcessen, processen.size());
+
+        ITable bericht = staging.createDataSet().getTable("bericht");
+        for (int i = 0; i < bericht.getRowCount(); i++) {
+            LOG.debug("\n\n" + bericht.getValue(i, "br_orgineel_xml") + "\n\n");
+            assertNotNull("BR origineel xml is null", bericht.getValue(i, "br_orgineel_xml"));
+        }
 
         LOG.info("Transformeren berichten naar rsgb DB.");
         Thread t = brmo.toRsgb();

--- a/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
@@ -239,21 +239,22 @@ public class NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
         assertNotNull("De verzameling processen bestaat niet.", processen);
         assertEquals("Het aantal processen is niet als verwacht.", aantalProcessen, processen.size());
 
-        ITable bericht = staging.createDataSet().getTable("bericht");
-        for (int i = 0; i < bericht.getRowCount(); i++) {
-            LOG.debug("\n\n" + bericht.getValue(i, "br_orgineel_xml") + "\n\n");
-            assertNotNull("BR origineel xml is null", bericht.getValue(i, "br_orgineel_xml"));
-        }
+        // alleen het eerste bericht heeft br_orgineel_xml, de rest niet
+        ITable bericht = staging.createQueryTable("bericht", "select * from bericht where volgordenummer=0");
+        assertEquals("Er zijn meer of minder dan 1 rij", 1, bericht.getRowCount());
+        LOG.debug("\n\n" + bericht.getValue(0, "br_orgineel_xml") + "\n\n");
+        assertNotNull("BR origineel xml is null", bericht.getValue(0, "br_orgineel_xml"));
+        Object berichtId = bericht.getValue(0, "id");
 
         LOG.info("Transformeren berichten naar rsgb DB.");
         Thread t = brmo.toRsgb();
         t.join();
 
         // na de verwerking moet soap payload er ook nog zijn
-        bericht = staging.createDataSet().getTable("bericht");
-        for (int i = 0; i < bericht.getRowCount(); i++) {
-            assertNotNull("BR origineel xml is null na transformatie", bericht.getValue(i, "br_orgineel_xml"));
-        }
+        bericht = staging.createQueryTable("bericht", "select * from bericht where br_orgineel_xml is not null");
+        assertEquals("Er zijn meer of minder dan 1 rij", 1, bericht.getRowCount());
+        assertNotNull("BR origineel xml is null na transformatie", bericht.getValue(0, "br_orgineel_xml"));
+        assertEquals("bericht met br_orgineel_xml moet hetzelfde id hebben na transformatie", berichtId, bericht.getValue(0, "id"));
 
         assertEquals("Niet alle berichten zijn OK getransformeerd", aantalBerichten, brmo.getCountBerichten(null, null, "nhr", "RSGB_OK"));
         berichten = brmo.listBerichten();

--- a/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
@@ -249,6 +249,12 @@ public class NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
         Thread t = brmo.toRsgb();
         t.join();
 
+        // na de verwerking moet soap payload er ook nog zijn
+        bericht = staging.createDataSet().getTable("bericht");
+        for (int i = 0; i < bericht.getRowCount(); i++) {
+            assertNotNull("BR origineel xml is null na transformatie", bericht.getValue(i, "br_orgineel_xml"));
+        }
+
         assertEquals("Niet alle berichten zijn OK getransformeerd", aantalBerichten, brmo.getCountBerichten(null, null, "nhr", "RSGB_OK"));
         berichten = brmo.listBerichten();
         for (Bericht b : berichten) {

--- a/brmo-loader/src/test/resources/log4j.xml
+++ b/brmo-loader/src/test/resources/log4j.xml
@@ -31,8 +31,11 @@
    <logger name="nl.b3p.topnl">
         <level value="info" />
     </logger>
+    <logger name="nl.b3p.brmo.loader">
+        <level value="info" />
+    </logger>
     <logger name="nl.b3p.brmo.loader.xml">
-        <level value="debug" />
+        <level value="info" />
     </logger>
     <root>
         <level value="info" />

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsActionBean.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsActionBean.java
@@ -91,6 +91,8 @@ public class AdvancedFunctionsActionBean implements ActionBean, ProgressUpdateLi
 
     private final String BRK_VERWIJDEREN_NOGMAALS_UITVOEREN = "Herhaal transformatie BRK verwijderberichten, oplossen achtergebleven 'kad_onrrnd_zk' records";
     private final String NHR_FIX_TYPERING = "Fix 'typering' en 'clazz' van nHR persoon";
+    private final String NHR_ARCHIVING = "Opschonen en archiveren van nHR berichten met status RSGB_OK, ouder dan 3 maanden";
+    private final String NHR_REMOVAL = "Verwijderen van nHR berichten met status ARCHIVE";
 
     private final boolean repairFirst = false;
 
@@ -212,8 +214,10 @@ public class AdvancedFunctionsActionBean implements ActionBean, ProgressUpdateLi
             new AdvancedFunctionProcess("Repareren BAG mutaties met status STAGING_NOK", BrmoFramework.BR_BAG, Bericht.STATUS.STAGING_NOK.toString()),
             new AdvancedFunctionProcess("Opschonen en archiveren van BRK berichten met status RSGB_OK, ouder dan 3 maanden", BrmoFramework.BR_BRK, Bericht.STATUS.RSGB_OK.toString()),
             new AdvancedFunctionProcess("Opschonen en archiveren van BAG berichten met status RSGB_OK, ouder dan 3 maanden", BrmoFramework.BR_BAG, Bericht.STATUS.RSGB_OK.toString()),
+            new AdvancedFunctionProcess(NHR_ARCHIVING, BrmoFramework.BR_NHR, Bericht.STATUS.RSGB_OK.toString()),
             new AdvancedFunctionProcess("Verwijderen van BRK berichten met status ARCHIVE", BrmoFramework.BR_BRK, Bericht.STATUS.ARCHIVE.toString()),
             new AdvancedFunctionProcess("Verwijderen van BAG berichten met status ARCHIVE", BrmoFramework.BR_BAG, Bericht.STATUS.ARCHIVE.toString()),
+            new AdvancedFunctionProcess(NHR_REMOVAL, BrmoFramework.BR_NHR, Bericht.STATUS.ARCHIVE.toString()),
             new AdvancedFunctionProcess(BRK_VERWIJDEREN_NOGMAALS_UITVOEREN, BrmoFramework.BR_BRK, Bericht.STATUS.RSGB_OK.toString()),
             new AdvancedFunctionProcess(NHR_FIX_TYPERING, BrmoFramework.BR_NHR, null)
         });
@@ -255,10 +259,14 @@ public class AdvancedFunctionsActionBean implements ActionBean, ProgressUpdateLi
                 cleanupBerichten(process.getConfig(), "brk");
             } else if (process.getName().equals("Opschonen en archiveren van BAG berichten met status RSGB_OK, ouder dan 3 maanden")) {
                 cleanupBerichten(process.getConfig(), "bag");
+            } else if (process.getName().equals(NHR_ARCHIVING)) {
+                cleanupBerichten(process.getConfig(), BrmoFramework.BR_NHR);
             } else if (process.getName().equals("Verwijderen van BRK berichten met status ARCHIVE")) {
                 deleteBerichten(process.getConfig(), "brk");
             } else if (process.getName().equals("Verwijderen van BAG berichten met status ARCHIVE")) {
                 deleteBerichten(process.getConfig(), "bag");
+            } else if (process.getName().equals(NHR_REMOVAL)) {
+                deleteBerichten(process.getConfig(), BrmoFramework.BR_NHR);
             } else if (process.getName().equals(BRK_VERWIJDEREN_NOGMAALS_UITVOEREN)) {
                 replayBRKVerwijderBerichten(process.getSoort(), process.getConfig());
             } else if (process.getName().equals(NHR_FIX_TYPERING)) {
@@ -575,7 +583,7 @@ public class AdvancedFunctionsActionBean implements ActionBean, ProgressUpdateLi
         Calendar c = Calendar.getInstance();
         c.setTime(new Date());
         c.add(Calendar.MONTH, -3);
-     
+
         String countsql = "select count(*) from " + BrmoFramework.BERICHT_TABLE 
                     + " where soort='" + soort + "' "
                     + " and status='" + config + "'"

--- a/brmo-service/src/main/webapp/WEB-INF/classes/log4j.properties
+++ b/brmo-service/src/main/webapp/WEB-INF/classes/log4j.properties
@@ -2,12 +2,14 @@ logFilePath=${catalina.base}/logs
 logFile=brmo-service.log
 
 log4j.rootLogger=INFO,file,GDS2urls
-log4j.logger.nl.b3p=INFO
+log4j.logger.nl.b3p.brmo.service.scanner.GDS2OphalenProces=INFO
 log4j.logger.nl.b3p.soap=INFO
 log4j.logger.nl.b3p.topnl=INFO
-log4j.logger.nl.b3p.soap=INFO
 log4j.logger.nl.b3p.web.jsp=INFO
-log4j.logger.nl.b3p.brmo.service.scanner.GDS2OphalenProces=INFO
+log4j.logger.nl.b3p.brmo.loader.xml=INFO
+log4j.logger.nl.b3p.brmo.loader=INFO
+log4j.logger.nl.b3p=INFO
+
 
 # hibernate logging
 # see https://docs.jboss.org/hibernate/core/3.6/reference/en-US/html/session-configuration.html#configuration-logging


### PR DESCRIPTION
Voeg de nHR soap response toe aan het eerste nHR bericht als `br_origineel_xml` zodat de bron beschikbaar blijft voor latere herleiding.

- [x] bericht parsen aanpassen
- [x] bericht verwerking aanpassen (de `br_origineel_xml` raakt kwijt tijdens transformatie #579 )
- [x] opruim procedures voor nHR in `nl.b3p.brmo.service.stripes.AdvancedFunctionsActionBean` "geavanceerde functies"
- [x] documentatie op de wiki voor de nieuwe nHR "geavanceerde functies": 
  - [Opschonen en archiveren van nHR berichten](https://github.com/B3Partners/brmo/wiki/Opschonen-en-archiveren-van-nHR-berichten)
  - [Verwijderen van nHR berichten met status ARCHIVE](https://github.com/B3Partners/brmo/wiki/Verwijderen-van-nHR-berichten-met-status-ARCHIVE)


close #549 
close #579