### PR TITLE
Oplossing van fout in gemeentelijke herindelings-scripts 2019 

### DIFF
--- a/datamodel/utility_scripts/oracle/120_vervallen_gemeenten.sql
+++ b/datamodel/utility_scripts/oracle/120_vervallen_gemeenten.sql
@@ -254,8 +254,8 @@ SET TRANSACTION NAME 'jan2019';
 -- Op 1 januari 2019 is het aantal gemeenten afgenomen met vijfentwintig, zodat het aantal gemeenten in Nederland 355 bedraagt.
 -- zie: https://www.cbs.nl/nl-nl/onze-diensten/methoden/classificaties/overig/gemeentelijke-indelingen-per-jaar/indeling%20per%20jaar/gemeentelijke-indeling-op-1-januari-2019
 UPDATE gemeente SET datum_einde_geldh = '2019-01-01', dat_beg_geldh = '2009-01-01' WHERE code IN (
--- Bedum (0005), Eemsmond (1651), De Marne (0053) en een deel van Winsum (0053) komen te vervallen
-5, 1651, 53,
+-- Bedum (0005), Eemsmond (1651), De Marne (1663) en een deel van Winsum (0053) komen te vervallen
+5, 1651, 1663, 53,
 -- Ten Boer (0009) en Haren (0017) komen te vervallen
 9, 17,
 -- Grootegast (0015), Leek (0022), Marum (0025), Zuidhorn (0056) en een deel van Winsum (0053) komen te vervallen
@@ -281,8 +281,8 @@ UPDATE gemeente SET datum_einde_geldh = '2019-01-01', dat_beg_geldh = '2009-01-0
 881, 951, 962
 );
 INSERT INTO gemeente_archief SELECT * FROM gemeente WHERE code IN (
--- Bedum (0005), Eemsmond (1651), De Marne (0053) en een deel van Winsum (0053) komen te vervallen
-5, 1651, 53,
+-- Bedum (0005), Eemsmond (1651), De Marne (1663) en een deel van Winsum (0053) komen te vervallen
+5, 1651, 1663, 53,
 -- Ten Boer (0009) en Haren (0017) komen te vervallen
 9, 17,
 -- Grootegast (0015), Leek (0022), Marum (0025), Zuidhorn (0056) en een deel van Winsum (0053) komen te vervallen
@@ -308,8 +308,8 @@ INSERT INTO gemeente_archief SELECT * FROM gemeente WHERE code IN (
 881, 951, 962
 );
 UPDATE wnplts SET fk_7gem_code=null WHERE fk_7gem_code IN (
--- Bedum (0005), Eemsmond (1651), De Marne (0053) en een deel van Winsum (0053) komen te vervallen
-5, 1651, 53,
+-- Bedum (0005), Eemsmond (1651), De Marne (1663) en een deel van Winsum (0053) komen te vervallen
+5, 1651, 1663, 53,
 -- Ten Boer (0009) en Haren (0017) komen te vervallen
 9, 17,
 -- Grootegast (0015), Leek (0022), Marum (0025), Zuidhorn (0056) en een deel van Winsum (0053) komen te vervallen
@@ -335,8 +335,8 @@ UPDATE wnplts SET fk_7gem_code=null WHERE fk_7gem_code IN (
 881, 951, 962
 );
 DELETE FROM gemeente WHERE code IN (
--- Bedum (0005), Eemsmond (1651), De Marne (0053) en een deel van Winsum (0053) komen te vervallen
-5, 1651, 53,
+-- Bedum (0005), Eemsmond (1651), De Marne (1663) en een deel van Winsum (0053) komen te vervallen
+5, 1651, 1663, 53,
 -- Ten Boer (0009) en Haren (0017) komen te vervallen
 9, 17,
 -- Grootegast (0015), Leek (0022), Marum (0025), Zuidhorn (0056) en een deel van Winsum (0053) komen te vervallen

--- a/datamodel/utility_scripts/oracle/120_vervallen_gemeenten.sql
+++ b/datamodel/utility_scripts/oracle/120_vervallen_gemeenten.sql
@@ -274,7 +274,7 @@ UPDATE gemeente SET datum_einde_geldh = '2019-01-01', dat_beg_geldh = '2009-01-0
 -- Oud-Beijerland (0584), Binnenmaas (0585), Korendijk (0588), Cromstrijen (0611) en Strijen (0617) komen te vervallen
 584, 585, 588, 611, 617,
 -- Giessenlanden (0689) en Molenwaard (1927) komen te vervallen
-589, 1927,
+689, 1927,
 -- Aalburg (0738), Werkendam (0870) en Woudrichem (0874) komen te vervallen
 738, 870, 874,
 -- Onderbanken (0881), Nuth (0951) en Schinnen (0962) komen te vervallen
@@ -301,7 +301,7 @@ INSERT INTO gemeente_archief SELECT * FROM gemeente WHERE code IN (
 -- Oud-Beijerland (0584), Binnenmaas (0585), Korendijk (0588), Cromstrijen (0611) en Strijen (0617) komen te vervallen
 584, 585, 588, 611, 617,
 -- Giessenlanden (0689) en Molenwaard (1927) komen te vervallen
-589, 1927,
+689, 1927,
 -- Aalburg (0738), Werkendam (0870) en Woudrichem (0874) komen te vervallen
 738, 870, 874,
 -- Onderbanken (0881), Nuth (0951) en Schinnen (0962) komen te vervallen
@@ -328,7 +328,7 @@ UPDATE wnplts SET fk_7gem_code=null WHERE fk_7gem_code IN (
 -- Oud-Beijerland (0584), Binnenmaas (0585), Korendijk (0588), Cromstrijen (0611) en Strijen (0617) komen te vervallen
 584, 585, 588, 611, 617,
 -- Giessenlanden (0689) en Molenwaard (1927) komen te vervallen
-589, 1927,
+689, 1927,
 -- Aalburg (0738), Werkendam (0870) en Woudrichem (0874) komen te vervallen
 738, 870, 874,
 -- Onderbanken (0881), Nuth (0951) en Schinnen (0962) komen te vervallen
@@ -355,7 +355,7 @@ DELETE FROM gemeente WHERE code IN (
 -- Oud-Beijerland (0584), Binnenmaas (0585), Korendijk (0588), Cromstrijen (0611) en Strijen (0617) komen te vervallen
 584, 585, 588, 611, 617,
 -- Giessenlanden (0689) en Molenwaard (1927) komen te vervallen
-589, 1927,
+689, 1927,
 -- Aalburg (0738), Werkendam (0870) en Woudrichem (0874) komen te vervallen
 738, 870, 874,
 -- Onderbanken (0881), Nuth (0951) en Schinnen (0962) komen te vervallen
@@ -371,5 +371,9 @@ INSERT INTO gemeente (dat_beg_geldh, code, naam) VALUES ('2019-01-01', 1966, 'He
 INSERT INTO gemeente (dat_beg_geldh, code, naam) VALUES ('2019-01-01', 1969, 'Westerkwartier');
 INSERT INTO gemeente (dat_beg_geldh, code, naam) VALUES ('2019-01-01', 1970, 'Noardeast-Fryslân');
 INSERT INTO gemeente (dat_beg_geldh, code, naam) VALUES ('2019-01-01', 1978, 'Molenlanden');
-UPDATE brmo_metadata SET waarde = '2019' WHERE naam = 'update_gem_tabel';
+
+-- herstel onterecht verwijderde gemeente Oudewater die in bestand van 8 jan 2019 is geslopen (update_gem_tabel=2019)
+INSERT INTO gemeente (code, naam) SELECT 589, 'Oudewater' FROM dual WHERE NOT EXISTS (SELECT code FROM gemeente WHERE code = 589);
+
+UPDATE brmo_metadata SET waarde = '2019.1' WHERE naam = 'update_gem_tabel';
 COMMIT;

--- a/datamodel/utility_scripts/postgresql/120_vervallen_gemeenten.sql
+++ b/datamodel/utility_scripts/postgresql/120_vervallen_gemeenten.sql
@@ -249,8 +249,8 @@ BEGIN TRANSACTION;
 -- Op 1 januari 2019 is het aantal gemeenten afgenomen met vijfentwintig, zodat het aantal gemeenten in Nederland 355 bedraagt.
 -- zie: https://www.cbs.nl/nl-nl/onze-diensten/methoden/classificaties/overig/gemeentelijke-indelingen-per-jaar/indeling%20per%20jaar/gemeentelijke-indeling-op-1-januari-2019
 UPDATE gemeente SET datum_einde_geldh = '2019-01-01', dat_beg_geldh = '2009-01-01' WHERE code IN (
--- Bedum (0005), Eemsmond (1651), De Marne (0053) en een deel van Winsum (0053) komen te vervallen
-5, 1651, 53,
+-- Bedum (0005), Eemsmond (1651), De Marne (1663) en een deel van Winsum (0053) komen te vervallen
+5, 1651, 1663, 53,
 -- Ten Boer (0009) en Haren (0017) komen te vervallen
 9, 17,
 -- Grootegast (0015), Leek (0022), Marum (0025), Zuidhorn (0056) en een deel van Winsum (0053) komen te vervallen
@@ -276,8 +276,8 @@ UPDATE gemeente SET datum_einde_geldh = '2019-01-01', dat_beg_geldh = '2009-01-0
 881, 951, 962
 );
 INSERT INTO gemeente_archief SELECT * FROM gemeente WHERE code IN (
--- Bedum (0005), Eemsmond (1651), De Marne (0053) en een deel van Winsum (0053) komen te vervallen
-5, 1651, 53,
+-- Bedum (0005), Eemsmond (1651), De Marne (1663) en een deel van Winsum (0053) komen te vervallen
+5, 1651, 1663, 53,
 -- Ten Boer (0009) en Haren (0017) komen te vervallen
 9, 17,
 -- Grootegast (0015), Leek (0022), Marum (0025), Zuidhorn (0056) en een deel van Winsum (0053) komen te vervallen
@@ -303,8 +303,8 @@ INSERT INTO gemeente_archief SELECT * FROM gemeente WHERE code IN (
 881, 951, 962
 );
 UPDATE wnplts SET fk_7gem_code=null WHERE fk_7gem_code IN (
--- Bedum (0005), Eemsmond (1651), De Marne (0053) en een deel van Winsum (0053) komen te vervallen
-5, 1651, 53,
+-- Bedum (0005), Eemsmond (1651), De Marne (1663) en een deel van Winsum (0053) komen te vervallen
+5, 1651, 1663, 53,
 -- Ten Boer (0009) en Haren (0017) komen te vervallen
 9, 17,
 -- Grootegast (0015), Leek (0022), Marum (0025), Zuidhorn (0056) en een deel van Winsum (0053) komen te vervallen
@@ -330,8 +330,8 @@ UPDATE wnplts SET fk_7gem_code=null WHERE fk_7gem_code IN (
 881, 951, 962
 );
 DELETE FROM gemeente WHERE code IN (
--- Bedum (0005), Eemsmond (1651), De Marne (0053) en een deel van Winsum (0053) komen te vervallen
-5, 1651, 53,
+-- Bedum (0005), Eemsmond (1651), De Marne (1663) en een deel van Winsum (0053) komen te vervallen
+5, 1651, 1663, 53,
 -- Ten Boer (0009) en Haren (0017) komen te vervallen
 9, 17,
 -- Grootegast (0015), Leek (0022), Marum (0025), Zuidhorn (0056) en een deel van Winsum (0053) komen te vervallen

--- a/datamodel/utility_scripts/postgresql/120_vervallen_gemeenten.sql
+++ b/datamodel/utility_scripts/postgresql/120_vervallen_gemeenten.sql
@@ -269,7 +269,7 @@ UPDATE gemeente SET datum_einde_geldh = '2019-01-01', dat_beg_geldh = '2009-01-0
 -- Oud-Beijerland (0584), Binnenmaas (0585), Korendijk (0588), Cromstrijen (0611) en Strijen (0617) komen te vervallen
 584, 585, 588, 611, 617,
 -- Giessenlanden (0689) en Molenwaard (1927) komen te vervallen
-589, 1927,
+689, 1927,
 -- Aalburg (0738), Werkendam (0870) en Woudrichem (0874) komen te vervallen
 738, 870, 874,
 -- Onderbanken (0881), Nuth (0951) en Schinnen (0962) komen te vervallen
@@ -296,7 +296,7 @@ INSERT INTO gemeente_archief SELECT * FROM gemeente WHERE code IN (
 -- Oud-Beijerland (0584), Binnenmaas (0585), Korendijk (0588), Cromstrijen (0611) en Strijen (0617) komen te vervallen
 584, 585, 588, 611, 617,
 -- Giessenlanden (0689) en Molenwaard (1927) komen te vervallen
-589, 1927,
+689, 1927,
 -- Aalburg (0738), Werkendam (0870) en Woudrichem (0874) komen te vervallen
 738, 870, 874,
 -- Onderbanken (0881), Nuth (0951) en Schinnen (0962) komen te vervallen
@@ -323,7 +323,7 @@ UPDATE wnplts SET fk_7gem_code=null WHERE fk_7gem_code IN (
 -- Oud-Beijerland (0584), Binnenmaas (0585), Korendijk (0588), Cromstrijen (0611) en Strijen (0617) komen te vervallen
 584, 585, 588, 611, 617,
 -- Giessenlanden (0689) en Molenwaard (1927) komen te vervallen
-589, 1927,
+689, 1927,
 -- Aalburg (0738), Werkendam (0870) en Woudrichem (0874) komen te vervallen
 738, 870, 874,
 -- Onderbanken (0881), Nuth (0951) en Schinnen (0962) komen te vervallen
@@ -350,7 +350,7 @@ DELETE FROM gemeente WHERE code IN (
 -- Oud-Beijerland (0584), Binnenmaas (0585), Korendijk (0588), Cromstrijen (0611) en Strijen (0617) komen te vervallen
 584, 585, 588, 611, 617,
 -- Giessenlanden (0689) en Molenwaard (1927) komen te vervallen
-589, 1927,
+689, 1927,
 -- Aalburg (0738), Werkendam (0870) en Woudrichem (0874) komen te vervallen
 738, 870, 874,
 -- Onderbanken (0881), Nuth (0951) en Schinnen (0962) komen te vervallen
@@ -366,5 +366,9 @@ INSERT INTO gemeente (dat_beg_geldh, code, naam) VALUES ('2019-01-01', 1966, 'He
 INSERT INTO gemeente (dat_beg_geldh, code, naam) VALUES ('2019-01-01', 1969, 'Westerkwartier');
 INSERT INTO gemeente (dat_beg_geldh, code, naam) VALUES ('2019-01-01', 1970, 'Noardeast-Fryslân');
 INSERT INTO gemeente (dat_beg_geldh, code, naam) VALUES ('2019-01-01', 1978, 'Molenlanden');
-UPDATE brmo_metadata SET waarde = '2019' WHERE naam = 'update_gem_tabel';
+
+-- herstel onterecht verwijderde gemeente Oudewater die in bestand van 8 jan 2019 is geslopen (update_gem_tabel=2019)
+INSERT INTO gemeente (code, naam) SELECT 589, 'Oudewater' WHERE NOT EXISTS (SELECT code FROM gemeente WHERE code = 589);
+
+UPDATE brmo_metadata SET waarde = '2019.1' WHERE naam = 'update_gem_tabel';
 COMMIT;

--- a/datamodel/utility_scripts/sqlserver/120_vervallen_gemeenten.sql
+++ b/datamodel/utility_scripts/sqlserver/120_vervallen_gemeenten.sql
@@ -250,8 +250,8 @@ BEGIN TRANSACTION;
 -- Op 1 januari 2019 is het aantal gemeenten afgenomen met vijfentwintig, zodat het aantal gemeenten in Nederland 355 bedraagt.
 -- zie: https://www.cbs.nl/nl-nl/onze-diensten/methoden/classificaties/overig/gemeentelijke-indelingen-per-jaar/indeling%20per%20jaar/gemeentelijke-indeling-op-1-januari-2019
 UPDATE gemeente SET datum_einde_geldh = '2019-01-01', dat_beg_geldh = '2009-01-01' WHERE code IN (
--- Bedum (0005), Eemsmond (1651), De Marne (0053) en een deel van Winsum (0053) komen te vervallen
-5, 1651, 53,
+-- Bedum (0005), Eemsmond (1651), De Marne (1663) en een deel van Winsum (0053) komen te vervallen
+5, 1651, 1663, 53,
 -- Ten Boer (0009) en Haren (0017) komen te vervallen
 9, 17,
 -- Grootegast (0015), Leek (0022), Marum (0025), Zuidhorn (0056) en een deel van Winsum (0053) komen te vervallen
@@ -277,8 +277,8 @@ UPDATE gemeente SET datum_einde_geldh = '2019-01-01', dat_beg_geldh = '2009-01-0
 881, 951, 962
 );
 INSERT INTO gemeente_archief SELECT * FROM gemeente WHERE code IN (
--- Bedum (0005), Eemsmond (1651), De Marne (0053) en een deel van Winsum (0053) komen te vervallen
-5, 1651, 53,
+-- Bedum (0005), Eemsmond (1651), De Marne (1663) en een deel van Winsum (0053) komen te vervallen
+5, 1651, 1663, 53,
 -- Ten Boer (0009) en Haren (0017) komen te vervallen
 9, 17,
 -- Grootegast (0015), Leek (0022), Marum (0025), Zuidhorn (0056) en een deel van Winsum (0053) komen te vervallen
@@ -304,8 +304,8 @@ INSERT INTO gemeente_archief SELECT * FROM gemeente WHERE code IN (
 881, 951, 962
 );
 UPDATE wnplts SET fk_7gem_code=null WHERE fk_7gem_code IN (
--- Bedum (0005), Eemsmond (1651), De Marne (0053) en een deel van Winsum (0053) komen te vervallen
-5, 1651, 53,
+-- Bedum (0005), Eemsmond (1651), De Marne (1663) en een deel van Winsum (0053) komen te vervallen
+5, 1651, 1663, 53,
 -- Ten Boer (0009) en Haren (0017) komen te vervallen
 9, 17,
 -- Grootegast (0015), Leek (0022), Marum (0025), Zuidhorn (0056) en een deel van Winsum (0053) komen te vervallen
@@ -331,8 +331,8 @@ UPDATE wnplts SET fk_7gem_code=null WHERE fk_7gem_code IN (
 881, 951, 962
 );
 DELETE FROM gemeente WHERE code IN (
--- Bedum (0005), Eemsmond (1651), De Marne (0053) en een deel van Winsum (0053) komen te vervallen
-5, 1651, 53,
+-- Bedum (0005), Eemsmond (1651), De Marne (1663) en een deel van Winsum (0053) komen te vervallen
+5, 1651, 1663, 53,
 -- Ten Boer (0009) en Haren (0017) komen te vervallen
 9, 17,
 -- Grootegast (0015), Leek (0022), Marum (0025), Zuidhorn (0056) en een deel van Winsum (0053) komen te vervallen

--- a/datamodel/utility_scripts/sqlserver/120_vervallen_gemeenten.sql
+++ b/datamodel/utility_scripts/sqlserver/120_vervallen_gemeenten.sql
@@ -270,7 +270,7 @@ UPDATE gemeente SET datum_einde_geldh = '2019-01-01', dat_beg_geldh = '2009-01-0
 -- Oud-Beijerland (0584), Binnenmaas (0585), Korendijk (0588), Cromstrijen (0611) en Strijen (0617) komen te vervallen
 584, 585, 588, 611, 617,
 -- Giessenlanden (0689) en Molenwaard (1927) komen te vervallen
-589, 1927,
+689, 1927,
 -- Aalburg (0738), Werkendam (0870) en Woudrichem (0874) komen te vervallen
 738, 870, 874,
 -- Onderbanken (0881), Nuth (0951) en Schinnen (0962) komen te vervallen
@@ -297,7 +297,7 @@ INSERT INTO gemeente_archief SELECT * FROM gemeente WHERE code IN (
 -- Oud-Beijerland (0584), Binnenmaas (0585), Korendijk (0588), Cromstrijen (0611) en Strijen (0617) komen te vervallen
 584, 585, 588, 611, 617,
 -- Giessenlanden (0689) en Molenwaard (1927) komen te vervallen
-589, 1927,
+689, 1927,
 -- Aalburg (0738), Werkendam (0870) en Woudrichem (0874) komen te vervallen
 738, 870, 874,
 -- Onderbanken (0881), Nuth (0951) en Schinnen (0962) komen te vervallen
@@ -324,7 +324,7 @@ UPDATE wnplts SET fk_7gem_code=null WHERE fk_7gem_code IN (
 -- Oud-Beijerland (0584), Binnenmaas (0585), Korendijk (0588), Cromstrijen (0611) en Strijen (0617) komen te vervallen
 584, 585, 588, 611, 617,
 -- Giessenlanden (0689) en Molenwaard (1927) komen te vervallen
-589, 1927,
+689, 1927,
 -- Aalburg (0738), Werkendam (0870) en Woudrichem (0874) komen te vervallen
 738, 870, 874,
 -- Onderbanken (0881), Nuth (0951) en Schinnen (0962) komen te vervallen
@@ -351,7 +351,7 @@ DELETE FROM gemeente WHERE code IN (
 -- Oud-Beijerland (0584), Binnenmaas (0585), Korendijk (0588), Cromstrijen (0611) en Strijen (0617) komen te vervallen
 584, 585, 588, 611, 617,
 -- Giessenlanden (0689) en Molenwaard (1927) komen te vervallen
-589, 1927,
+689, 1927,
 -- Aalburg (0738), Werkendam (0870) en Woudrichem (0874) komen te vervallen
 738, 870, 874,
 -- Onderbanken (0881), Nuth (0951) en Schinnen (0962) komen te vervallen
@@ -367,5 +367,9 @@ INSERT INTO gemeente (dat_beg_geldh, code, naam) VALUES ('2019-01-01', 1966, 'He
 INSERT INTO gemeente (dat_beg_geldh, code, naam) VALUES ('2019-01-01', 1969, 'Westerkwartier');
 INSERT INTO gemeente (dat_beg_geldh, code, naam) VALUES ('2019-01-01', 1970, 'Noardeast-Fryslân');
 INSERT INTO gemeente (dat_beg_geldh, code, naam) VALUES ('2019-01-01', 1978, 'Molenlanden');
-UPDATE brmo_metadata SET waarde = '2019' WHERE naam = 'update_gem_tabel';
+
+-- herstel onterecht verwijderde gemeente Oudewater die in bestand van 8 jan 2019 is geslopen (update_gem_tabel=2019)
+IF NOT EXISTS (SELECT * FROM gemeente WHERE code = 589) INSERT INTO gemeente (code, naam) VALUES (589, 'Oudewater');
+
+UPDATE brmo_metadata SET waarde = '2019.1' WHERE naam = 'update_gem_tabel';
 COMMIT;


### PR DESCRIPTION
Bevat: 
- correctie voor vervallen gemeente De Marne(1663) welke niet naar het archief werd verplaatst
- herstel onterecht gearchiveerde gemeente Oudewater(589) die in het bestand van 8 jan 2019 is geslopen en archiveer Giessenlanden(689)

## Instructies
Onderstaande instructies zijn van toepassing op release 1.5.2 en jonger, oudere versies werken mogelijk niet. Deze instructies zijn ook geldig als het eerdere 2019 script al eens is gedraaid.

### gemeente tabel update
- Voer het script `120_vervallen_gemeenten.sql` (in [utility_scripts](https://github.com/B3Partners/brmo/tree/master/datamodel/utility_scripts)) uit om de vervallen gemeenten naar de archief tabel te verplaatsen en nieuwe gemeenten te laden
- Voer het script `201_update_wnplts_gemcode.sql` (in [utility_scripts](https://github.com/B3Partners/brmo/tree/master/datamodel/utility_scripts)) uit om de Gemeente / Woonplaats koppeling bij te werken

De gemeente tabel moet nu 355 gemeenten bevatten

close #610