### PR TITLE
BRKDirectoryScanner: duplicaat berichten negeren

### DIFF
--- a/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/BRKDirectoryScanner.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/BRKDirectoryScanner.java
@@ -149,10 +149,6 @@ public class BRKDirectoryScanner extends AbstractExecutableProces {
         Arrays.sort(files, NameFileComparator.NAME_COMPARATOR);
 
         processXMLFiles(files, scanDirectory, archiefDirectory, em);
-
-        em.flush();
-        em.getTransaction().commit();
-        em.clear();
     }
 
     /**

--- a/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/editbrkdirscannerproces.jsp
+++ b/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/editbrkdirscannerproces.jsp
@@ -19,8 +19,4 @@
             <brmo:formatCron cronExpression="${actionBean.proces.cronExpressie}" />
         </td>
     </tr>
-    <tr>
-        <td><stripes:label name="">Commit page size (leeg voor default)</stripes:label></td>
-        <td><stripes:text name="config['commitPageSize']"/></td>
-    </tr>
 </table>

--- a/brmo-service/src/test/java/nl/b3p/brmo/service/scanner/BRKDirectoryScannerIntegrationTest.java
+++ b/brmo-service/src/test/java/nl/b3p/brmo/service/scanner/BRKDirectoryScannerIntegrationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2019 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.brmo.service.scanner;
+
+import java.io.File;
+import nl.b3p.brmo.persistence.staging.BRKScannerProces;
+import nl.b3p.brmo.loader.BrmoFramework;
+import nl.b3p.brmo.loader.util.BrmoException;
+import nl.b3p.brmo.service.testutil.TestUtil;
+import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static nl.b3p.brmo.loader.BrmoFramework.BR_BRK;
+import static nl.b3p.brmo.persistence.staging.LaadProces.STATUS.STAGING_OK;
+import static nl.b3p.brmo.persistence.staging.LaadProces.STATUS.STAGING_DUPLICAAT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
+import org.junit.Ignore;
+import org.stripesstuff.stripersist.Stripersist;
+
+/**
+ *
+ * run:
+ * {@code mvn -Dit.test=BRKDirectoryScannerIntegrationTest -Dtest.onlyITs=true verify -Ppostgresql}
+ *
+ * @author mprins
+ */
+public class BRKDirectoryScannerIntegrationTest extends TestUtil {
+
+    private static final Log LOG = LogFactory.getLog(BRKDirectoryScannerIntegrationTest.class);
+
+    private BrmoFramework brmo;
+    private BRKDirectoryScanner scanner;
+
+    @Before
+    @Override
+    public void setUp() throws BrmoException {
+        BasicDataSource dsStaging = new BasicDataSource();
+        dsStaging.setUrl(DBPROPS.getProperty("staging.url"));
+        dsStaging.setUsername(DBPROPS.getProperty("staging.username"));
+        dsStaging.setPassword(DBPROPS.getProperty("staging.password"));
+        dsStaging.setAccessToUnderlyingConnectionAllowed(true);
+        brmo = new BrmoFramework(dsStaging, null);
+
+        /*
+         * TODO werkend maken...
+         * Stripersist.requestInit();
+         * of
+         * @Mock
+         * private EntityManager entityManager;
+         * Mockito.when(METHOD_EXPECTED_TO_BE_CALLED).thenReturn(AnyObjectoftheReturnType);
+         *
+         */
+        assumeNotNull("Het test bestand moet er zijn.", BRKDirectoryScannerIntegrationTest.class.getResource("/duplicaatberichten/MUTBX01.xml"));
+        String scanDirectory = BRKDirectoryScannerIntegrationTest.class.getResource("/duplicaatberichten/MUTBX01.xml").getPath();
+
+        BRKScannerProces config = new BRKScannerProces();
+        config.setScanDirectory(scanDirectory);
+        config.setArchiefDirectory(scanDirectory + File.separatorChar + "archief");
+        scanner = new BRKDirectoryScanner(config);
+    }
+
+    @After
+    public void tearDown() throws BrmoException {
+//        Stripersist.requestComplete();
+        brmo.emptyStagingDb();
+        brmo.closeBrmoFramework();
+    }
+
+    @Test
+    @Ignore("TODO deze test werkt nu niet omdat de stripes entity manager niet geinitialiseerd wordt, de test draait niet in de servlet container.")
+    public void testDuplicaatBerichten() throws BrmoException {
+        scanner.execute();
+        assertEquals("Aantal berichten is niet gelijk.", 2L, brmo.getCountBerichten(null, null, BR_BRK, STAGING_OK.toString()));
+        assertEquals("Aantal OK laadprocessen is niet gelijk.", 2L, brmo.getCountLaadProcessen(null, null, BR_BRK, STAGING_OK.toString()));
+        assertEquals("Aantal duplicaat laadprocessen is niet gelijk.", 3L, brmo.getCountLaadProcessen(null, null, BR_BRK, STAGING_DUPLICAAT.toString()));
+    }
+}

--- a/brmo-service/src/test/resources/duplicaatberichten/7999bytesBRxml.xml
+++ b/brmo-service/src/test/resources/duplicaatberichten/7999bytesBRxml.xml
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Mutatie:Mutatie xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:Mutatie="http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901" xmlns:Snapshot="http://www.kadaster.nl/schemas/brk-levering/snapshot/v20120901" xmlns:GbaPersoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon/v20120901" xmlns:Adres="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-adres/v20120201" xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201" xmlns:Persoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon/v20120201" xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201" xmlns:BagAdres="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-bag-adres/v20120201" xmlns:KadastraalObject="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject/v20120701" xmlns:InOnderzoek="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-inonderzoek/v20120201" xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml" xmlns:NhrRechtspersoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-nhr-rechtspersoon/v20120201" xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201" xmlns:GbaPersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon-ref/v20120201" xmlns:PersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon-ref/v20120201" xmlns:NhrRechtspersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-nhr-rechtspersoon-ref/v20120201" xmlns:RechtRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht-ref/v20120201" xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201" xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201" xsi:schemaLocation="http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901 http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901/BRKLeveringMutatie_v1_1_4.xsd http://www.opengis.net/gml http://www.kadaster.nl/schemas/gml/3.1.1/base/gml.xsd http://www.w3.org/1999/xlink http://www.kadaster.nl/schemas/xlink/1.0.0/xlinks.xsd">
+  <Mutatie:aardStukdeel>
+    <Typen:code>179</Typen:code>
+    <Typen:waarde>Toevoegen titels met behulp van Tr. 34</Typen:waarde>
+  </Mutatie:aardStukdeel>
+  <Mutatie:BRKDatum>2017-08-02</Mutatie:BRKDatum>
+  <Mutatie:volgnummerKadastraalObjectDatum>1</Mutatie:volgnummerKadastraalObjectDatum>
+  <Mutatie:ingeschrevenStuk>
+    <Mutatie:AanduidingKadasterstuk>
+      <Mutatie:stuk>
+        <StukRef:KadasterstukRef xlink:href="NL.KAD.KadasterStuk.AKR1.100000003758678" />
+      </Mutatie:stuk>
+      <Mutatie:AKRPortefeuilleNr>ACG75271     GNG</Mutatie:AKRPortefeuilleNr>
+    </Mutatie:AanduidingKadasterstuk>
+  </Mutatie:ingeschrevenStuk>
+  <Mutatie:kadastraalObject>
+    <Mutatie:AanduidingKadastraalObject>
+      <Mutatie:indicatieDeelperceel>false</Mutatie:indicatieDeelperceel>
+      <Mutatie:kadastraleAanduiding>
+        <KadastraalObject:AKRKadastraleGemeenteCode>
+          <Typen:code>386</Typen:code>
+          <Typen:waarde>GNG00</Typen:waarde>
+        </KadastraalObject:AKRKadastraleGemeenteCode>
+        <KadastraalObject:naamKadastraleGemeente>
+          <Typen:code>339</Typen:code>
+          <Typen:waarde>Groningen</Typen:waarde>
+        </KadastraalObject:naamKadastraleGemeente>
+        <KadastraalObject:sectie>C</KadastraalObject:sectie>
+        <KadastraalObject:perceelnummer>9442</KadastraalObject:perceelnummer>
+      </Mutatie:kadastraleAanduiding>
+      <Mutatie:kadastraalObject>
+        <KadastraalObjectRef:PerceelRef xlink:href="NL.KAD.OnroerendeZaak.58930944270000" />
+      </Mutatie:kadastraalObject>
+    </Mutatie:AanduidingKadastraalObject>
+  </Mutatie:kadastraalObject>
+  <Mutatie:was>
+    <Snapshot:KadastraalObjectSnapshot>
+      <Snapshot:referentie>3598EDFFDEB0-1D4B50B2144</Snapshot:referentie>
+      <Snapshot:toestandsdatum>2013-08-21</Snapshot:toestandsdatum><KadastraalObject:Perceel id="ID.2313021871">
+  <KadastraalObject:identificatie>
+    <NEN3610:namespace>NL.KAD.OnroerendeZaak</NEN3610:namespace>
+    <NEN3610:lokaalId>58930944270000</NEN3610:lokaalId>
+  </KadastraalObject:identificatie>
+  <KadastraalObject:heeftLocatie>
+    <KadastraalObject:LocatieKadastraalObject>
+      <KadastraalObject:cultuurBebouwd>
+        <Typen:code>18</Typen:code>
+        <Typen:waarde>Berging - Stalling (garage-schuur)</Typen:waarde>
+      </KadastraalObject:cultuurBebouwd>
+      <KadastraalObject:adres>
+        <Adres:KADBinnenlandsAdres>
+          <Adres:openbareRuimteNaam>HOORNSEDIEP</Adres:openbareRuimteNaam>
+          <Adres:woonplaatsNaam>GRONINGEN</Adres:woonplaatsNaam>
+        </Adres:KADBinnenlandsAdres>
+      </KadastraalObject:adres>
+    </KadastraalObject:LocatieKadastraalObject>
+  </KadastraalObject:heeftLocatie>
+  <KadastraalObject:kadastraleAanduiding>
+    <KadastraalObject:AKRKadastraleGemeenteCode>
+      <Typen:code>386</Typen:code>
+      <Typen:waarde>GNG00</Typen:waarde>
+    </KadastraalObject:AKRKadastraleGemeenteCode>
+    <KadastraalObject:naamKadastraleGemeente>
+      <Typen:code>339</Typen:code>
+      <Typen:waarde>Groningen</Typen:waarde>
+    </KadastraalObject:naamKadastraleGemeente>
+    <KadastraalObject:sectie>C</KadastraalObject:sectie>
+    <KadastraalObject:perceelnummer>9442</KadastraalObject:perceelnummer>
+  </KadastraalObject:kadastraleAanduiding>
+  <KadastraalObject:begrenzingPerceel><gml:Surface srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:patches>
+    <gml:PolygonPatch>
+      <gml:exterior>
+        <gml:LinearRing>
+          <gml:posList srsDimension="2" count="7">233417.686 580684.44 233412.82 580682.193 233413.695 580679.293 233416.247 580680.022 233415.81 580681.473 233418.361 580682.201 233417.686 580684.44</gml:posList>
+        </gml:LinearRing>
+      </gml:exterior>
+    </gml:PolygonPatch>
+  </gml:patches>
+</gml:Surface></KadastraalObject:begrenzingPerceel>
+  <KadastraalObject:indicatieDeelperceel>false</KadastraalObject:indicatieDeelperceel>
+  <KadastraalObject:kadastraleGrootte>
+    <KadastraalObject:waarde>14</KadastraalObject:waarde>
+  </KadastraalObject:kadastraleGrootte>
+  <KadastraalObject:soortGrootte>
+    <Typen:code>1</Typen:code>
+    <Typen:waarde>Vastgesteld</Typen:waarde>
+  </KadastraalObject:soortGrootte>
+  <KadastraalObject:perceelnummerVerschuiving>
+    <KadastraalObject:deltaX>-17.645</KadastraalObject:deltaX>
+    <KadastraalObject:deltaY>10.078</KadastraalObject:deltaY>
+  </KadastraalObject:perceelnummerVerschuiving>
+  <KadastraalObject:plaatscoordinaten><gml:Point srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:pos>233416.795 580683.025</gml:pos>
+</gml:Point></KadastraalObject:plaatscoordinaten>
+</KadastraalObject:Perceel><Recht:ZakelijkRecht id="ID.2313021875">
+  <Recht:identificatie>
+    <NEN3610:namespace>NL.KAD.ZakelijkRecht</NEN3610:namespace>
+    <NEN3610:lokaalId>AKR1.9934028</NEN3610:lokaalId>
+  </Recht:identificatie>
+  <Recht:aard>
+    <Typen:code>2</Typen:code>
+    <Typen:waarde>Eigendom (recht van)</Typen:waarde>
+  </Recht:aard>
+  <Recht:rustOp>
+    <KadastraalObjectRef:PerceelRef xlink:href="#ID.2313021871" />
+  </Recht:rustOp>
+  <Recht:betrokkenBij>
+    <Recht:HoofdSplitsing>
+      <Recht:verenigingVanEigenaren>
+        <PersoonRef:KADNietNatuurlijkPersoonRef xlink:href="#ID.2313021877" />
+      </Recht:verenigingVanEigenaren>
+      <Recht:isGebaseerdOp>
+        <StukRef:StukdeelRef xlink:href="#ID.2313021881" />
+      </Recht:isGebaseerdOp>
+    </Recht:HoofdSplitsing>
+  </Recht:betrokkenBij>
+</Recht:ZakelijkRecht><Persoon:KADNietNatuurlijkPersoon id="ID.2313021877">
+  <Persoon:identificatie>
+    <NEN3610:namespace>NL.KAD.Persoon</NEN3610:namespace>
+    <NEN3610:lokaalId>47050190</NEN3610:lokaalId>
+  </Persoon:identificatie>
+  <Persoon:naam>Vereniging Van Eigenaars Flat-Hoornsediep 71, 71a En 71b</Persoon:naam>
+  <Persoon:rechtsvorm>
+    <Typen:code>13</Typen:code>
+    <Typen:waarde>Vereniging van eigenaren</Typen:waarde>
+  </Persoon:rechtsvorm>
+  <Persoon:statutaireZetel>GRONINGEN</Persoon:statutaireZetel>
+</Persoon:KADNietNatuurlijkPersoon><Stuk:Kadasterstuk id="ID.2313021879">
+  <Stuk:identificatie>
+    <NEN3610:namespace>NL.KAD.Kadasterstuk</NEN3610:namespace>
+    <NEN3610:lokaalId>AKR1.11306674</NEN3610:lokaalId>
+  </Stuk:identificatie>
+  <Stuk:omvat>
+    <Stuk:Stukdeel id="ID.2313021881">
+      <Stuk:identificatie>
+        <NEN3610:namespace>NL.KAD.Stukdeel</NEN3610:namespace>
+        <NEN3610:lokaalId>AKR1.11102558</NEN3610:lokaalId>
+      </Stuk:identificatie>
+      <Stuk:aardStukdeel nilReason="waardeOnbekend">
+        <Typen:code>NIL</Typen:code>
+        <Typen:waarde>NIL</Typen:waarde>
+      </Stuk:aardStukdeel>
+    </Stuk:Stukdeel>
+  </Stuk:omvat>
+  <Stuk:AKRPortefeuilleNr>84 GNG0059310GNG</Stuk:AKRPortefeuilleNr>
+</Stuk:Kadasterstuk>
+    </Snapshot:KadastraalObjectSnapshot>
+  </Mutatie:was>
+  <Mutatie:wordt>
+    <Snapshot:KadastraalObjectSnapshot>
+      <Snapshot:referentie>3598EDFFDEB0-1D5A3594B6D</Snapshot:referentie>
+      <Snapshot:toestandsdatum>2017-08-02</Snapshot:toestandsdatum><KadastraalObject:Perceel id="ID.5668233245">
+  <KadastraalObject:identificatie>
+    <NEN3610:namespace>NL.KAD.OnroerendeZaak</NEN3610:namespace>
+    <NEN3610:lokaalId>58930944270000</NEN3610:lokaalId>
+  </KadastraalObject:identificatie>
+  <KadastraalObject:heeftLocatie>
+    <KadastraalObject:LocatieKadastraalObject>
+      <KadastraalObject:cultuurBebouwd>
+        <Typen:code>18</Typen:code>
+        <Typen:waarde>Berging - Stalling (garage-schuur)</Typen:waarde>
+      </KadastraalObject:cultuurBebouwd>
+    </KadastraalObject:LocatieKadastraalObject>
+  </KadastraalObject:heeftLocatie>
+  <KadastraalObject:kadastraleAanduiding>
+    <KadastraalObject:AKRKadastraleGemeenteCode>
+      <Typen:code>386</Typen:code>
+      <Typen:waarde>GNG00</Typen:waarde>
+    </KadastraalObject:AKRKadastraleGemeenteCode>
+    <KadastraalObject:naamKadastraleGemeente>
+      <Typen:code>339</Typen:code>
+      <Typen:waarde>Groningen</Typen:waarde>
+    </KadastraalObject:naamKadastraleGemeente>
+    <KadastraalObject:sectie>C</KadastraalObject:sectie>
+    <KadastraalObject:perceelnummer>9442</KadastraalObject:perceelnummer>
+  </KadastraalObject:kadastraleAanduiding>
+  <KadastraalObject:begrenzingPerceel><gml:Surface srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:patches>
+    <gml:PolygonPatch>
+      <gml:exterior>
+        <gml:LinearRing>
+          <gml:posList srsDimension="2" count="7">233417.686 580684.44 233412.82 580682.193 233413.695 580679.293 233416.247 580680.022 233415.81 580681.473 233418.361 580682.201 233417.686 580684.44</gml:posList>
+        </gml:LinearRing>
+      </gml:exterior>
+    </gml:PolygonPatch>
+  </gml:patches>
+</gml:Surface></KadastraalObject:begrenzingPerceel>
+  <KadastraalObject:indicatieDeelperceel>false</KadastraalObject:indicatieDeelperceel>
+  <KadastraalObject:kadastraleGrootte>
+    <KadastraalObject:waarde>14</KadastraalObject:waarde>
+  </KadastraalObject:kadastraleGrootte>
+  <KadastraalObject:soortGrootte>
+    <Typen:code>1</Typen:code>
+    <Typen:waarde>Vastgesteld</Typen:waarde>
+  </KadastraalObject:soortGrootte>
+  <KadastraalObject:perceelnummerVerschuiving>
+    <KadastraalObject:deltaX>-17.645</KadastraalObject:deltaX>
+    <KadastraalObject:deltaY>10.078</KadastraalObject:deltaY>
+  </KadastraalObject:perceelnummerVerschuiving>
+  <KadastraalObject:plaatscoordinaten><gml:Point srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:pos>233416.795 580683.025</gml:pos>
+</gml:Point></KadastraalObject:plaatscoordinaten>
+</KadastraalObject:Perceel><Recht:ZakelijkRecht id="ID.5668233247">
+  <Recht:identificatie>
+    <NEN3610:namespace>NL.KAD.ZakelijkRecht</NEN3610:namespace>
+    <NEN3610:lokaalId>AKR1.9934028</NEN3610:lokaalId>
+  </Recht:identificatie>
+  <Recht:aard>
+    <Typen:code>2</Typen:code>
+    <Typen:waarde>Eigendom (recht van)</Typen:waarde>
+  </Recht:aard>
+  <Recht:rustOp>
+    <KadastraalObjectRef:PerceelRef xlink:href="#ID.5668233245" />
+  </Recht:rustOp>
+  <Recht:betrokkenBij>
+   <Recht:HoofdSplitsing>
+  <Recht:verenigingVanEigenaren>
+      <PersoonRef:KADNietNatuurlijkPersoonRef xlink:href="#ID.5668233248" />
+     </Recht:verenigingVanEigenaren>
+      <Recht:isGebaseerdOp>
+        <StukRef:StukdeelRef xlink:href="#ID.5668233250" />
+      </Recht:isGebaseerdOp>
+    </Recht:HoofdSplitsing>
+  </Recht:betrokkenBij>
+</Recht:ZakelijkRecht><Persoon:KADNietNatuurlijkPersoon id="ID.5668233248">
+  <Persoon:identificatie>
+    <NEN3610:namespace>NL.KAD.Persoon</NEN3610:namespace>
+    <NEN3610:lokaalId>47050190</NEN3610:lokaalId>
+  </Persoon:identificatie>
+  <Persoon:naam>Vereniging Van Eigenaars Flat-Hoornsediep 71, 71a En 71b</Persoon:naam>
+  <Persoon:rechtsvorm>
+    <Typen:code>21</Typen:code>
+    <Typen:waarde>Vereniging van eigenaars</Typen:waarde>
+  </Persoon:rechtsvorm>
+  <Persoon:statutaireZetel>GRONINGEN</Persoon:statutaireZetel>
+</Persoon:KADNietNatuurlijkPersoon><Stuk:Kadasterstuk id="ID.5668233249">
+<Stuk:identificatie>
+<NEN3610:namespace>NL.KAD.Kadasterstuk</NEN3610:namespace>
+<NEN3610:lokaalId>AKR1.11306674</NEN3610:lokaalId>
+</Stuk:identificatie>
+<Stuk:omvat>
+<Stuk:Stukdeel id="ID.5668233250">
+<Stuk:identificatie>
+<NEN3610:namespace>NL.KAD.Stukdeel</NEN3610:namespace>
+<NEN3610:lokaalId>AKR1.11102558</NEN3610:lokaalId>
+</Stuk:identificatie>
+<Stuk:aardStukdeel nilReason="waardeOnbekend">
+<Typen:code>NIL</Typen:code>
+<Typen:waarde>NIL</Typen:waarde>
+</Stuk:aardStukdeel>
+</Stuk:Stukdeel>
+</Stuk:omvat>
+<Stuk:AKRPortefeuilleNr>84 GNG0059310GNG</Stuk:AKRPortefeuilleNr>
+</Stuk:Kadasterstuk>
+</Snapshot:KadastraalObjectSnapshot>
+  </Mutatie:wordt>
+</Mutatie:Mutatie>

--- a/brmo-service/src/test/resources/duplicaatberichten/8000bytesBRxml.xml
+++ b/brmo-service/src/test/resources/duplicaatberichten/8000bytesBRxml.xml
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Mutatie:Mutatie xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:Mutatie="http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901" xmlns:Snapshot="http://www.kadaster.nl/schemas/brk-levering/snapshot/v20120901" xmlns:GbaPersoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon/v20120901" xmlns:Adres="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-adres/v20120201" xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201" xmlns:Persoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon/v20120201" xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201" xmlns:BagAdres="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-bag-adres/v20120201" xmlns:KadastraalObject="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject/v20120701" xmlns:InOnderzoek="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-inonderzoek/v20120201" xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml" xmlns:NhrRechtspersoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-nhr-rechtspersoon/v20120201" xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201" xmlns:GbaPersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon-ref/v20120201" xmlns:PersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon-ref/v20120201" xmlns:NhrRechtspersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-nhr-rechtspersoon-ref/v20120201" xmlns:RechtRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht-ref/v20120201" xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201" xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201" xsi:schemaLocation="http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901 http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901/BRKLeveringMutatie_v1_1_4.xsd http://www.opengis.net/gml http://www.kadaster.nl/schemas/gml/3.1.1/base/gml.xsd http://www.w3.org/1999/xlink http://www.kadaster.nl/schemas/xlink/1.0.0/xlinks.xsd">
+  <Mutatie:aardStukdeel>
+    <Typen:code>179</Typen:code>
+    <Typen:waarde>Toevoegen titels met behulp van Tr. 34</Typen:waarde>
+  </Mutatie:aardStukdeel>
+  <Mutatie:BRKDatum>2017-08-02</Mutatie:BRKDatum>
+  <Mutatie:volgnummerKadastraalObjectDatum>1</Mutatie:volgnummerKadastraalObjectDatum>
+  <Mutatie:ingeschrevenStuk>
+    <Mutatie:AanduidingKadasterstuk>
+      <Mutatie:stuk>
+        <StukRef:KadasterstukRef xlink:href="NL.KAD.KadasterStuk.AKR1.100000003758678" />
+      </Mutatie:stuk>
+      <Mutatie:AKRPortefeuilleNr>ACG75271     GNG</Mutatie:AKRPortefeuilleNr>
+    </Mutatie:AanduidingKadasterstuk>
+  </Mutatie:ingeschrevenStuk>
+  <Mutatie:kadastraalObject>
+    <Mutatie:AanduidingKadastraalObject>
+      <Mutatie:indicatieDeelperceel>false</Mutatie:indicatieDeelperceel>
+      <Mutatie:kadastraleAanduiding>
+        <KadastraalObject:AKRKadastraleGemeenteCode>
+          <Typen:code>386</Typen:code>
+          <Typen:waarde>GNG00</Typen:waarde>
+        </KadastraalObject:AKRKadastraleGemeenteCode>
+        <KadastraalObject:naamKadastraleGemeente>
+          <Typen:code>339</Typen:code>
+          <Typen:waarde>Groningen</Typen:waarde>
+        </KadastraalObject:naamKadastraleGemeente>
+        <KadastraalObject:sectie>C</KadastraalObject:sectie>
+        <KadastraalObject:perceelnummer>9442</KadastraalObject:perceelnummer>
+      </Mutatie:kadastraleAanduiding>
+      <Mutatie:kadastraalObject>
+        <KadastraalObjectRef:PerceelRef xlink:href="NL.KAD.OnroerendeZaak.58930944270000" />
+      </Mutatie:kadastraalObject>
+    </Mutatie:AanduidingKadastraalObject>
+  </Mutatie:kadastraalObject>
+  <Mutatie:was>
+    <Snapshot:KadastraalObjectSnapshot>
+      <Snapshot:referentie>3598EDFFDEB0-1D4B50B2144</Snapshot:referentie>
+      <Snapshot:toestandsdatum>2013-08-21</Snapshot:toestandsdatum><KadastraalObject:Perceel id="ID.2313021871">
+  <KadastraalObject:identificatie>
+    <NEN3610:namespace>NL.KAD.OnroerendeZaak</NEN3610:namespace>
+    <NEN3610:lokaalId>58930944270000</NEN3610:lokaalId>
+  </KadastraalObject:identificatie>
+  <KadastraalObject:heeftLocatie>
+    <KadastraalObject:LocatieKadastraalObject>
+      <KadastraalObject:cultuurBebouwd>
+        <Typen:code>18</Typen:code>
+        <Typen:waarde>Berging - Stalling (garage-schuur)</Typen:waarde>
+      </KadastraalObject:cultuurBebouwd>
+      <KadastraalObject:adres>
+        <Adres:KADBinnenlandsAdres>
+          <Adres:openbareRuimteNaam>HOORNSEDIEP</Adres:openbareRuimteNaam>
+          <Adres:woonplaatsNaam>GRONINGEN</Adres:woonplaatsNaam>
+        </Adres:KADBinnenlandsAdres>
+      </KadastraalObject:adres>
+    </KadastraalObject:LocatieKadastraalObject>
+  </KadastraalObject:heeftLocatie>
+  <KadastraalObject:kadastraleAanduiding>
+    <KadastraalObject:AKRKadastraleGemeenteCode>
+      <Typen:code>386</Typen:code>
+      <Typen:waarde>GNG00</Typen:waarde>
+    </KadastraalObject:AKRKadastraleGemeenteCode>
+    <KadastraalObject:naamKadastraleGemeente>
+      <Typen:code>339</Typen:code>
+      <Typen:waarde>Groningen</Typen:waarde>
+    </KadastraalObject:naamKadastraleGemeente>
+    <KadastraalObject:sectie>C</KadastraalObject:sectie>
+    <KadastraalObject:perceelnummer>9442</KadastraalObject:perceelnummer>
+  </KadastraalObject:kadastraleAanduiding>
+  <KadastraalObject:begrenzingPerceel><gml:Surface srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:patches>
+    <gml:PolygonPatch>
+      <gml:exterior>
+        <gml:LinearRing>
+          <gml:posList srsDimension="2" count="7">233417.686 580684.44 233412.82 580682.193 233413.695 580679.293 233416.247 580680.022 233415.81 580681.473 233418.361 580682.201 233417.686 580684.44</gml:posList>
+        </gml:LinearRing>
+      </gml:exterior>
+    </gml:PolygonPatch>
+  </gml:patches>
+</gml:Surface></KadastraalObject:begrenzingPerceel>
+  <KadastraalObject:indicatieDeelperceel>false</KadastraalObject:indicatieDeelperceel>
+  <KadastraalObject:kadastraleGrootte>
+    <KadastraalObject:waarde>14</KadastraalObject:waarde>
+  </KadastraalObject:kadastraleGrootte>
+  <KadastraalObject:soortGrootte>
+    <Typen:code>1</Typen:code>
+    <Typen:waarde>Vastgesteld</Typen:waarde>
+  </KadastraalObject:soortGrootte>
+  <KadastraalObject:perceelnummerVerschuiving>
+    <KadastraalObject:deltaX>-17.645</KadastraalObject:deltaX>
+    <KadastraalObject:deltaY>10.078</KadastraalObject:deltaY>
+  </KadastraalObject:perceelnummerVerschuiving>
+  <KadastraalObject:plaatscoordinaten><gml:Point srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:pos>233416.795 580683.025</gml:pos>
+</gml:Point></KadastraalObject:plaatscoordinaten>
+</KadastraalObject:Perceel><Recht:ZakelijkRecht id="ID.2313021875">
+  <Recht:identificatie>
+    <NEN3610:namespace>NL.KAD.ZakelijkRecht</NEN3610:namespace>
+    <NEN3610:lokaalId>AKR1.9934028</NEN3610:lokaalId>
+  </Recht:identificatie>
+  <Recht:aard>
+    <Typen:code>2</Typen:code>
+    <Typen:waarde>Eigendom (recht van)</Typen:waarde>
+  </Recht:aard>
+  <Recht:rustOp>
+    <KadastraalObjectRef:PerceelRef xlink:href="#ID.2313021871" />
+  </Recht:rustOp>
+  <Recht:betrokkenBij>
+    <Recht:HoofdSplitsing>
+      <Recht:verenigingVanEigenaren>
+        <PersoonRef:KADNietNatuurlijkPersoonRef xlink:href="#ID.2313021877" />
+      </Recht:verenigingVanEigenaren>
+      <Recht:isGebaseerdOp>
+        <StukRef:StukdeelRef xlink:href="#ID.2313021881" />
+      </Recht:isGebaseerdOp>
+    </Recht:HoofdSplitsing>
+  </Recht:betrokkenBij>
+</Recht:ZakelijkRecht><Persoon:KADNietNatuurlijkPersoon id="ID.2313021877">
+  <Persoon:identificatie>
+    <NEN3610:namespace>NL.KAD.Persoon</NEN3610:namespace>
+    <NEN3610:lokaalId>47050190</NEN3610:lokaalId>
+  </Persoon:identificatie>
+  <Persoon:naam>Vereniging Van Eigenaars Flat-Hoornsediep 71, 71a En 71b</Persoon:naam>
+  <Persoon:rechtsvorm>
+    <Typen:code>13</Typen:code>
+    <Typen:waarde>Vereniging van eigenaren</Typen:waarde>
+  </Persoon:rechtsvorm>
+  <Persoon:statutaireZetel>GRONINGEN</Persoon:statutaireZetel>
+</Persoon:KADNietNatuurlijkPersoon><Stuk:Kadasterstuk id="ID.2313021879">
+  <Stuk:identificatie>
+    <NEN3610:namespace>NL.KAD.Kadasterstuk</NEN3610:namespace>
+    <NEN3610:lokaalId>AKR1.11306674</NEN3610:lokaalId>
+  </Stuk:identificatie>
+  <Stuk:omvat>
+    <Stuk:Stukdeel id="ID.2313021881">
+      <Stuk:identificatie>
+        <NEN3610:namespace>NL.KAD.Stukdeel</NEN3610:namespace>
+        <NEN3610:lokaalId>AKR1.11102558</NEN3610:lokaalId>
+      </Stuk:identificatie>
+      <Stuk:aardStukdeel nilReason="waardeOnbekend">
+        <Typen:code>NIL</Typen:code>
+        <Typen:waarde>NIL</Typen:waarde>
+      </Stuk:aardStukdeel>
+    </Stuk:Stukdeel>
+  </Stuk:omvat>
+  <Stuk:AKRPortefeuilleNr>84 GNG0059310GNG</Stuk:AKRPortefeuilleNr>
+</Stuk:Kadasterstuk>
+    </Snapshot:KadastraalObjectSnapshot>
+  </Mutatie:was>
+  <Mutatie:wordt>
+    <Snapshot:KadastraalObjectSnapshot>
+      <Snapshot:referentie>3598EDFFDEB0-1D5A3594B6D</Snapshot:referentie>
+      <Snapshot:toestandsdatum>2017-08-02</Snapshot:toestandsdatum><KadastraalObject:Perceel id="ID.5668233245">
+  <KadastraalObject:identificatie>
+    <NEN3610:namespace>NL.KAD.OnroerendeZaak</NEN3610:namespace>
+    <NEN3610:lokaalId>58930944270000</NEN3610:lokaalId>
+  </KadastraalObject:identificatie>
+  <KadastraalObject:heeftLocatie>
+    <KadastraalObject:LocatieKadastraalObject>
+      <KadastraalObject:cultuurBebouwd>
+        <Typen:code>18</Typen:code>
+        <Typen:waarde>Berging - Stalling (garage-schuur)</Typen:waarde>
+      </KadastraalObject:cultuurBebouwd>
+    </KadastraalObject:LocatieKadastraalObject>
+  </KadastraalObject:heeftLocatie>
+  <KadastraalObject:kadastraleAanduiding>
+    <KadastraalObject:AKRKadastraleGemeenteCode>
+      <Typen:code>386</Typen:code>
+      <Typen:waarde>GNG00</Typen:waarde>
+    </KadastraalObject:AKRKadastraleGemeenteCode>
+    <KadastraalObject:naamKadastraleGemeente>
+      <Typen:code>339</Typen:code>
+      <Typen:waarde>Groningen</Typen:waarde>
+    </KadastraalObject:naamKadastraleGemeente>
+    <KadastraalObject:sectie>C</KadastraalObject:sectie>
+    <KadastraalObject:perceelnummer>9442</KadastraalObject:perceelnummer>
+  </KadastraalObject:kadastraleAanduiding>
+  <KadastraalObject:begrenzingPerceel><gml:Surface srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:patches>
+    <gml:PolygonPatch>
+      <gml:exterior>
+        <gml:LinearRing>
+          <gml:posList srsDimension="2" count="7">233417.686 580684.44 233412.82 580682.193 233413.695 580679.293 233416.247 580680.022 233415.81 580681.473 233418.361 580682.201 233417.686 580684.44</gml:posList>
+        </gml:LinearRing>
+      </gml:exterior>
+    </gml:PolygonPatch>
+  </gml:patches>
+</gml:Surface></KadastraalObject:begrenzingPerceel>
+  <KadastraalObject:indicatieDeelperceel>false</KadastraalObject:indicatieDeelperceel>
+  <KadastraalObject:kadastraleGrootte>
+    <KadastraalObject:waarde>14</KadastraalObject:waarde>
+  </KadastraalObject:kadastraleGrootte>
+  <KadastraalObject:soortGrootte>
+    <Typen:code>1</Typen:code>
+    <Typen:waarde>Vastgesteld</Typen:waarde>
+  </KadastraalObject:soortGrootte>
+  <KadastraalObject:perceelnummerVerschuiving>
+    <KadastraalObject:deltaX>-17.645</KadastraalObject:deltaX>
+    <KadastraalObject:deltaY>10.078</KadastraalObject:deltaY>
+  </KadastraalObject:perceelnummerVerschuiving>
+  <KadastraalObject:plaatscoordinaten><gml:Point srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:pos>233416.795 580683.025</gml:pos>
+</gml:Point></KadastraalObject:plaatscoordinaten>
+</KadastraalObject:Perceel><Recht:ZakelijkRecht id="ID.5668233247">
+  <Recht:identificatie>
+    <NEN3610:namespace>NL.KAD.ZakelijkRecht</NEN3610:namespace>
+    <NEN3610:lokaalId>AKR1.9934028</NEN3610:lokaalId>
+  </Recht:identificatie>
+  <Recht:aard>
+    <Typen:code>2</Typen:code>
+    <Typen:waarde>Eigendom (recht van)</Typen:waarde>
+  </Recht:aard>
+  <Recht:rustOp>
+    <KadastraalObjectRef:PerceelRef xlink:href="#ID.5668233245" />
+  </Recht:rustOp>
+  <Recht:betrokkenBij>
+   <Recht:HoofdSplitsing>
+  <Recht:verenigingVanEigenaren>
+      <PersoonRef:KADNietNatuurlijkPersoonRef xlink:href="#ID.5668233248" />
+      </Recht:verenigingVanEigenaren>
+      <Recht:isGebaseerdOp>
+        <StukRef:StukdeelRef xlink:href="#ID.5668233250" />
+      </Recht:isGebaseerdOp>
+    </Recht:HoofdSplitsing>
+  </Recht:betrokkenBij>
+</Recht:ZakelijkRecht><Persoon:KADNietNatuurlijkPersoon id="ID.5668233248">
+  <Persoon:identificatie>
+    <NEN3610:namespace>NL.KAD.Persoon</NEN3610:namespace>
+    <NEN3610:lokaalId>47050190</NEN3610:lokaalId>
+  </Persoon:identificatie>
+  <Persoon:naam>Vereniging Van Eigenaars Flat-Hoornsediep 71, 71a En 71b</Persoon:naam>
+  <Persoon:rechtsvorm>
+    <Typen:code>21</Typen:code>
+    <Typen:waarde>Vereniging van eigenaars</Typen:waarde>
+  </Persoon:rechtsvorm>
+  <Persoon:statutaireZetel>GRONINGEN</Persoon:statutaireZetel>
+</Persoon:KADNietNatuurlijkPersoon><Stuk:Kadasterstuk id="ID.5668233249">
+<Stuk:identificatie>
+<NEN3610:namespace>NL.KAD.Kadasterstuk</NEN3610:namespace>
+<NEN3610:lokaalId>AKR1.11306674</NEN3610:lokaalId>
+</Stuk:identificatie>
+<Stuk:omvat>
+<Stuk:Stukdeel id="ID.5668233250">
+<Stuk:identificatie>
+<NEN3610:namespace>NL.KAD.Stukdeel</NEN3610:namespace>
+<NEN3610:lokaalId>AKR1.11102558</NEN3610:lokaalId>
+</Stuk:identificatie>
+<Stuk:aardStukdeel nilReason="waardeOnbekend">
+<Typen:code>NIL</Typen:code>
+<Typen:waarde>NIL</Typen:waarde>
+</Stuk:aardStukdeel>
+</Stuk:Stukdeel>
+</Stuk:omvat>
+<Stuk:AKRPortefeuilleNr>84 GNG0059310GNG</Stuk:AKRPortefeuilleNr>
+</Stuk:Kadasterstuk>
+</Snapshot:KadastraalObjectSnapshot>
+  </Mutatie:wordt>
+</Mutatie:Mutatie>

--- a/brmo-service/src/test/resources/duplicaatberichten/8001bytesBRxml.xml
+++ b/brmo-service/src/test/resources/duplicaatberichten/8001bytesBRxml.xml
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Mutatie:Mutatie xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:Mutatie="http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901" xmlns:Snapshot="http://www.kadaster.nl/schemas/brk-levering/snapshot/v20120901" xmlns:GbaPersoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon/v20120901" xmlns:Adres="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-adres/v20120201" xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201" xmlns:Persoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon/v20120201" xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201" xmlns:BagAdres="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-bag-adres/v20120201" xmlns:KadastraalObject="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject/v20120701" xmlns:InOnderzoek="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-inonderzoek/v20120201" xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml" xmlns:NhrRechtspersoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-nhr-rechtspersoon/v20120201" xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201" xmlns:GbaPersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon-ref/v20120201" xmlns:PersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon-ref/v20120201" xmlns:NhrRechtspersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-nhr-rechtspersoon-ref/v20120201" xmlns:RechtRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht-ref/v20120201" xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201" xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201" xsi:schemaLocation="http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901 http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901/BRKLeveringMutatie_v1_1_4.xsd http://www.opengis.net/gml http://www.kadaster.nl/schemas/gml/3.1.1/base/gml.xsd http://www.w3.org/1999/xlink http://www.kadaster.nl/schemas/xlink/1.0.0/xlinks.xsd">
+  <Mutatie:aardStukdeel>
+    <Typen:code>179</Typen:code>
+    <Typen:waarde>Toevoegen titels met behulp van Tr. 34</Typen:waarde>
+  </Mutatie:aardStukdeel>
+  <Mutatie:BRKDatum>2017-08-02</Mutatie:BRKDatum>
+  <Mutatie:volgnummerKadastraalObjectDatum>1</Mutatie:volgnummerKadastraalObjectDatum>
+  <Mutatie:ingeschrevenStuk>
+    <Mutatie:AanduidingKadasterstuk>
+      <Mutatie:stuk>
+        <StukRef:KadasterstukRef xlink:href="NL.KAD.KadasterStuk.AKR1.100000003758678" />
+      </Mutatie:stuk>
+      <Mutatie:AKRPortefeuilleNr>ACG75271     GNG</Mutatie:AKRPortefeuilleNr>
+    </Mutatie:AanduidingKadasterstuk>
+  </Mutatie:ingeschrevenStuk>
+  <Mutatie:kadastraalObject>
+    <Mutatie:AanduidingKadastraalObject>
+      <Mutatie:indicatieDeelperceel>false</Mutatie:indicatieDeelperceel>
+      <Mutatie:kadastraleAanduiding>
+        <KadastraalObject:AKRKadastraleGemeenteCode>
+          <Typen:code>386</Typen:code>
+          <Typen:waarde>GNG00</Typen:waarde>
+        </KadastraalObject:AKRKadastraleGemeenteCode>
+        <KadastraalObject:naamKadastraleGemeente>
+          <Typen:code>339</Typen:code>
+          <Typen:waarde>Groningen</Typen:waarde>
+        </KadastraalObject:naamKadastraleGemeente>
+        <KadastraalObject:sectie>C</KadastraalObject:sectie>
+        <KadastraalObject:perceelnummer>9442</KadastraalObject:perceelnummer>
+      </Mutatie:kadastraleAanduiding>
+      <Mutatie:kadastraalObject>
+        <KadastraalObjectRef:PerceelRef xlink:href="NL.KAD.OnroerendeZaak.58930944270000" />
+      </Mutatie:kadastraalObject>
+    </Mutatie:AanduidingKadastraalObject>
+  </Mutatie:kadastraalObject>
+  <Mutatie:was>
+    <Snapshot:KadastraalObjectSnapshot>
+      <Snapshot:referentie>3598EDFFDEB0-1D4B50B2144</Snapshot:referentie>
+      <Snapshot:toestandsdatum>2013-08-21</Snapshot:toestandsdatum><KadastraalObject:Perceel id="ID.2313021871">
+  <KadastraalObject:identificatie>
+    <NEN3610:namespace>NL.KAD.OnroerendeZaak</NEN3610:namespace>
+    <NEN3610:lokaalId>58930944270000</NEN3610:lokaalId>
+  </KadastraalObject:identificatie>
+  <KadastraalObject:heeftLocatie>
+    <KadastraalObject:LocatieKadastraalObject>
+      <KadastraalObject:cultuurBebouwd>
+        <Typen:code>18</Typen:code>
+        <Typen:waarde>Berging - Stalling (garage-schuur)</Typen:waarde>
+      </KadastraalObject:cultuurBebouwd>
+      <KadastraalObject:adres>
+        <Adres:KADBinnenlandsAdres>
+          <Adres:openbareRuimteNaam>HOORNSEDIEP</Adres:openbareRuimteNaam>
+          <Adres:woonplaatsNaam>GRONINGEN</Adres:woonplaatsNaam>
+        </Adres:KADBinnenlandsAdres>
+      </KadastraalObject:adres>
+    </KadastraalObject:LocatieKadastraalObject>
+  </KadastraalObject:heeftLocatie>
+  <KadastraalObject:kadastraleAanduiding>
+    <KadastraalObject:AKRKadastraleGemeenteCode>
+      <Typen:code>386</Typen:code>
+      <Typen:waarde>GNG00</Typen:waarde>
+    </KadastraalObject:AKRKadastraleGemeenteCode>
+    <KadastraalObject:naamKadastraleGemeente>
+      <Typen:code>339</Typen:code>
+      <Typen:waarde>Groningen</Typen:waarde>
+    </KadastraalObject:naamKadastraleGemeente>
+    <KadastraalObject:sectie>C</KadastraalObject:sectie>
+    <KadastraalObject:perceelnummer>9442</KadastraalObject:perceelnummer>
+  </KadastraalObject:kadastraleAanduiding>
+  <KadastraalObject:begrenzingPerceel><gml:Surface srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:patches>
+    <gml:PolygonPatch>
+      <gml:exterior>
+        <gml:LinearRing>
+          <gml:posList srsDimension="2" count="7">233417.686 580684.44 233412.82 580682.193 233413.695 580679.293 233416.247 580680.022 233415.81 580681.473 233418.361 580682.201 233417.686 580684.44</gml:posList>
+        </gml:LinearRing>
+      </gml:exterior>
+    </gml:PolygonPatch>
+  </gml:patches>
+</gml:Surface></KadastraalObject:begrenzingPerceel>
+  <KadastraalObject:indicatieDeelperceel>false</KadastraalObject:indicatieDeelperceel>
+  <KadastraalObject:kadastraleGrootte>
+    <KadastraalObject:waarde>14</KadastraalObject:waarde>
+  </KadastraalObject:kadastraleGrootte>
+  <KadastraalObject:soortGrootte>
+    <Typen:code>1</Typen:code>
+    <Typen:waarde>Vastgesteld</Typen:waarde>
+  </KadastraalObject:soortGrootte>
+  <KadastraalObject:perceelnummerVerschuiving>
+    <KadastraalObject:deltaX>-17.645</KadastraalObject:deltaX>
+    <KadastraalObject:deltaY>10.078</KadastraalObject:deltaY>
+  </KadastraalObject:perceelnummerVerschuiving>
+  <KadastraalObject:plaatscoordinaten><gml:Point srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:pos>233416.795 580683.025</gml:pos>
+</gml:Point></KadastraalObject:plaatscoordinaten>
+</KadastraalObject:Perceel><Recht:ZakelijkRecht id="ID.2313021875">
+  <Recht:identificatie>
+    <NEN3610:namespace>NL.KAD.ZakelijkRecht</NEN3610:namespace>
+    <NEN3610:lokaalId>AKR1.9934028</NEN3610:lokaalId>
+  </Recht:identificatie>
+  <Recht:aard>
+    <Typen:code>2</Typen:code>
+    <Typen:waarde>Eigendom (recht van)</Typen:waarde>
+  </Recht:aard>
+  <Recht:rustOp>
+    <KadastraalObjectRef:PerceelRef xlink:href="#ID.2313021871" />
+  </Recht:rustOp>
+  <Recht:betrokkenBij>
+    <Recht:HoofdSplitsing>
+      <Recht:verenigingVanEigenaren>
+        <PersoonRef:KADNietNatuurlijkPersoonRef xlink:href="#ID.2313021877" />
+      </Recht:verenigingVanEigenaren>
+      <Recht:isGebaseerdOp>
+        <StukRef:StukdeelRef xlink:href="#ID.2313021881" />
+      </Recht:isGebaseerdOp>
+    </Recht:HoofdSplitsing>
+  </Recht:betrokkenBij>
+</Recht:ZakelijkRecht><Persoon:KADNietNatuurlijkPersoon id="ID.2313021877">
+  <Persoon:identificatie>
+    <NEN3610:namespace>NL.KAD.Persoon</NEN3610:namespace>
+    <NEN3610:lokaalId>47050190</NEN3610:lokaalId>
+  </Persoon:identificatie>
+  <Persoon:naam>Vereniging Van Eigenaars Flat-Hoornsediep 71, 71a En 71b</Persoon:naam>
+  <Persoon:rechtsvorm>
+    <Typen:code>13</Typen:code>
+    <Typen:waarde>Vereniging van eigenaren</Typen:waarde>
+  </Persoon:rechtsvorm>
+  <Persoon:statutaireZetel>GRONINGEN</Persoon:statutaireZetel>
+</Persoon:KADNietNatuurlijkPersoon><Stuk:Kadasterstuk id="ID.2313021879">
+  <Stuk:identificatie>
+    <NEN3610:namespace>NL.KAD.Kadasterstuk</NEN3610:namespace>
+    <NEN3610:lokaalId>AKR1.11306674</NEN3610:lokaalId>
+  </Stuk:identificatie>
+  <Stuk:omvat>
+    <Stuk:Stukdeel id="ID.2313021881">
+      <Stuk:identificatie>
+        <NEN3610:namespace>NL.KAD.Stukdeel</NEN3610:namespace>
+        <NEN3610:lokaalId>AKR1.11102558</NEN3610:lokaalId>
+      </Stuk:identificatie>
+      <Stuk:aardStukdeel nilReason="waardeOnbekend">
+        <Typen:code>NIL</Typen:code>
+        <Typen:waarde>NIL</Typen:waarde>
+      </Stuk:aardStukdeel>
+    </Stuk:Stukdeel>
+  </Stuk:omvat>
+  <Stuk:AKRPortefeuilleNr>84 GNG0059310GNG</Stuk:AKRPortefeuilleNr>
+</Stuk:Kadasterstuk>
+    </Snapshot:KadastraalObjectSnapshot>
+  </Mutatie:was>
+  <Mutatie:wordt>
+    <Snapshot:KadastraalObjectSnapshot>
+      <Snapshot:referentie>3598EDFFDEB0-1D5A3594B6D</Snapshot:referentie>
+      <Snapshot:toestandsdatum>2017-08-02</Snapshot:toestandsdatum><KadastraalObject:Perceel id="ID.5668233245">
+  <KadastraalObject:identificatie>
+    <NEN3610:namespace>NL.KAD.OnroerendeZaak</NEN3610:namespace>
+    <NEN3610:lokaalId>58930944270000</NEN3610:lokaalId>
+  </KadastraalObject:identificatie>
+  <KadastraalObject:heeftLocatie>
+    <KadastraalObject:LocatieKadastraalObject>
+      <KadastraalObject:cultuurBebouwd>
+        <Typen:code>18</Typen:code>
+        <Typen:waarde>Berging - Stalling (garage-schuur)</Typen:waarde>
+      </KadastraalObject:cultuurBebouwd>
+    </KadastraalObject:LocatieKadastraalObject>
+  </KadastraalObject:heeftLocatie>
+  <KadastraalObject:kadastraleAanduiding>
+    <KadastraalObject:AKRKadastraleGemeenteCode>
+      <Typen:code>386</Typen:code>
+      <Typen:waarde>GNG00</Typen:waarde>
+    </KadastraalObject:AKRKadastraleGemeenteCode>
+    <KadastraalObject:naamKadastraleGemeente>
+      <Typen:code>339</Typen:code>
+      <Typen:waarde>Groningen</Typen:waarde>
+    </KadastraalObject:naamKadastraleGemeente>
+    <KadastraalObject:sectie>C</KadastraalObject:sectie>
+    <KadastraalObject:perceelnummer>9442</KadastraalObject:perceelnummer>
+  </KadastraalObject:kadastraleAanduiding>
+  <KadastraalObject:begrenzingPerceel><gml:Surface srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:patches>
+    <gml:PolygonPatch>
+      <gml:exterior>
+        <gml:LinearRing>
+          <gml:posList srsDimension="2" count="7">233417.686 580684.44 233412.82 580682.193 233413.695 580679.293 233416.247 580680.022 233415.81 580681.473 233418.361 580682.201 233417.686 580684.44</gml:posList>
+        </gml:LinearRing>
+      </gml:exterior>
+    </gml:PolygonPatch>
+  </gml:patches>
+</gml:Surface></KadastraalObject:begrenzingPerceel>
+  <KadastraalObject:indicatieDeelperceel>false</KadastraalObject:indicatieDeelperceel>
+  <KadastraalObject:kadastraleGrootte>
+    <KadastraalObject:waarde>14</KadastraalObject:waarde>
+  </KadastraalObject:kadastraleGrootte>
+  <KadastraalObject:soortGrootte>
+    <Typen:code>1</Typen:code>
+    <Typen:waarde>Vastgesteld</Typen:waarde>
+  </KadastraalObject:soortGrootte>
+  <KadastraalObject:perceelnummerVerschuiving>
+    <KadastraalObject:deltaX>-17.645</KadastraalObject:deltaX>
+    <KadastraalObject:deltaY>10.078</KadastraalObject:deltaY>
+  </KadastraalObject:perceelnummerVerschuiving>
+  <KadastraalObject:plaatscoordinaten><gml:Point srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:pos>233416.795 580683.025</gml:pos>
+</gml:Point></KadastraalObject:plaatscoordinaten>
+</KadastraalObject:Perceel><Recht:ZakelijkRecht id="ID.5668233247">
+  <Recht:identificatie>
+    <NEN3610:namespace>NL.KAD.ZakelijkRecht</NEN3610:namespace>
+    <NEN3610:lokaalId>AKR1.9934028</NEN3610:lokaalId>
+  </Recht:identificatie>
+  <Recht:aard>
+    <Typen:code>2</Typen:code>
+    <Typen:waarde>Eigendom (recht van)</Typen:waarde>
+  </Recht:aard>
+  <Recht:rustOp>
+    <KadastraalObjectRef:PerceelRef xlink:href="#ID.5668233245" />
+  </Recht:rustOp>
+  <Recht:betrokkenBij>
+   <Recht:HoofdSplitsing>
+  <Recht:verenigingVanEigenaren>
+      <PersoonRef:KADNietNatuurlijkPersoonRef xlink:href="#ID.5668233248" />
+       </Recht:verenigingVanEigenaren>
+      <Recht:isGebaseerdOp>
+        <StukRef:StukdeelRef xlink:href="#ID.5668233250" />
+      </Recht:isGebaseerdOp>
+    </Recht:HoofdSplitsing>
+  </Recht:betrokkenBij>
+</Recht:ZakelijkRecht><Persoon:KADNietNatuurlijkPersoon id="ID.5668233248">
+  <Persoon:identificatie>
+    <NEN3610:namespace>NL.KAD.Persoon</NEN3610:namespace>
+    <NEN3610:lokaalId>47050190</NEN3610:lokaalId>
+  </Persoon:identificatie>
+  <Persoon:naam>Vereniging Van Eigenaars Flat-Hoornsediep 71, 71a En 71b</Persoon:naam>
+  <Persoon:rechtsvorm>
+    <Typen:code>21</Typen:code>
+    <Typen:waarde>Vereniging van eigenaars</Typen:waarde>
+  </Persoon:rechtsvorm>
+  <Persoon:statutaireZetel>GRONINGEN</Persoon:statutaireZetel>
+</Persoon:KADNietNatuurlijkPersoon><Stuk:Kadasterstuk id="ID.5668233249">
+<Stuk:identificatie>
+<NEN3610:namespace>NL.KAD.Kadasterstuk</NEN3610:namespace>
+<NEN3610:lokaalId>AKR1.11306674</NEN3610:lokaalId>
+</Stuk:identificatie>
+<Stuk:omvat>
+<Stuk:Stukdeel id="ID.5668233250">
+<Stuk:identificatie>
+<NEN3610:namespace>NL.KAD.Stukdeel</NEN3610:namespace>
+<NEN3610:lokaalId>AKR1.11102558</NEN3610:lokaalId>
+</Stuk:identificatie>
+<Stuk:aardStukdeel nilReason="waardeOnbekend">
+<Typen:code>NIL</Typen:code>
+<Typen:waarde>NIL</Typen:waarde>
+</Stuk:aardStukdeel>
+</Stuk:Stukdeel>
+</Stuk:omvat>
+<Stuk:AKRPortefeuilleNr>84 GNG0059310GNG</Stuk:AKRPortefeuilleNr>
+</Stuk:Kadasterstuk>
+</Snapshot:KadastraalObjectSnapshot>
+  </Mutatie:wordt>
+</Mutatie:Mutatie>

--- a/brmo-service/src/test/resources/duplicaatberichten/MUTBX01.xml
+++ b/brmo-service/src/test/resources/duplicaatberichten/MUTBX01.xml
@@ -1,0 +1,295 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Mutatie:Mutatie xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:Mutatie="http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901" xmlns:Snapshot="http://www.kadaster.nl/schemas/brk-levering/snapshot/v20120901" xmlns:GbaPersoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon/v20120901" xmlns:Adres="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-adres/v20120201" xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201" xmlns:Persoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon/v20120201" xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201" xmlns:BagAdres="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-bag-adres/v20120201" xmlns:KadastraalObject="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject/v20120701" xmlns:InOnderzoek="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-inonderzoek/v20120201" xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml" xmlns:NhrRechtspersoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-nhr-rechtspersoon/v20120201" xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201" xmlns:GbaPersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon-ref/v20120201" xmlns:PersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon-ref/v20120201" xmlns:NhrRechtspersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-nhr-rechtspersoon-ref/v20120201" xmlns:RechtRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht-ref/v20120201" xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201" xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201" xsi:schemaLocation="http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901 http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901/BRKLeveringMutatie_v1_1_4.xsd http://www.opengis.net/gml http://www.kadaster.nl/schemas/gml/3.1.1/base/gml.xsd http://www.w3.org/1999/xlink http://www.kadaster.nl/schemas/xlink/1.0.0/xlinks.xsd">
+  <Mutatie:aardStukdeel>
+    <Typen:code>179</Typen:code>
+    <Typen:waarde>Toevoegen titels met behulp van Tr. 34</Typen:waarde>
+  </Mutatie:aardStukdeel>
+  <Mutatie:BRKDatum>2017-07-03</Mutatie:BRKDatum>
+  <Mutatie:volgnummerKadastraalObjectDatum>1</Mutatie:volgnummerKadastraalObjectDatum>
+  <Mutatie:ingeschrevenStuk>
+    <Mutatie:AanduidingKadasterstuk>
+      <Mutatie:stuk>
+        <StukRef:KadasterstukRef xlink:href="NL.KAD.KadasterStuk.AKR1.100000003696292" />
+      </Mutatie:stuk>
+      <Mutatie:AKRPortefeuilleNr>ACG75310     AHM</Mutatie:AKRPortefeuilleNr>
+    </Mutatie:AanduidingKadasterstuk>
+  </Mutatie:ingeschrevenStuk>
+  <Mutatie:kadastraalObject>
+    <Mutatie:AanduidingKadastraalObject>
+      <Mutatie:indicatieDeelperceel>false</Mutatie:indicatieDeelperceel>
+      <Mutatie:kadastraleAanduiding>
+        <KadastraalObject:AKRKadastraleGemeenteCode>
+          <Typen:code>418</Typen:code>
+          <Typen:waarde>HTT02</Typen:waarde>
+        </KadastraalObject:AKRKadastraleGemeenteCode>
+        <KadastraalObject:naamKadastraleGemeente>
+          <Typen:code>369</Typen:code>
+          <Typen:waarde>Hatert</Typen:waarde>
+        </KadastraalObject:naamKadastraleGemeente>
+        <KadastraalObject:sectie>B</KadastraalObject:sectie>
+        <KadastraalObject:perceelnummer>4317</KadastraalObject:perceelnummer>
+      </Mutatie:kadastraleAanduiding>
+      <Mutatie:kadastraalObject>
+        <KadastraalObjectRef:PerceelRef xlink:href="NL.KAD.OnroerendeZaak.82070431770000" />
+      </Mutatie:kadastraalObject>
+    </Mutatie:AanduidingKadastraalObject>
+  </Mutatie:kadastraalObject>
+  <Mutatie:was>
+    <Snapshot:KadastraalObjectSnapshot>
+      <Snapshot:referentie>4AA482EEA590-1D4B5A6C522</Snapshot:referentie>
+      <Snapshot:toestandsdatum>2013-09-23</Snapshot:toestandsdatum><KadastraalObject:Perceel id="ID.2335666821">
+  <KadastraalObject:identificatie>
+    <NEN3610:namespace>NL.KAD.OnroerendeZaak</NEN3610:namespace>
+    <NEN3610:lokaalId>82070431770000</NEN3610:lokaalId>
+  </KadastraalObject:identificatie>
+  <KadastraalObject:heeftLocatie>
+    <KadastraalObject:LocatieKadastraalObject>
+      <KadastraalObject:cultuurBebouwd>
+        <Typen:code>37</Typen:code>
+        <Typen:waarde>Wonen met bedrijvigheid</Typen:waarde>
+      </KadastraalObject:cultuurBebouwd>
+      <KadastraalObject:adres>
+        <Adres:KADBinnenlandsAdres>
+          <Adres:openbareRuimteNaam>KAN BOENENSTR</Adres:openbareRuimteNaam>
+          <Adres:woonplaatsNaam>NYMEGEN</Adres:woonplaatsNaam>
+        </Adres:KADBinnenlandsAdres>
+      </KadastraalObject:adres>
+    </KadastraalObject:LocatieKadastraalObject>
+    <KadastraalObject:LocatieKadastraalObject>
+      <KadastraalObject:cultuurBebouwd>
+        <Typen:code>37</Typen:code>
+        <Typen:waarde>Wonen met bedrijvigheid</Typen:waarde>
+      </KadastraalObject:cultuurBebouwd>
+      <KadastraalObject:adres>
+        <Adres:KADBinnenlandsAdres>
+          <Adres:openbareRuimteNaam>KAN MYLLINCKSTR</Adres:openbareRuimteNaam>
+          <Adres:woonplaatsNaam>NYMEGEN</Adres:woonplaatsNaam>
+        </Adres:KADBinnenlandsAdres>
+      </KadastraalObject:adres>
+    </KadastraalObject:LocatieKadastraalObject>
+    <KadastraalObject:LocatieKadastraalObject>
+      <KadastraalObject:cultuurBebouwd>
+        <Typen:code>37</Typen:code>
+        <Typen:waarde>Wonen met bedrijvigheid</Typen:waarde>
+      </KadastraalObject:cultuurBebouwd>
+      <KadastraalObject:adres>
+        <Adres:KADBinnenlandsAdres>
+          <Adres:openbareRuimteNaam>KAN PELSSTR</Adres:openbareRuimteNaam>
+          <Adres:woonplaatsNaam>NYMEGEN</Adres:woonplaatsNaam>
+        </Adres:KADBinnenlandsAdres>
+      </KadastraalObject:adres>
+    </KadastraalObject:LocatieKadastraalObject>
+    <KadastraalObject:LocatieKadastraalObject>
+      <KadastraalObject:cultuurBebouwd>
+        <Typen:code>37</Typen:code>
+        <Typen:waarde>Wonen met bedrijvigheid</Typen:waarde>
+      </KadastraalObject:cultuurBebouwd>
+      <KadastraalObject:adres>
+        <Adres:KADBinnenlandsAdres>
+          <Adres:openbareRuimteNaam>KAN VD PUTSTR</Adres:openbareRuimteNaam>
+          <Adres:woonplaatsNaam>NYMEGEN</Adres:woonplaatsNaam>
+        </Adres:KADBinnenlandsAdres>
+      </KadastraalObject:adres>
+    </KadastraalObject:LocatieKadastraalObject>
+  </KadastraalObject:heeftLocatie>
+  <KadastraalObject:kadastraleAanduiding>
+    <KadastraalObject:AKRKadastraleGemeenteCode>
+      <Typen:code>418</Typen:code>
+      <Typen:waarde>HTT02</Typen:waarde>
+    </KadastraalObject:AKRKadastraleGemeenteCode>
+    <KadastraalObject:naamKadastraleGemeente>
+      <Typen:code>369</Typen:code>
+      <Typen:waarde>Hatert</Typen:waarde>
+    </KadastraalObject:naamKadastraleGemeente>
+    <KadastraalObject:sectie>B</KadastraalObject:sectie>
+    <KadastraalObject:perceelnummer>4317</KadastraalObject:perceelnummer>
+  </KadastraalObject:kadastraleAanduiding>
+  <KadastraalObject:begrenzingPerceel><gml:Surface srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:patches>
+    <gml:PolygonPatch>
+      <gml:exterior>
+        <gml:LinearRing>
+          <gml:posList srsDimension="2" count="5">187738.621 425313.37 187730.854 425313.392 187730.863 425311.793 187738.607 425311.755 187738.621 425313.37</gml:posList>
+        </gml:LinearRing>
+      </gml:exterior>
+    </gml:PolygonPatch>
+  </gml:patches>
+</gml:Surface></KadastraalObject:begrenzingPerceel>
+  <KadastraalObject:indicatieDeelperceel>false</KadastraalObject:indicatieDeelperceel>
+  <KadastraalObject:kadastraleGrootte>
+    <KadastraalObject:waarde>14</KadastraalObject:waarde>
+  </KadastraalObject:kadastraleGrootte>
+  <KadastraalObject:soortGrootte>
+    <Typen:code>1</Typen:code>
+    <Typen:waarde>Vastgesteld</Typen:waarde>
+  </KadastraalObject:soortGrootte>
+  <KadastraalObject:perceelnummerVerschuiving>
+    <KadastraalObject:deltaX>0.307</KadastraalObject:deltaX>
+    <KadastraalObject:deltaY>5.083</KadastraalObject:deltaY>
+  </KadastraalObject:perceelnummerVerschuiving>
+  <KadastraalObject:plaatscoordinaten><gml:Point srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:pos>187735.245 425312.495</gml:pos>
+</gml:Point></KadastraalObject:plaatscoordinaten>
+</KadastraalObject:Perceel><Recht:ZakelijkRecht id="ID.2335666831">
+  <Recht:identificatie>
+    <NEN3610:namespace>NL.KAD.ZakelijkRecht</NEN3610:namespace>
+    <NEN3610:lokaalId>AKR1.12795923</NEN3610:lokaalId>
+  </Recht:identificatie>
+  <Recht:aard>
+    <Typen:code>2</Typen:code>
+    <Typen:waarde>Eigendom (recht van)</Typen:waarde>
+  </Recht:aard>
+  <Recht:rustOp>
+    <KadastraalObjectRef:PerceelRef xlink:href="#ID.2335666821" />
+  </Recht:rustOp>
+  <Recht:betrokkenBij>
+    <Recht:HoofdSplitsing>
+      <Recht:verenigingVanEigenaren>
+        <PersoonRef:KADNietNatuurlijkPersoonRef xlink:href="#ID.2335666833" />
+      </Recht:verenigingVanEigenaren>
+      <Recht:isGebaseerdOp>
+        <StukRef:StukdeelRef xlink:href="#ID.2335666837" />
+      </Recht:isGebaseerdOp>
+    </Recht:HoofdSplitsing>
+  </Recht:betrokkenBij>
+</Recht:ZakelijkRecht><Persoon:KADNietNatuurlijkPersoon id="ID.2335666833">
+  <Persoon:identificatie>
+    <NEN3610:namespace>NL.KAD.Persoon</NEN3610:namespace>
+    <NEN3610:lokaalId>109786357</NEN3610:lokaalId>
+  </Persoon:identificatie>
+  <Persoon:naam>Vereniging Van Eigenaars Van Het Flatgebouw Aan De Kanunnik Van De Put -Boenen- Pels - Mijllinckstraat Te Nijmegen</Persoon:naam>
+  <Persoon:rechtsvorm>
+    <Typen:code>13</Typen:code>
+    <Typen:waarde>Vereniging van eigenaren</Typen:waarde>
+  </Persoon:rechtsvorm>
+  <Persoon:statutaireZetel>NIJMEGEN</Persoon:statutaireZetel>
+</Persoon:KADNietNatuurlijkPersoon><Stuk:Kadasterstuk id="ID.2335666835">
+  <Stuk:identificatie>
+    <NEN3610:namespace>NL.KAD.Kadasterstuk</NEN3610:namespace>
+    <NEN3610:lokaalId>AKR1.15413829</NEN3610:lokaalId>
+  </Stuk:identificatie>
+  <Stuk:omvat>
+    <Stuk:Stukdeel id="ID.2335666837">
+      <Stuk:identificatie>
+        <NEN3610:namespace>NL.KAD.Stukdeel</NEN3610:namespace>
+        <NEN3610:lokaalId>AKR1.15207253</NEN3610:lokaalId>
+      </Stuk:identificatie>
+      <Stuk:aardStukdeel nilReason="waardeOnbekend">
+        <Typen:code>NIL</Typen:code>
+        <Typen:waarde>NIL</Typen:waarde>
+      </Stuk:aardStukdeel>
+    </Stuk:Stukdeel>
+  </Stuk:omvat>
+  <Stuk:AKRPortefeuilleNr>84 HTT0236372AHM</Stuk:AKRPortefeuilleNr>
+</Stuk:Kadasterstuk>
+    </Snapshot:KadastraalObjectSnapshot>
+  </Mutatie:was>
+  <Mutatie:wordt>
+    <Snapshot:KadastraalObjectSnapshot>
+      <Snapshot:referentie>4AA482EEA590-1D5A2C23C28</Snapshot:referentie>
+      <Snapshot:toestandsdatum>2017-07-03</Snapshot:toestandsdatum><KadastraalObject:Perceel id="ID.5616094109">
+  <KadastraalObject:identificatie>
+    <NEN3610:namespace>NL.KAD.OnroerendeZaak</NEN3610:namespace>
+    <NEN3610:lokaalId>82070431770000</NEN3610:lokaalId>
+  </KadastraalObject:identificatie>
+  <KadastraalObject:heeftLocatie>
+    <KadastraalObject:LocatieKadastraalObject>
+      <KadastraalObject:cultuurBebouwd>
+        <Typen:code>37</Typen:code>
+        <Typen:waarde>Wonen met bedrijvigheid</Typen:waarde>
+      </KadastraalObject:cultuurBebouwd>
+    </KadastraalObject:LocatieKadastraalObject>
+  </KadastraalObject:heeftLocatie>
+  <KadastraalObject:kadastraleAanduiding>
+    <KadastraalObject:AKRKadastraleGemeenteCode>
+      <Typen:code>418</Typen:code>
+      <Typen:waarde>HTT02</Typen:waarde>
+    </KadastraalObject:AKRKadastraleGemeenteCode>
+    <KadastraalObject:naamKadastraleGemeente>
+      <Typen:code>369</Typen:code>
+      <Typen:waarde>Hatert</Typen:waarde>
+    </KadastraalObject:naamKadastraleGemeente>
+    <KadastraalObject:sectie>B</KadastraalObject:sectie>
+    <KadastraalObject:perceelnummer>4317</KadastraalObject:perceelnummer>
+  </KadastraalObject:kadastraleAanduiding>
+  <KadastraalObject:begrenzingPerceel><gml:Surface srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:patches>
+    <gml:PolygonPatch>
+      <gml:exterior>
+        <gml:LinearRing>
+          <gml:posList srsDimension="2" count="5">187738.621 425313.37 187730.854 425313.392 187730.863 425311.793 187738.607 425311.755 187738.621 425313.37</gml:posList>
+        </gml:LinearRing>
+      </gml:exterior>
+    </gml:PolygonPatch>
+  </gml:patches>
+</gml:Surface></KadastraalObject:begrenzingPerceel>
+  <KadastraalObject:indicatieDeelperceel>false</KadastraalObject:indicatieDeelperceel>
+  <KadastraalObject:kadastraleGrootte>
+    <KadastraalObject:waarde>14</KadastraalObject:waarde>
+  </KadastraalObject:kadastraleGrootte>
+  <KadastraalObject:soortGrootte>
+    <Typen:code>1</Typen:code>
+    <Typen:waarde>Vastgesteld</Typen:waarde>
+  </KadastraalObject:soortGrootte>
+  <KadastraalObject:perceelnummerVerschuiving>
+    <KadastraalObject:deltaX>0.307</KadastraalObject:deltaX>
+    <KadastraalObject:deltaY>5.083</KadastraalObject:deltaY>
+  </KadastraalObject:perceelnummerVerschuiving>
+  <KadastraalObject:plaatscoordinaten><gml:Point srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:pos>187735.245 425312.495</gml:pos>
+</gml:Point></KadastraalObject:plaatscoordinaten>
+</KadastraalObject:Perceel><Recht:ZakelijkRecht id="ID.5616094111">
+  <Recht:identificatie>
+    <NEN3610:namespace>NL.KAD.ZakelijkRecht</NEN3610:namespace>
+    <NEN3610:lokaalId>AKR1.12795923</NEN3610:lokaalId>
+  </Recht:identificatie>
+  <Recht:aard>
+    <Typen:code>2</Typen:code>
+    <Typen:waarde>Eigendom (recht van)</Typen:waarde>
+  </Recht:aard>
+  <Recht:rustOp>
+    <KadastraalObjectRef:PerceelRef xlink:href="#ID.5616094109" />
+  </Recht:rustOp>
+  <Recht:betrokkenBij>
+    <Recht:HoofdSplitsing>
+      <Recht:verenigingVanEigenaren>
+        <PersoonRef:KADNietNatuurlijkPersoonRef xlink:href="#ID.5616094112" />
+      </Recht:verenigingVanEigenaren>
+      <Recht:isGebaseerdOp>
+        <StukRef:StukdeelRef xlink:href="#ID.5616094114" />
+      </Recht:isGebaseerdOp>
+    </Recht:HoofdSplitsing>
+  </Recht:betrokkenBij>
+</Recht:ZakelijkRecht><Persoon:KADNietNatuurlijkPersoon id="ID.5616094112">
+  <Persoon:identificatie>
+    <NEN3610:namespace>NL.KAD.Persoon</NEN3610:namespace>
+    <NEN3610:lokaalId>109786357</NEN3610:lokaalId>
+  </Persoon:identificatie>
+  <Persoon:naam>Vereniging Van Eigenaars Van Het Flatgebouw Aan De Kanunnik Van De Put -Boenen- Pels - Mijllinckstraat Te Nijmegen</Persoon:naam>
+  <Persoon:rechtsvorm>
+    <Typen:code>21</Typen:code>
+    <Typen:waarde>Vereniging van eigenaars</Typen:waarde>
+  </Persoon:rechtsvorm>
+  <Persoon:statutaireZetel>NIJMEGEN</Persoon:statutaireZetel>
+</Persoon:KADNietNatuurlijkPersoon><Stuk:Kadasterstuk id="ID.5616094113">
+  <Stuk:identificatie>
+    <NEN3610:namespace>NL.KAD.Kadasterstuk</NEN3610:namespace>
+    <NEN3610:lokaalId>AKR1.15413829</NEN3610:lokaalId>
+  </Stuk:identificatie>
+  <Stuk:omvat>
+    <Stuk:Stukdeel id="ID.5616094114">
+      <Stuk:identificatie>
+        <NEN3610:namespace>NL.KAD.Stukdeel</NEN3610:namespace>
+        <NEN3610:lokaalId>AKR1.15207253</NEN3610:lokaalId>
+      </Stuk:identificatie>
+      <Stuk:aardStukdeel nilReason="waardeOnbekend">
+        <Typen:code>NIL</Typen:code>
+        <Typen:waarde>NIL</Typen:waarde>
+      </Stuk:aardStukdeel>
+    </Stuk:Stukdeel>
+  </Stuk:omvat>
+  <Stuk:AKRPortefeuilleNr>84 HTT0236372AHM</Stuk:AKRPortefeuilleNr>
+</Stuk:Kadasterstuk>
+    </Snapshot:KadastraalObjectSnapshot>
+  </Mutatie:wordt>
+</Mutatie:Mutatie>

--- a/brmo-service/src/test/resources/duplicaatberichten/PD_MUTBX01_23-8-2017.xml
+++ b/brmo-service/src/test/resources/duplicaatberichten/PD_MUTBX01_23-8-2017.xml
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Mutatie:Mutatie xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:Mutatie="http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901" xmlns:Snapshot="http://www.kadaster.nl/schemas/brk-levering/snapshot/v20120901" xmlns:GbaPersoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon/v20120901" xmlns:Adres="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-adres/v20120201" xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201" xmlns:Persoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon/v20120201" xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201" xmlns:BagAdres="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-bag-adres/v20120201" xmlns:KadastraalObject="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject/v20120701" xmlns:InOnderzoek="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-inonderzoek/v20120201" xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml" xmlns:NhrRechtspersoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-nhr-rechtspersoon/v20120201" xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201" xmlns:GbaPersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon-ref/v20120201" xmlns:PersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon-ref/v20120201" xmlns:NhrRechtspersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-nhr-rechtspersoon-ref/v20120201" xmlns:RechtRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht-ref/v20120201" xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201" xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201" xsi:schemaLocation="http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901 http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901/BRKLeveringMutatie_v1_1_4.xsd http://www.opengis.net/gml http://www.kadaster.nl/schemas/gml/3.1.1/base/gml.xsd http://www.w3.org/1999/xlink http://www.kadaster.nl/schemas/xlink/1.0.0/xlinks.xsd">
+  <Mutatie:aardStukdeel>
+    <Typen:code>179</Typen:code>
+    <Typen:waarde>Toevoegen titels met behulp van Tr. 34</Typen:waarde>
+  </Mutatie:aardStukdeel>
+  <Mutatie:BRKDatum>2017-08-02</Mutatie:BRKDatum>
+  <Mutatie:volgnummerKadastraalObjectDatum>1</Mutatie:volgnummerKadastraalObjectDatum>
+  <Mutatie:ingeschrevenStuk>
+    <Mutatie:AanduidingKadasterstuk>
+      <Mutatie:stuk>
+        <StukRef:KadasterstukRef xlink:href="NL.KAD.KadasterStuk.AKR1.100000003758678" />
+      </Mutatie:stuk>
+      <Mutatie:AKRPortefeuilleNr>ACG75271     GNG</Mutatie:AKRPortefeuilleNr>
+    </Mutatie:AanduidingKadasterstuk>
+  </Mutatie:ingeschrevenStuk>
+  <Mutatie:kadastraalObject>
+    <Mutatie:AanduidingKadastraalObject>
+      <Mutatie:indicatieDeelperceel>false</Mutatie:indicatieDeelperceel>
+      <Mutatie:kadastraleAanduiding>
+        <KadastraalObject:AKRKadastraleGemeenteCode>
+          <Typen:code>386</Typen:code>
+          <Typen:waarde>GNG00</Typen:waarde>
+        </KadastraalObject:AKRKadastraleGemeenteCode>
+        <KadastraalObject:naamKadastraleGemeente>
+          <Typen:code>339</Typen:code>
+          <Typen:waarde>Groningen</Typen:waarde>
+        </KadastraalObject:naamKadastraleGemeente>
+        <KadastraalObject:sectie>C</KadastraalObject:sectie>
+        <KadastraalObject:perceelnummer>9442</KadastraalObject:perceelnummer>
+      </Mutatie:kadastraleAanduiding>
+      <Mutatie:kadastraalObject>
+        <KadastraalObjectRef:PerceelRef xlink:href="NL.KAD.OnroerendeZaak.58930944270000" />
+      </Mutatie:kadastraalObject>
+    </Mutatie:AanduidingKadastraalObject>
+  </Mutatie:kadastraalObject>
+  <Mutatie:was>
+    <Snapshot:KadastraalObjectSnapshot>
+      <Snapshot:referentie>3598EDFFDEB0-1D4B50B2144</Snapshot:referentie>
+      <Snapshot:toestandsdatum>2013-08-21</Snapshot:toestandsdatum><KadastraalObject:Perceel id="ID.2313021871">
+  <KadastraalObject:identificatie>
+    <NEN3610:namespace>NL.KAD.OnroerendeZaak</NEN3610:namespace>
+    <NEN3610:lokaalId>58930944270000</NEN3610:lokaalId>
+  </KadastraalObject:identificatie>
+  <KadastraalObject:heeftLocatie>
+    <KadastraalObject:LocatieKadastraalObject>
+      <KadastraalObject:cultuurBebouwd>
+        <Typen:code>18</Typen:code>
+        <Typen:waarde>Berging - Stalling (garage-schuur)</Typen:waarde>
+      </KadastraalObject:cultuurBebouwd>
+      <KadastraalObject:adres>
+        <Adres:KADBinnenlandsAdres>
+          <Adres:openbareRuimteNaam>HOORNSEDIEP</Adres:openbareRuimteNaam>
+          <Adres:woonplaatsNaam>GRONINGEN</Adres:woonplaatsNaam>
+        </Adres:KADBinnenlandsAdres>
+      </KadastraalObject:adres>
+    </KadastraalObject:LocatieKadastraalObject>
+  </KadastraalObject:heeftLocatie>
+  <KadastraalObject:kadastraleAanduiding>
+    <KadastraalObject:AKRKadastraleGemeenteCode>
+      <Typen:code>386</Typen:code>
+      <Typen:waarde>GNG00</Typen:waarde>
+    </KadastraalObject:AKRKadastraleGemeenteCode>
+    <KadastraalObject:naamKadastraleGemeente>
+      <Typen:code>339</Typen:code>
+      <Typen:waarde>Groningen</Typen:waarde>
+    </KadastraalObject:naamKadastraleGemeente>
+    <KadastraalObject:sectie>C</KadastraalObject:sectie>
+    <KadastraalObject:perceelnummer>9442</KadastraalObject:perceelnummer>
+  </KadastraalObject:kadastraleAanduiding>
+  <KadastraalObject:begrenzingPerceel><gml:Surface srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:patches>
+    <gml:PolygonPatch>
+      <gml:exterior>
+        <gml:LinearRing>
+          <gml:posList srsDimension="2" count="7">233417.686 580684.44 233412.82 580682.193 233413.695 580679.293 233416.247 580680.022 233415.81 580681.473 233418.361 580682.201 233417.686 580684.44</gml:posList>
+        </gml:LinearRing>
+      </gml:exterior>
+    </gml:PolygonPatch>
+  </gml:patches>
+</gml:Surface></KadastraalObject:begrenzingPerceel>
+  <KadastraalObject:indicatieDeelperceel>false</KadastraalObject:indicatieDeelperceel>
+  <KadastraalObject:kadastraleGrootte>
+    <KadastraalObject:waarde>14</KadastraalObject:waarde>
+  </KadastraalObject:kadastraleGrootte>
+  <KadastraalObject:soortGrootte>
+    <Typen:code>1</Typen:code>
+    <Typen:waarde>Vastgesteld</Typen:waarde>
+  </KadastraalObject:soortGrootte>
+  <KadastraalObject:perceelnummerVerschuiving>
+    <KadastraalObject:deltaX>-17.645</KadastraalObject:deltaX>
+    <KadastraalObject:deltaY>10.078</KadastraalObject:deltaY>
+  </KadastraalObject:perceelnummerVerschuiving>
+  <KadastraalObject:plaatscoordinaten><gml:Point srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:pos>233416.795 580683.025</gml:pos>
+</gml:Point></KadastraalObject:plaatscoordinaten>
+</KadastraalObject:Perceel><Recht:ZakelijkRecht id="ID.2313021875">
+  <Recht:identificatie>
+    <NEN3610:namespace>NL.KAD.ZakelijkRecht</NEN3610:namespace>
+    <NEN3610:lokaalId>AKR1.9934028</NEN3610:lokaalId>
+  </Recht:identificatie>
+  <Recht:aard>
+    <Typen:code>2</Typen:code>
+    <Typen:waarde>Eigendom (recht van)</Typen:waarde>
+  </Recht:aard>
+  <Recht:rustOp>
+    <KadastraalObjectRef:PerceelRef xlink:href="#ID.2313021871" />
+  </Recht:rustOp>
+  <Recht:betrokkenBij>
+    <Recht:HoofdSplitsing>
+      <Recht:verenigingVanEigenaren>
+        <PersoonRef:KADNietNatuurlijkPersoonRef xlink:href="#ID.2313021877" />
+      </Recht:verenigingVanEigenaren>
+      <Recht:isGebaseerdOp>
+        <StukRef:StukdeelRef xlink:href="#ID.2313021881" />
+      </Recht:isGebaseerdOp>
+    </Recht:HoofdSplitsing>
+  </Recht:betrokkenBij>
+</Recht:ZakelijkRecht><Persoon:KADNietNatuurlijkPersoon id="ID.2313021877">
+  <Persoon:identificatie>
+    <NEN3610:namespace>NL.KAD.Persoon</NEN3610:namespace>
+    <NEN3610:lokaalId>47050190</NEN3610:lokaalId>
+  </Persoon:identificatie>
+  <Persoon:naam>Vereniging Van Eigenaars Flat-Hoornsediep 71, 71a En 71b</Persoon:naam>
+  <Persoon:rechtsvorm>
+    <Typen:code>13</Typen:code>
+    <Typen:waarde>Vereniging van eigenaren</Typen:waarde>
+  </Persoon:rechtsvorm>
+  <Persoon:statutaireZetel>GRONINGEN</Persoon:statutaireZetel>
+</Persoon:KADNietNatuurlijkPersoon><Stuk:Kadasterstuk id="ID.2313021879">
+  <Stuk:identificatie>
+    <NEN3610:namespace>NL.KAD.Kadasterstuk</NEN3610:namespace>
+    <NEN3610:lokaalId>AKR1.11306674</NEN3610:lokaalId>
+  </Stuk:identificatie>
+  <Stuk:omvat>
+    <Stuk:Stukdeel id="ID.2313021881">
+      <Stuk:identificatie>
+        <NEN3610:namespace>NL.KAD.Stukdeel</NEN3610:namespace>
+        <NEN3610:lokaalId>AKR1.11102558</NEN3610:lokaalId>
+      </Stuk:identificatie>
+      <Stuk:aardStukdeel nilReason="waardeOnbekend">
+        <Typen:code>NIL</Typen:code>
+        <Typen:waarde>NIL</Typen:waarde>
+      </Stuk:aardStukdeel>
+    </Stuk:Stukdeel>
+  </Stuk:omvat>
+  <Stuk:AKRPortefeuilleNr>84 GNG0059310GNG</Stuk:AKRPortefeuilleNr>
+</Stuk:Kadasterstuk>
+    </Snapshot:KadastraalObjectSnapshot>
+  </Mutatie:was>
+  <Mutatie:wordt>
+    <Snapshot:KadastraalObjectSnapshot>
+      <Snapshot:referentie>3598EDFFDEB0-1D5A3594B6D</Snapshot:referentie>
+      <Snapshot:toestandsdatum>2017-08-02</Snapshot:toestandsdatum><KadastraalObject:Perceel id="ID.5668233245">
+  <KadastraalObject:identificatie>
+    <NEN3610:namespace>NL.KAD.OnroerendeZaak</NEN3610:namespace>
+    <NEN3610:lokaalId>58930944270000</NEN3610:lokaalId>
+  </KadastraalObject:identificatie>
+  <KadastraalObject:heeftLocatie>
+    <KadastraalObject:LocatieKadastraalObject>
+      <KadastraalObject:cultuurBebouwd>
+        <Typen:code>18</Typen:code>
+        <Typen:waarde>Berging - Stalling (garage-schuur)</Typen:waarde>
+      </KadastraalObject:cultuurBebouwd>
+    </KadastraalObject:LocatieKadastraalObject>
+  </KadastraalObject:heeftLocatie>
+  <KadastraalObject:kadastraleAanduiding>
+    <KadastraalObject:AKRKadastraleGemeenteCode>
+      <Typen:code>386</Typen:code>
+      <Typen:waarde>GNG00</Typen:waarde>
+    </KadastraalObject:AKRKadastraleGemeenteCode>
+    <KadastraalObject:naamKadastraleGemeente>
+      <Typen:code>339</Typen:code>
+      <Typen:waarde>Groningen</Typen:waarde>
+    </KadastraalObject:naamKadastraleGemeente>
+    <KadastraalObject:sectie>C</KadastraalObject:sectie>
+    <KadastraalObject:perceelnummer>9442</KadastraalObject:perceelnummer>
+  </KadastraalObject:kadastraleAanduiding>
+  <KadastraalObject:begrenzingPerceel><gml:Surface srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:patches>
+    <gml:PolygonPatch>
+      <gml:exterior>
+        <gml:LinearRing>
+          <gml:posList srsDimension="2" count="7">233417.686 580684.44 233412.82 580682.193 233413.695 580679.293 233416.247 580680.022 233415.81 580681.473 233418.361 580682.201 233417.686 580684.44</gml:posList>
+        </gml:LinearRing>
+      </gml:exterior>
+    </gml:PolygonPatch>
+  </gml:patches>
+</gml:Surface></KadastraalObject:begrenzingPerceel>
+  <KadastraalObject:indicatieDeelperceel>false</KadastraalObject:indicatieDeelperceel>
+  <KadastraalObject:kadastraleGrootte>
+    <KadastraalObject:waarde>14</KadastraalObject:waarde>
+  </KadastraalObject:kadastraleGrootte>
+  <KadastraalObject:soortGrootte>
+    <Typen:code>1</Typen:code>
+    <Typen:waarde>Vastgesteld</Typen:waarde>
+  </KadastraalObject:soortGrootte>
+  <KadastraalObject:perceelnummerVerschuiving>
+    <KadastraalObject:deltaX>-17.645</KadastraalObject:deltaX>
+    <KadastraalObject:deltaY>10.078</KadastraalObject:deltaY>
+  </KadastraalObject:perceelnummerVerschuiving>
+  <KadastraalObject:plaatscoordinaten><gml:Point srsName="urn:ogc:def:crs:EPSG::28992">
+  <gml:pos>233416.795 580683.025</gml:pos>
+</gml:Point></KadastraalObject:plaatscoordinaten>
+</KadastraalObject:Perceel><Recht:ZakelijkRecht id="ID.5668233247">
+  <Recht:identificatie>
+    <NEN3610:namespace>NL.KAD.ZakelijkRecht</NEN3610:namespace>
+    <NEN3610:lokaalId>AKR1.9934028</NEN3610:lokaalId>
+  </Recht:identificatie>
+  <Recht:aard>
+    <Typen:code>2</Typen:code>
+    <Typen:waarde>Eigendom (recht van)</Typen:waarde>
+  </Recht:aard>
+  <Recht:rustOp>
+    <KadastraalObjectRef:PerceelRef xlink:href="#ID.5668233245" />
+  </Recht:rustOp>
+  <Recht:betrokkenBij>
+    <Recht:HoofdSplitsing>
+      <Recht:verenigingVanEigenaren>
+        <PersoonRef:KADNietNatuurlijkPersoonRef xlink:href="#ID.5668233248" />
+      </Recht:verenigingVanEigenaren>
+      <Recht:isGebaseerdOp>
+        <StukRef:StukdeelRef xlink:href="#ID.5668233250" />
+      </Recht:isGebaseerdOp>
+    </Recht:HoofdSplitsing>
+  </Recht:betrokkenBij>
+</Recht:ZakelijkRecht><Persoon:KADNietNatuurlijkPersoon id="ID.5668233248">
+  <Persoon:identificatie>
+    <NEN3610:namespace>NL.KAD.Persoon</NEN3610:namespace>
+    <NEN3610:lokaalId>47050190</NEN3610:lokaalId>
+  </Persoon:identificatie>
+  <Persoon:naam>Vereniging Van Eigenaars Flat-Hoornsediep 71, 71a En 71b</Persoon:naam>
+  <Persoon:rechtsvorm>
+    <Typen:code>21</Typen:code>
+    <Typen:waarde>Vereniging van eigenaars</Typen:waarde>
+  </Persoon:rechtsvorm>
+  <Persoon:statutaireZetel>GRONINGEN</Persoon:statutaireZetel>
+</Persoon:KADNietNatuurlijkPersoon><Stuk:Kadasterstuk id="ID.5668233249">
+  <Stuk:identificatie>
+    <NEN3610:namespace>NL.KAD.Kadasterstuk</NEN3610:namespace>
+    <NEN3610:lokaalId>AKR1.11306674</NEN3610:lokaalId>
+  </Stuk:identificatie>
+  <Stuk:omvat>
+    <Stuk:Stukdeel id="ID.5668233250">
+      <Stuk:identificatie>
+        <NEN3610:namespace>NL.KAD.Stukdeel</NEN3610:namespace>
+        <NEN3610:lokaalId>AKR1.11102558</NEN3610:lokaalId>
+      </Stuk:identificatie>
+      <Stuk:aardStukdeel nilReason="waardeOnbekend">
+        <Typen:code>NIL</Typen:code>
+        <Typen:waarde>NIL</Typen:waarde>
+      </Stuk:aardStukdeel>
+    </Stuk:Stukdeel>
+  </Stuk:omvat>
+  <Stuk:AKRPortefeuilleNr>84 GNG0059310GNG</Stuk:AKRPortefeuilleNr>
+</Stuk:Kadasterstuk>
+    </Snapshot:KadastraalObjectSnapshot>
+  </Mutatie:wordt>
+</Mutatie:Mutatie>


### PR DESCRIPTION
Sla laden van duplicaat berichten over in de BRKDirectoryScanner, maak wel een melding en een laadproces met het duplicaat erin.

**NB** Deze aanpassing heeft een performance impact omdat na ieder bericht een commit wordt uitgevoerd waar dat voorheen in batches werd gedaan.


- testdata: deze data bestaat uit dezelfde bestanden als de 8000bytes bug bestanden in de brmo-loader module
- testcase: de testcase wordt op dit moment overgeslagen omdat de runtime omgeving voor de test ontbreekt, mocken van de Stripersist EntityManager moet nog gedaan worden



close #625 