### PR TITLE
Bump tomcat test dependency naar 7.0.94

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <javax.mail.version>1.6.2</javax.mail.version>
         <quartz.version>2.3.1</quartz.version>
         <!-- bij ophogen van tomcat versie evt. ook de .mvn/owasp-suppression.xml file bijwerken -->
-        <tomcat.version>7.0.93</tomcat.version>
+        <tomcat.version>7.0.94</tomcat.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- om unit tests met postgres te draaien gebruik je


### PR DESCRIPTION
Verhelpt CVE-2019-0232 melding, de BRMO code is niet kwetsbaar, maar automatische scanners weten dat niet.

/cc @Sjoske 