### PR TITLE
Maven update (3.6.1 -> 3.6.2) op de CI services

### DIFF
--- a/.mvn/owasp-suppression.xml
+++ b/.mvn/owasp-suppression.xml
@@ -1,75 +1,93 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-        <suppress>
-            <notes><![CDATA[
-          Negeer meldingen mbt tomcat-catalina-7.0.94.jar omdat we geen tomcat mee leveren en deze
-          alleen voor bepaalde deployments geldt.
-          ]]></notes>
-            <filePath regex="true">.*\btomcat-catalina-7\.0\.94\.jar</filePath>
-            <cve>CVE-2016-5388</cve>
-            <cve>CVE-2016-5425</cve>
-            <cve>CVE-2016-6325</cve>
-            <cve>CVE-2017-6056</cve>
-        </suppress>
-        <suppress>
-            <notes><![CDATA[
-          Negeer melding mbt gt-jdbc jar, false positive "data-tools" wat iets heel anders is.
-          ]]></notes>
-            <gav regex="true">^org\.geotools:gt-jdbc:.*$</gav>
-            <cpe>cpe:/a:data-tools_project:data_tools</cpe>
-        </suppress>
-        <suppress>
-            <notes><![CDATA[
-          Negeer melding mbt gt-jdbc-sqlserver jar, false positive "data-tools" wat iets heel anders is.
-          ]]></notes>
-            <gav regex="true">^org\.geotools\.jdbc:gt-jdbc-sqlserver:.*$</gav>
-            <cpe>cpe:/a:data-tools_project:data_tools</cpe>
-        </suppress>
-        <suppress>
-            <notes><![CDATA[
-          Negeer melding mbt gt-coverage jar, false positive mbt jpeg thumbnail disclosure.
-          ]]></notes>
-            <gav regex="true">^org\.geotools:gt-coverage:.*$</gav>
-            <cve>CVE-2005-0406</cve>
-        </suppress>
-        <suppress>
-            <notes><![CDATA[
-          Negeer melding mbt gt-main jar, false positive mbt integer overflow in data-tools
-          ]]></notes>
-            <gav regex="true">^org\.geotools:gt-main:.*$</gav>
-            <cpe>cpe:/a:data-tools_project:data_tools</cpe>
-        </suppress>
-        <suppress>
-            <notes><![CDATA[
-          Negeer melding mbt gt-data jar, false positive mbt integer overflow in data-tools
-            ]]></notes>
-            <gav regex="true">^org\.geotools:gt-data:.*$</gav>
-            <cpe>cpe:/a:data-tools_project:data_tools</cpe>
-        </suppress>
-        <suppress>
-            <notes><![CDATA[
-          Negeer melding mbt log4j-1.2.17.jar, false positive, CVE heeft betrekking op versie 2 en hoger.
-            ]]></notes>
-            <gav regex="true">^log4j:log4j:1\.2\.17$</gav>
-            <cve>CVE-2017-5645</cve>
-        </suppress>
-        <suppress>
-            <notes><![CDATA[
-          Deze kwetsbaarheid is niet van toepassing, er wordt geen gebruik gemaakt van RC4 voor TLS.
-            ]]></notes>
-            <gav regex="true">^org\.glassfish\.ha:ha-api:3\.1\.9$</gav>
-            <cve>CVE-2013-2566</cve>
-            <cve>CVE-2015-2808</cve>
-        </suppress>
-        <suppress>
-            <notes><![CDATA[
-          Negeer meldingen mbt postgis-jdbc jar, hebben allemaal betrekking op de database engine
-            ]]></notes>
-            <gav regex="true">^net\.postgis:postgis-jdbc:.*$</gav>
-            <cpe>cpe:/a:postgresql:postgresql</cpe>
-            <cpe>cpe:/a:postgresql:postgresql_jdbc_driver</cpe>
-            <cpe>cpe:/a:postgis_project:postgis</cpe>
-            <!--<cve>CVE-2007-2138</cve>-->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes>
+            <![CDATA[
+                     Negeer meldingen mbt tomcat-catalina-7.0.96.jar omdat we geen tomcat mee leveren en deze
+                     alleen voor bepaalde deployments geldt.
+            ]]>
+        </notes>
+        <filePath regex="true">.*\btomcat-catalina-7\.0\.96\.jar</filePath>
+        <cve>CVE-2016-5388</cve>
+        <cve>CVE-2016-5425</cve>
+        <cve>CVE-2016-6325</cve>
+        <cve>CVE-2017-6056</cve>
+    </suppress>
+    <suppress>
+        <notes>
+            <![CDATA[
+                     Negeer melding mbt gt-jdbc jar, false positive "data-tools" wat iets heel anders is.
+            ]]>
+        </notes>
+        <gav regex="true">^org\.geotools:gt-jdbc:.*$</gav>
+        <cpe>cpe:/a:data-tools_project:data_tools</cpe>
+    </suppress>
+    <suppress>
+        <notes>
+            <![CDATA[
+                     Negeer melding mbt gt-jdbc-sqlserver jar, false positive "data-tools" wat iets heel anders is.
+            ]]>
+        </notes>
+        <gav regex="true">^org\.geotools\.jdbc:gt-jdbc-sqlserver:.*$</gav>
+        <cpe>cpe:/a:data-tools_project:data_tools</cpe>
+    </suppress>
+    <suppress>
+        <notes>
+            <![CDATA[
+                     Negeer melding mbt gt-coverage jar, false positive mbt jpeg thumbnail disclosure.
+            ]]>
+        </notes>
+        <gav regex="true">^org\.geotools:gt-coverage:.*$</gav>
+        <cve>CVE-2005-0406</cve>
+    </suppress>
+    <suppress>
+        <notes>
+            <![CDATA[
+                     Negeer melding mbt gt-main jar, false positive mbt integer overflow in data-tools
+            ]]>
+        </notes>
+        <gav regex="true">^org\.geotools:gt-main:.*$</gav>
+        <cpe>cpe:/a:data-tools_project:data_tools</cpe>
+    </suppress>
+    <suppress>
+        <notes>
+            <![CDATA[
+                     Negeer melding mbt gt-data jar, false positive mbt integer overflow in data-tools
+            ]]>
+        </notes>
+        <gav regex="true">^org\.geotools:gt-data:.*$</gav>
+        <cpe>cpe:/a:data-tools_project:data_tools</cpe>
+    </suppress>
+    <suppress>
+        <notes>
+            <![CDATA[
+                     Negeer melding mbt log4j-1.2.17.jar, false positive, CVE heeft betrekking op versie 2 en hoger.
+            ]]>
+        </notes>
+        <gav regex="true">^log4j:log4j:1\.2\.17$</gav>
+        <cve>CVE-2017-5645</cve>
+    </suppress>
+    <suppress>
+        <notes>
+            <![CDATA[
+                     Deze kwetsbaarheid is niet van toepassing, er wordt geen gebruik gemaakt van RC4 voor TLS.
+            ]]>
+        </notes>
+        <gav regex="true">^org\.glassfish\.ha:ha-api:3\.1\.9$</gav>
+        <cve>CVE-2013-2566</cve>
+        <cve>CVE-2015-2808</cve>
+    </suppress>
+    <suppress>
+        <notes>
+            <![CDATA[
+                     Negeer meldingen mbt postgis-jdbc jar, hebben allemaal betrekking op de database engine
+            ]]>
+        </notes>
+        <gav regex="true">^net\.postgis:postgis-jdbc:.*$</gav>
+        <cpe>cpe:/a:postgresql:postgresql</cpe>
+        <cpe>cpe:/a:postgresql:postgresql_jdbc_driver</cpe>
+        <cpe>cpe:/a:postgis_project:postgis</cpe>
+        <!--<cve>CVE-2007-2138</cve>-->
         <!--<cve>CVE-2010-0733</cve>-->
         <!--<cve>CVE-2014-0060</cve>-->
         <!--<cve>CVE-2014-0061</cve>-->
@@ -93,9 +111,11 @@
         <!--<cve>CVE-2017-1115</cve>-->
     </suppress>
     <suppress>
-        <notes><![CDATA[
-        Negeer meldingen mbt jtds jar, hebben allemaal betrekking op de database engine
-        ]]></notes>
+        <notes>
+            <![CDATA[
+                     Negeer meldingen mbt jtds jar, hebben allemaal betrekking op de database engine
+            ]]>
+        </notes>
         <gav regex="true">^net\.sourceforge\.jtds:jtds:.*$</gav>
         <cpe>cpe:/a:microsoft:sql_server</cpe>
         <!--CVE-2001-0509-->

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,18 +109,18 @@ matrix:
     dist: xenial
     jdk: openjdk8
     sudo: required
+    env:
+      - PG_VERSION="11"
+      - MVN_ARGS="-Dit.test=TopNLIntegrationTest"
     addons:
-      postgresql: 10
+      postgresql: 11
       apt:
         packages:
-          - postgresql-10
-          - postgresql-client-10
-          - postgresql-10-postgis-2.5
-          - postgresql-10-postgis-2.5-scripts
+          - postgresql-11
+          - postgresql-client-11
+          - postgresql-11-postgis-2.5
+          - postgresql-11-postgis-2.5-scripts
           - xmlstarlet
-    env:
-      - PG_VERSION="10"
-      - MVN_ARGS="-Dit.test=TopNLIntegrationTest"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - secure: "NynQI56H74dDi6sK4wxPawnLoLsrzADKmD8Jl7w3yQnYTfVU7zP07KeJKoIWhFaYB3GCKyG2qdeM1I5DOeim183c0h51WcQTVvHX3o1D3DyrdfuhqKTBXmAUXJObp/jUoABD2KKejSKZj+mkzqutITMUUbHDiMu5PD6WXEuCYT8="
     - PG_VERSION="9.6"
     - PROFILE="postgresql"
-    - MVN_VERSION="3.6.1"
+    - MVN_VERSION="3.6.2"
     - MVN_ARGS="-Dit.test=!TopNLIntegrationTest"
     - PGPORT=5432
     - MAVEN_OPTS=-Djava.awt.headless=true -Xms8G -Xmx12G
@@ -103,6 +103,7 @@ matrix:
         packages:
           - xmlstarlet
           - postgresql-9.6-postgis-2.3
+          - postgresql-9.6-postgis-2.3-scripts
   - name: "TopNL tests"
     group: edge
     dist: xenial

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ timestamps {
         jdks.eachWithIndex { jdk, indexOfJdk ->
             final String jdkTestName = jdk.toString()
 
-            withEnv(["JAVA_HOME=${ tool jdkTestName }", "PATH+MAVEN=${tool 'Maven 3.6.1'}/bin:${env.JAVA_HOME}/bin"]) {
+            withEnv(["JAVA_HOME=${ tool jdkTestName }", "PATH+MAVEN=${tool 'Maven 3.6.2'}/bin:${env.JAVA_HOME}/bin"]) {
 
                 echo "Using JDK: ${jdkTestName} at ${env.JAVA_HOME}"
 
@@ -148,7 +148,7 @@ timestamps {
             }
         }
 
-        withEnv(["JAVA_HOME=${ tool 'JDK8' }", "PATH+MAVEN=${tool 'Maven 3.6.1'}/bin:${env.JAVA_HOME}/bin"]) {
+        withEnv(["JAVA_HOME=${ tool 'JDK8' }", "PATH+MAVEN=${tool 'Maven 3.6.2'}/bin:${env.JAVA_HOME}/bin"]) {
             stage('Publish Results') {
                 junit allowEmptyResults: true, testResults: '**/target/surefire-reports/TEST-*.xml, **/target/failsafe-reports/TEST-*.xml'
             }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ init:
 
 environment:
   BGT_ONLY_ITESTS : false
-  # Microsoft SQL Server 2016 Service Pack 1 heeft een EOL van 13-7-2021
-  # Microsoft SQL Server 2017 is de jongst-beschikbare release op AppVeyor, maar testen we op Travis-CI (veel sneller)
+  # Microsoft SQL Server 2016 Service Pack 2 heeft een EOL (einde basisondersteuning) van 13-7-2021
+  # Microsoft SQL Server 2017 is de jongst-beschikbare release op AppVeyor, maar testen we (ook) op Travis-CI (veel sneller)
   matrix:
     - SQL: MSSQL$SQL2016
       INSTANCENAME: SQL2016

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,10 +42,10 @@ install:
   - ps: |
         Add-Type -AssemblyName System.IO.Compression.FileSystem
         if (!(Test-Path("C:\Users\appveyor\downloads\maven-bin.zip"))) {
-            (new-object System.Net.WebClient).DownloadFile('https://archive.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.zip', 'C:\Users\appveyor\downloads\maven-bin.zip')
+            (new-object System.Net.WebClient).DownloadFile('https://archive.apache.org/dist/maven/maven-3/3.6.2/binaries/apache-maven-3.6.2-bin.zip', 'C:\Users\appveyor\downloads\maven-bin.zip')
         }
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\Users\appveyor\downloads\maven-bin.zip", "C:\maven")
-  - cmd: SET PATH=C:\maven\apache-maven-3.6.1\bin;%PATH%
+  - cmd: SET PATH=C:\maven\apache-maven-3.6.2\bin;%PATH%
   - cmd: echo %PATH%
   - cmd: java -version
   - cmd: mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <jaxb.impl.version>2.3.2</jaxb.impl.version>
         <activation.api.version>1.2.1</activation.api.version>
         <!-- bij ophogen van tomcat versie evt. ook de .mvn/owasp-suppression.xml file bijwerken -->
-        <tomcat.version>7.0.94</tomcat.version>
+        <tomcat.version>7.0.96</tomcat.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- om unit tests met postgres te draaien gebruik je
@@ -281,7 +281,7 @@
             </dependency>
             <!-- database en persistence -->
             <dependency>
-                <!-- override v 3.1 die met hibernate meekomt, eigenlijk zouden we naar 4.3 moeten, maar die is ws. niet compatibel -->
+                <!-- override v 3.1 die met hibernate meekomt, eigenlijk zouden we naar 4.4 moeten, maar die is ws. niet compatibel -->
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
                 <version>3.2.2</version>


### PR DESCRIPTION
- gebuik maven 3.6.2 op de CI servers
- update Tomcat test dependency van 7.0.94 naar 7.0.96
- gebruik postgresql 11 / postgis 2.5 voor de TopNL tests op Travis-CI