### PR TITLE
Vervang jtds driver door mssql-jdbc driver

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ timestamps {
                                 sh "mvn -e verify -B -Poracle -T1 -Dtest.onlyITs=true -pl 'brmo-loader' -Dit.test=!TopNLIntegrationTest"
                             }
 
-                            lock('brmo-tomcat-9091') {
+                            lock('tomcat-tcp9091') {
                                 stage("brmo-service Integration Test: ${jdkTestName}") {
                                     echo "run integratie tests voor brmo-service module"
                                     timeout(30) {

--- a/bgt-gml-loader/pom.xml
+++ b/bgt-gml-loader/pom.xml
@@ -20,6 +20,7 @@
             </testResource>
             <testResource>
                 <directory>src/test/resources</directory>
+                <filtering>true</filtering>
             </testResource>
         </testResources>
         <resources>

--- a/bgt-gml-loader/pom.xml
+++ b/bgt-gml-loader/pom.xml
@@ -306,8 +306,8 @@
             <artifactId>gt-jdbc-oracle</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.jtds</groupId>
-            <artifactId>jtds</artifactId>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.geotools.jdbc</groupId>

--- a/bgt-gml-loader/src/main/java/nl/b3p/brmo/loader/gml/BGTGMLLightLoader.java
+++ b/bgt-gml-loader/src/main/java/nl/b3p/brmo/loader/gml/BGTGMLLightLoader.java
@@ -158,7 +158,7 @@ public class BGTGMLLightLoader {
         this.dbConnProps = dbConnProps;
 
         this.isOracle = "oracle".equalsIgnoreCase(dbConnProps.getProperty("dbtype"));
-        this.isMSSQL = ("jtds-sqlserver".equalsIgnoreCase(dbConnProps.getProperty("dbtype")) | "sqlserver".equalsIgnoreCase(dbConnProps.getProperty("dbtype")));
+        this.isMSSQL = ("sqlserver".equalsIgnoreCase(dbConnProps.getProperty("dbtype")) | "sqlserver".equalsIgnoreCase(dbConnProps.getProperty("dbtype")));
     }
 
     /**
@@ -560,7 +560,7 @@ public class BGTGMLLightLoader {
     public void setDbConnProps(Properties dbConnProps) {
         this.dbConnProps = dbConnProps;
         this.isOracle = "oracle".equalsIgnoreCase(dbConnProps.getProperty("dbtype"));
-        this.isMSSQL = ("jtds-sqlserver".equalsIgnoreCase(dbConnProps.getProperty("dbtype")) | "sqlserver".equalsIgnoreCase(dbConnProps.getProperty("dbtype")));
+        this.isMSSQL = ("sqlserver".equalsIgnoreCase(dbConnProps.getProperty("dbtype")) | "sqlserver".equalsIgnoreCase(dbConnProps.getProperty("dbtype")));
     }
 
     /**

--- a/bgt-gml-loader/src/main/resources/voorbeeld.bgtloader.properties
+++ b/bgt-gml-loader/src/main/resources/voorbeeld.bgtloader.properties
@@ -29,7 +29,7 @@ passwd=rsgb
 #---------------------------------
 # voorbeeld configuratie sqlserver
 #---------------------------------
-# dbtype=jtds-sqlserver
+# dbtype=sqlserver
 # host=192.168.1.15
 # port=1433
 # instance=SQLEXPRESS

--- a/bgt-gml-loader/src/test/java/nl/b3p/brmo/loader/gml/TestingBase.java
+++ b/bgt-gml-loader/src/test/java/nl/b3p/brmo/loader/gml/TestingBase.java
@@ -97,7 +97,7 @@ public abstract class TestingBase {
         }
 
         isOracle = "oracle".equalsIgnoreCase(params.getProperty("dbtype"));
-        isMsSQL = "jtds-sqlserver".equalsIgnoreCase(params.getProperty("dbtype"));
+        isMsSQL = "sqlserver".equalsIgnoreCase(params.getProperty("dbtype"));
 
         try {
             Class.forName(params.getProperty("jdbc.driverClassName"));

--- a/bgt-gml-loader/src/test/resources/sqlserver.properties
+++ b/bgt-gml-loader/src/test/resources/sqlserver.properties
@@ -1,6 +1,6 @@
 # evt. override met een local.sqlserver.properties
 #geotools
-dbtype=jtds-sqlserver
+dbtype=sqlserver
 host=127.0.0.1
 port=1433
 instance=${mssql.instancename}
@@ -9,5 +9,5 @@ schema=dbo
 user=sa
 passwd=Password12!
 # regular jdbc
-jdbc.driverClassName=net.sourceforge.jtds.jdbc.Driver
-jdbc.url=jdbc:jtds:sqlserver://127.0.0.1:1433/bgttest;instance=${mssql.instancename}
+jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
+jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;instance=${mssql.instancename}

--- a/brmo-commandline/pom.xml
+++ b/brmo-commandline/pom.xml
@@ -81,8 +81,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.jtds</groupId>
-            <artifactId>jtds</artifactId>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>

--- a/brmo-commandline/pom.xml
+++ b/brmo-commandline/pom.xml
@@ -255,11 +255,15 @@
                                     <target>
                                         <mkdir dir="${project.build.directory}/itest" />
                                         <unzip src="${project.build.directory}/${project.build.finalName}.zip" dest="${project.build.directory}/itest" overwrite="true" />
-                                        <copy todir="${project.build.directory}/itest/conf">
+                                        <copy todir="${project.build.directory}/itest/conf" overwrite="true">
                                             <fileset dir="${project.build.testSourceDirectory}/../resources/" />
+                                        </copy>
+                                        <copy todir="${project.build.directory}/itest/conf" overwrite="true">
+                                            <fileset dir="${project.build.testOutputDirectory}/" includes="*.properties"/>
                                         </copy>
                                         <move file="${project.build.directory}/itest/conf/mssql.properties" tofile="${project.build.directory}/itest/conf/test.properties" />
                                     </target>
+                                    <skip>${maven.test.skip}</skip>
                                 </configuration>
                                 <goals>
                                     <goal>run</goal>

--- a/brmo-commandline/src/main/java/nl/b3p/brmo/commandline/Main.java
+++ b/brmo-commandline/src/main/java/nl/b3p/brmo/commandline/Main.java
@@ -187,8 +187,8 @@ public class Main {
                 case "postgis":
                     Class.forName("org.postgresql.Driver");
                     break;
-                case "jtds-sqlserver":
-                    Class.forName("net.sourceforge.jtds.jdbc.Driver");
+                case "sqlserver":
+                    Class.forName("com.microsoft.sqlserver.jdbc.SQLServerDriver");
                     break;
                 default:
                     throw new IllegalArgumentException("Het database type " + dbProps.getProperty("dbtype") + " wordt niet ondersteund of is niet opgegeven.");

--- a/brmo-commandline/src/main/java/nl/b3p/brmo/commandline/Main.java
+++ b/brmo-commandline/src/main/java/nl/b3p/brmo/commandline/Main.java
@@ -569,7 +569,7 @@ public class Main {
         BrmoFramework brmo = new BrmoFramework(ds, null);
         brmo.setOrderBerichten(true);
         brmo.setErrorState("ignore");
-        brmo.loadFromFile(brType, fileName,null);
+        brmo.loadFromFile(brType, fileName, null);
         brmo.closeBrmoFramework();
         LOG.info(String.format("Klaar met laden van bestand: %s, type %s", fileName, brType));
         archiveerBestand(fileName, archiefDir);

--- a/brmo-commandline/src/main/resources/commandline-example.properties
+++ b/brmo-commandline/src/main/resources/commandline-example.properties
@@ -2,7 +2,7 @@
 # voorbeeld commandline database configuratie voor de brmo commandline tool
 
 # database type een van de typen
-#    oracle | postgis | jtds-sqlserver
+#    oracle | postgis | sqlserver
 dbtype=postgis
 
 # staging database gegevens

--- a/brmo-commandline/src/test/resources/mssql.properties
+++ b/brmo-commandline/src/test/resources/mssql.properties
@@ -3,29 +3,16 @@
 dbtype=sqlserver
 
 # rsgb database gegevens
-rsgb.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;instance=${mssql.instancename}
+rsgb.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;applicationName=brmo-commandline-test;instance=${mssql.instancename}
 rsgb.user=sa
 rsgb.password=Password12!
 
 # staging database gegevens
-staging.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;instance=${mssql.instancename}
+staging.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;applicationName=brmo-commandline-test;instance=${mssql.instancename}
 staging.user=sa
 staging.password=Password12!
 
 # rsgbbgt database gegevens
-rsgbbgt.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;instance=${mssql.instancename}
+rsgbbgt.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;applicationName=brmo-commandline-test;instance=${mssql.instancename}
 rsgbbgt.user=sa
 rsgbbgt.password=Password12!
-
-# lokaal
-#rsgb.url=jdbc:sqlserver://localhost:1401rsgb;instance=sql1
-#rsgb.user=sa
-#rsgb.passwd=YourStrong!Passw0rd
-#
-#staging.url=jdbc:sqlserver://localhost:1401;databaseName=staging;instance=sql1
-#staging.user=sa
-#staging.passwd=YourStrong!Passw0rd
-#
-#rsgbbgt.url=jdbc:sqlserver://localhost:1401;databaseName=rsgbbgt;instance=sql1
-#rsgbbgt.user=sa
-#rsgbbgt.passwd=YourStrong!Passw0rd

--- a/brmo-commandline/src/test/resources/mssql.properties
+++ b/brmo-commandline/src/test/resources/mssql.properties
@@ -16,3 +16,16 @@ staging.password=Password12!
 rsgbbgt.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;applicationName=brmo-commandline-test;instance=${mssql.instancename}
 rsgbbgt.user=sa
 rsgbbgt.password=Password12!
+
+# lokaal
+#rsgb.url=jdbc:sqlserver://localhost:1401;databaseName=rsgb;instance=sql1
+#rsgb.user=sa
+#rsgb.passwd=YourStrong!Passw0rd
+#
+#staging.url=jdbc:sqlserver://localhost:1401;databaseName=staging;instance=sql1
+#staging.user=sa
+#staging.passwd=YourStrong!Passw0rd
+#
+#rsgbbgt.url=jdbc:sqlserver://localhost:1401;databaseName=rsgbbgt;instance=sql1
+#rsgbbgt.user=sa
+#rsgbbgt.passwd=YourStrong!Passw0rd

--- a/brmo-commandline/src/test/resources/mssql.properties
+++ b/brmo-commandline/src/test/resources/mssql.properties
@@ -1,31 +1,31 @@
 # Copyright (C) 2017 B3Partners B.V.
 # mssql test commandline database configuratie voor de brmo commandline tool
-dbtype=jtds-sqlserver
+dbtype=sqlserver
 
 # rsgb database gegevens
-rsgb.url=jdbc:jtds:sqlserver://127.0.0.1:1433/rsgb;instance=${mssql.instancename}
+rsgb.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;instance=${mssql.instancename}
 rsgb.user=sa
 rsgb.password=Password12!
 
 # staging database gegevens
-staging.url=jdbc:jtds:sqlserver://127.0.0.1:1433/staging;instance=${mssql.instancename}
+staging.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;instance=${mssql.instancename}
 staging.user=sa
 staging.password=Password12!
 
 # rsgbbgt database gegevens
-rsgbbgt.url=jdbc:jtds:sqlserver://127.0.0.1:1433/bgttest;instance=${mssql.instancename}
+rsgbbgt.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;instance=${mssql.instancename}
 rsgbbgt.user=sa
 rsgbbgt.password=Password12!
 
 # lokaal
-#rsgb.url=jdbc:jtds:sqlserver://localhost:1401/rsgb;instance=sql1
+#rsgb.url=jdbc:sqlserver://localhost:1401rsgb;instance=sql1
 #rsgb.user=sa
 #rsgb.passwd=YourStrong!Passw0rd
 #
-#staging.url=jdbc:jtds:sqlserver://localhost:1401/staging;instance=sql1
+#staging.url=jdbc:sqlserver://localhost:1401;databaseName=staging;instance=sql1
 #staging.user=sa
 #staging.passwd=YourStrong!Passw0rd
 #
-#rsgbbgt.url=jdbc:jtds:sqlserver://localhost:1401/rsgbbgt;instance=sql1
+#rsgbbgt.url=jdbc:sqlserver://localhost:1401;databaseName=rsgbbgt;instance=sql1
 #rsgbbgt.user=sa
 #rsgbbgt.passwd=YourStrong!Passw0rd

--- a/brmo-commandline/src/test/resources/test.properties
+++ b/brmo-commandline/src/test/resources/test.properties
@@ -2,7 +2,7 @@
 # voorbeeld commandline database configuratie voor de brmo commandline tool
 
 # database type een van de typen
-#dbtype=oracle | postgis | jtds-sqlserver
+#dbtype=oracle | postgis | sqlserver
 dbtype=postgis
 
 # rsgb database gegevens

--- a/brmo-dist/assembly.xml
+++ b/brmo-dist/assembly.xml
@@ -49,7 +49,7 @@
             <includes>
                 <include>com.sun.mail:jakarta.mail</include>
                 <include>com.sun.activation:jakarta.activation</include>
-                <include>net.sourceforge.jtds:jtds</include>
+                <include>com.microsoft.sqlserver:mssql-jdbc</include>
             </includes>
             <outputFileNameMapping>${artifact.artifactId}-${artifact.version}.${artifact.extension}</outputFileNameMapping>
         </dependencySet>

--- a/brmo-dist/pom.xml
+++ b/brmo-dist/pom.xml
@@ -91,8 +91,8 @@
             <artifactId>postgis-jdbc</artifactId>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.jtds</groupId>
-            <artifactId>jtds</artifactId>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>

--- a/brmo-dist/src/site/markdown/drivers.md
+++ b/brmo-dist/src/site/markdown/drivers.md
@@ -5,7 +5,7 @@
 Ten behoeve van een snelle installatie worden de volgende drivers meegepakt (voor iedere database omgeving een setje):
 
   - PostgreSQL JDBC, Postgis en mail drivers
-  - jTDS JDBC driver voor MSSQL en mail drivers
+  - Microsoft JDBC driver voor MSSQL en mail drivers
   - Oracle JDBC en mail drivers (De Oracle JDBC driver wordt beschikbaar gesteld onder de "Oracle Free Use Terms and Conditions (FUTC)", zie hieronder).
 
 De bestanden dienen in de `lib` directory van Tomcat te worden geplaatst zodat ze gebruikt kunnen worden in de verschillende JNDI bronnen.

--- a/brmo-loader/pom.xml
+++ b/brmo-loader/pom.xml
@@ -225,7 +225,7 @@
                                 <database.properties.file>sqlserver.properties</database.properties.file>
                                 <project.version>${project.version}</project.version>
                             </systemPropertyVariables>
-                            <excludedGroups>nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures</excludedGroups>
+                            <excludedGroups>nl.b3p.brmo.test.util.database.MSSqlServerDriverBasedFailures</excludedGroups>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/brmo-loader/pom.xml
+++ b/brmo-loader/pom.xml
@@ -86,9 +86,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.jtds</groupId>
-            <artifactId>jtds</artifactId>
-            <!-- Bij JNDI db verbinding moet de jtds driver jar in tomcat lib staan -->
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -134,8 +133,8 @@
                     <artifactId>postgis-jdbc</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>net.sourceforge.jtds</groupId>
-                    <artifactId>jtds</artifactId>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/BrmoFramework.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/BrmoFramework.java
@@ -28,7 +28,6 @@ import nl.b3p.topnl.TopNLType;
 import org.apache.commons.dbutils.DbUtils;
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.handlers.ScalarHandler;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.commons.io.input.CountingInputStream;
 import org.apache.commons.logging.Log;

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/entity/LaadProces.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/entity/LaadProces.java
@@ -216,4 +216,29 @@ public class LaadProces {
     public void setBeschikbaar_tot(Date beschikbaar_tot) {
         this.beschikbaar_tot = beschikbaar_tot;
     }
+
+    @Override
+    public String toString() {
+        return "LaadProces{" +
+                "id=" + id +
+                ", bestandNaam='" + bestandNaam + '\'' +
+                ", bestandNaamHersteld='" + bestandNaamHersteld + '\'' +
+                ", bestandDatum=" + bestandDatum +
+                ", soort='" + soort + '\'' +
+                ", gebied='" + gebied + '\'' +
+                ", opmerking='" + opmerking + '\'' +
+                ", status=" + status +
+                ", statusDatum=" + statusDatum +
+                ", contactEmail='" + contactEmail + '\'' +
+                ", automatischProces=" + automatischProces +
+                ", klantafgiftenummer=" + klantafgiftenummer +
+                ", contractafgiftenummer=" + contractafgiftenummer +
+                ", artikelnummer='" + artikelnummer + '\'' +
+                ", contractnummer='" + contractnummer + '\'' +
+                ", afgifteid='" + afgifteid + '\'' +
+                ", afgiftereferentie='" + afgiftereferentie + '\'' +
+                ", bestandsreferentie='" + bestandsreferentie + '\'' +
+                ", beschikbaar_tot=" + beschikbaar_tot +
+                '}';
+    }
 }

--- a/brmo-loader/src/test/java/nl/b3p/AbstractDatabaseIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/AbstractDatabaseIntegrationTest.java
@@ -87,7 +87,7 @@ public abstract class AbstractDatabaseIntegrationTest {
             // negeren; het override bestand is normaal niet aanwezig
         }
         isOracle = "oracle".equalsIgnoreCase(params.getProperty("dbtype"));
-        isMsSQL = "jtds-sqlserver".equalsIgnoreCase(params.getProperty("dbtype"));
+        isMsSQL = "sqlserver".equalsIgnoreCase(params.getProperty("dbtype"));
         isPostgis = "postgis".equalsIgnoreCase(params.getProperty("dbtype"));
 
         try {

--- a/brmo-loader/src/test/java/nl/b3p/AbstractDatabaseIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/AbstractDatabaseIntegrationTest.java
@@ -91,10 +91,10 @@ public abstract class AbstractDatabaseIntegrationTest {
         isPostgis = "postgis".equalsIgnoreCase(params.getProperty("dbtype"));
 
         try {
-            Class rsgbDriverClass = Class.forName(params.getProperty("rsgb.jdbc.driverClassName"));
-            Class stagingDriverClass = Class.forName(params.getProperty("staging.jdbc.driverClassName"));
-            Class rsgbbgtDriverClass = Class.forName(params.getProperty("rsgbbgt.jdbc.driverClassName"));
-            Class topnlDriverClass = Class.forName(params.getProperty("topnl.jdbc.driverClassName"));
+            Class<?> rsgbDriverClass = Class.forName(params.getProperty("rsgb.jdbc.driverClassName"));
+            Class<?> stagingDriverClass = Class.forName(params.getProperty("staging.jdbc.driverClassName"));
+            Class<?> rsgbbgtDriverClass = Class.forName(params.getProperty("rsgbbgt.jdbc.driverClassName"));
+            Class<?> topnlDriverClass = Class.forName(params.getProperty("topnl.jdbc.driverClassName"));
         } catch (ClassNotFoundException ex) {
             LOG.error("Database driver niet gevonden.", ex);
         }

--- a/brmo-loader/src/test/java/nl/b3p/BrkToStagingToRsgbIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/BrkToStagingToRsgbIntegrationTest.java
@@ -56,7 +56,7 @@ public class BrkToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
             // {"type","filename", aantalBerichten, aantalProcessen, "datumEersteMutatie"},
              {"brk", "/nl/b3p/brmo/loader/xml/MUTBX01-ASN00T1660-20091119-1-singleline.xml", 1, 1, "2009-11-19"},
                 // mislukt op SQL server met melding mbt ongeldige geom
-             {"brk", "/nl/b3p/brmo/loader/xml/BURBX01-ASN00-AA331-big-geom.xml", 1, 1, "2009-11-30"},
+             {"brk", "/nl/b3p/brmo/loader/xml/BURBX01-ASN00-AA331-big-geom.xml", 1, 1, "2009-10-31"},
                 /* dit bestand zit in de DVD Proefbestanden BRK Levering oktober 2012 (Totaalstanden)
                 * /mnt/v_b3p_projecten/BRMO/BRK/BRK_STUF_IMKAD/BRK/Levering(dvd)/Proefbestanden BRK Levering oktober 2012 (Totaalstanden)/20091130/
                 * en staat op de git-ignore lijst omdat 't 18.5MB groot is, `grep -o KadastraalObjectSnapshot BURBX01.xml | wc -w`/2 geeft aantal berichten

--- a/brmo-loader/src/test/java/nl/b3p/BrkToStagingToRsgbIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/BrkToStagingToRsgbIntegrationTest.java
@@ -39,7 +39,7 @@ import org.junit.runners.Parameterized;
 /**
  *
  * Draaien met:
- * {@code mvn -Dit.test=BrkToStagingToRsgbIntegrationTest -Dtest.onlyITs=true verify -Pmssql > target/mssql.log}
+ * {@code mvn -Dit.test=BrkToStagingToRsgbIntegrationTest -Dtest.onlyITs=true verify -Pmssql -pl brmo-loader > target/mssql.log}
  * voor bijvoorbeeld MSSQL.
  *
  * @author Boy de Wit
@@ -54,12 +54,14 @@ public class BrkToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
     public static Collection params() {
         return Arrays.asList(new Object[][]{
             // {"type","filename", aantalBerichten, aantalProcessen, "datumEersteMutatie"},
-
-            {"brk", "/nl/b3p/brmo/loader/xml/MUTBX01-ASN00T1660-20091119-1-singleline.xml", 1, 1, "2009-11-19"} /*
-             * dit bestand zit in de DVD Proefbestanden BRK Levering oktober 2012 (Totaalstanden)
-             * /mnt/v_b3p_projecten/BRMO/BRK/BRK_STUF_IMKAD/BRK/Levering(dvd)/Proefbestanden BRK Levering oktober 2012 (Totaalstanden)/20091130/
-             * en staat op de git-ignore lijst omdat 't 18.5MB groot is, `grep -o KadastraalObjectSnapshot BURBX01.xml | wc -w`/2 geeft aantal berichten
-             */, {"brk", "/nl/b3p/brmo/loader/xml/BURBX01-ASN00-20091130-6000015280-9100000039.zip", (63104 / 2), 1, "2009-10-31"}
+             {"brk", "/nl/b3p/brmo/loader/xml/MUTBX01-ASN00T1660-20091119-1-singleline.xml", 1, 1, "2009-11-19"},
+                // mislukt op SQL server met melding mbt ongeldige geom
+             {"brk", "/nl/b3p/brmo/loader/xml/BURBX01-ASN00-AA331-big-geom.xml", 1, 1, "2009-11-30"},
+                /* dit bestand zit in de DVD Proefbestanden BRK Levering oktober 2012 (Totaalstanden)
+                * /mnt/v_b3p_projecten/BRMO/BRK/BRK_STUF_IMKAD/BRK/Levering(dvd)/Proefbestanden BRK Levering oktober 2012 (Totaalstanden)/20091130/
+                * en staat op de git-ignore lijst omdat 't 18.5MB groot is, `grep -o KadastraalObjectSnapshot BURBX01.xml | wc -w`/2 geeft aantal berichten
+                */
+             {"brk", "/nl/b3p/brmo/loader/xml/BURBX01-ASN00-20091130-6000015280-9100000039.zip", (63104 / 2), 1, "2009-10-31"},
         });
     }
 
@@ -153,7 +155,7 @@ public class BrkToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
     public void cleanup() throws Exception {
         brmo.closeBrmoFramework();
 
-        CleanUtil.cleanSTAGING(staging, false);
+        // CleanUtil.cleanSTAGING(staging, false);
         staging.close();
 
         CleanUtil.cleanRSGB_BRK(rsgb, true);

--- a/brmo-loader/src/test/java/nl/b3p/GBAVXMLToStagingIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/GBAVXMLToStagingIntegrationTest.java
@@ -55,7 +55,7 @@ import org.junit.runners.Parameterized;
  * Draaien met:
  * {@code mvn -Dit.test=GBAVXMLToStagingIntegrationTest -Dtest.onlyITs=true verify -Ppostgresql > target/postgresql.log}
  * voor bijvoorbeeld PostgresQL of
- * {@code mvn -Dit.test=GBAVXMLToStagingIntegrationTest -Dtest.onlyITs=true verify -Pmssql > target/mssql.log}
+ * {@code mvn -Dit.test=GBAVXMLToStagingIntegrationTest -Dtest.onlyITs=true verify -pl brmo-loader -Pmssql > mssql.log}
  * voor bijvoorbeeld MS SQL.
  *
  * @author Mark Prins

--- a/brmo-loader/src/test/java/nl/b3p/GH789GroteWaardeIDIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/GH789GroteWaardeIDIntegrationTest.java
@@ -5,7 +5,6 @@ import java.io.FileInputStream;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import nl.b3p.brmo.loader.BrmoFramework;
-import nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures;
 import nl.b3p.brmo.test.util.database.dbunit.CleanUtil;
 import nl.b3p.loader.jdbc.OracleConnectionUnwrapper;
 import org.apache.commons.dbcp.BasicDataSource;
@@ -25,13 +24,10 @@ import org.dbunit.ext.postgresql.PostgresqlDataTypeFactory;
 import org.dbunit.operation.DatabaseOperation;
 import org.junit.After;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 /**
  * Testcases voor mantis-14743 / GH #789; te grote waarde voor een int (laadprocesid)

--- a/brmo-loader/src/test/java/nl/b3p/Mantis10315IntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/Mantis10315IntegrationTest.java
@@ -5,7 +5,6 @@ import java.io.FileInputStream;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import nl.b3p.brmo.loader.BrmoFramework;
-import nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures;
 import nl.b3p.brmo.test.util.database.dbunit.CleanUtil;
 import nl.b3p.loader.jdbc.OracleConnectionUnwrapper;
 import org.apache.commons.dbcp.BasicDataSource;
@@ -31,7 +30,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 /**
  * Testcases voor mantis-10315; ontbrekende rechthebbende bij KAD_RECHT. <br>
@@ -39,12 +37,9 @@ import org.junit.experimental.categories.Category;
  * {@code mvn -Dit.test=Mantis10315IntegrationTest -Dtest.onlyITs=true verify -Poracle > target/oracle.log}
  * voor bijvoorbeeld Oracle of
  * {@code mvn -Dit.test=Mantis10315IntegrationTest -Dtest.onlyITs=true verify -Ppostgresql > target/postgresql.log}.
- * <strong>NB.</strong> werkt niet op mssql, althans niet met de jTDS driver
- * omdat die geen JtdsPreparedStatement#setNull() methode heeft.
  *
  * @author mprins
  */
-@Category(JTDSDriverBasedFailures.class)
 public class Mantis10315IntegrationTest extends AbstractDatabaseIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(Mantis10315IntegrationTest.class);

--- a/brmo-loader/src/test/java/nl/b3p/Mantis10547IntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/Mantis10547IntegrationTest.java
@@ -4,7 +4,6 @@
 package nl.b3p;
 
 import nl.b3p.brmo.loader.BrmoFramework;
-import nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures;
 import nl.b3p.brmo.test.util.database.dbunit.CleanUtil;
 import nl.b3p.loader.jdbc.OracleConnectionUnwrapper;
 import org.apache.commons.dbcp.BasicDataSource;
@@ -14,8 +13,6 @@ import org.dbunit.database.DatabaseConfig;
 import org.dbunit.database.DatabaseConnection;
 import org.dbunit.database.DatabaseDataSourceConnection;
 import org.dbunit.database.IDatabaseConnection;
-import org.dbunit.dataset.DefaultDataSet;
-import org.dbunit.dataset.DefaultTable;
 import org.dbunit.dataset.IDataSet;
 import org.dbunit.dataset.ITable;
 import org.dbunit.dataset.xml.XmlDataSet;
@@ -27,10 +24,8 @@ import org.dbunit.operation.DatabaseOperation;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.Arrays;
@@ -38,7 +33,6 @@ import java.util.Collection;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
-
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 
@@ -50,13 +44,9 @@ import static org.junit.Assume.assumeTrue;
  * {@code mvn -Dit.test=Mantis10315IntegrationTest -Dtest.onlyITs=true verify -Ppostgresql > target/postgresql.log}
  * voor postgresql.
  *
- * <strong>NB. werkt niet op mssql, althans niet met de jTDS driver omdat die
- * geen JtdsPreparedStatement#setNull() methode heeft.</strong>
- *
  * @author mprins
  */
 @RunWith(Parameterized.class)
-@Category(JTDSDriverBasedFailures.class)
 public class Mantis10547IntegrationTest extends AbstractDatabaseIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(Mantis10547IntegrationTest.class);
@@ -107,8 +97,6 @@ public class Mantis10547IntegrationTest extends AbstractDatabaseIntegrationTest 
         rsgb = new DatabaseDataSourceConnection(dsRsgb);
         staging = new DatabaseDataSourceConnection(dsStaging);
 
-        //assumeTrue("Deze test werkt niet met de jTDS driver omdat die geen JtdsPreparedStatement#setNull() methode heeft.", !this.isMsSQL);
-
         if (this.isMsSQL) {
             rsgb.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new MsSqlDataTypeFactory());
             staging.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new MsSqlDataTypeFactory());
@@ -154,8 +142,6 @@ public class Mantis10547IntegrationTest extends AbstractDatabaseIntegrationTest 
             // in geval van niet waar gemaakte assumptions
             brmo.closeBrmoFramework();
         }
-        //assumeTrue("Deze test werkt niet met de jTDS driver omdat die geen JtdsPreparedStatement#setNull() methode heeft.", !this.isMsSQL);
-
         CleanUtil.cleanRSGB_BRK(rsgb, true);
         rsgb.close();
 

--- a/brmo-loader/src/test/java/nl/b3p/Mantis10547IntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/Mantis10547IntegrationTest.java
@@ -107,7 +107,7 @@ public class Mantis10547IntegrationTest extends AbstractDatabaseIntegrationTest 
         rsgb = new DatabaseDataSourceConnection(dsRsgb);
         staging = new DatabaseDataSourceConnection(dsStaging);
 
-        assumeTrue("Deze test werkt niet met de jTDS driver omdat die geen JtdsPreparedStatement#setNull() methode heeft.", !this.isMsSQL);
+        //assumeTrue("Deze test werkt niet met de jTDS driver omdat die geen JtdsPreparedStatement#setNull() methode heeft.", !this.isMsSQL);
 
         if (this.isMsSQL) {
             rsgb.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new MsSqlDataTypeFactory());
@@ -154,7 +154,7 @@ public class Mantis10547IntegrationTest extends AbstractDatabaseIntegrationTest 
             // in geval van niet waar gemaakte assumptions
             brmo.closeBrmoFramework();
         }
-        assumeTrue("Deze test werkt niet met de jTDS driver omdat die geen JtdsPreparedStatement#setNull() methode heeft.", !this.isMsSQL);
+        //assumeTrue("Deze test werkt niet met de jTDS driver omdat die geen JtdsPreparedStatement#setNull() methode heeft.", !this.isMsSQL);
 
         CleanUtil.cleanRSGB_BRK(rsgb, true);
         rsgb.close();

--- a/brmo-loader/src/test/java/nl/b3p/Mantis11180IntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/Mantis11180IntegrationTest.java
@@ -5,7 +5,6 @@ import java.io.FileInputStream;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import nl.b3p.brmo.loader.BrmoFramework;
-import nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures;
 import nl.b3p.brmo.test.util.database.dbunit.CleanUtil;
 import nl.b3p.loader.jdbc.OracleConnectionUnwrapper;
 import org.apache.commons.dbcp.BasicDataSource;
@@ -31,7 +30,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 /**
  * Testcases voor mantis-11180; ontbrekende clazz waarde voor NIET INGEZETENE

--- a/brmo-loader/src/test/java/nl/b3p/Mantis6166IntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/Mantis6166IntegrationTest.java
@@ -11,7 +11,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import nl.b3p.brmo.loader.BrmoFramework;
 import nl.b3p.brmo.loader.RsgbProxy;
-import nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures;
 import nl.b3p.brmo.test.util.database.dbunit.CleanUtil;
 import nl.b3p.loader.jdbc.OracleConnectionUnwrapper;
 import org.apache.commons.dbcp.BasicDataSource;
@@ -24,8 +23,6 @@ import org.dbunit.dataset.IDataSet;
 import org.dbunit.operation.DatabaseOperation;
 import org.dbunit.ext.mssql.InsertIdentityOperation;
 import org.dbunit.database.DatabaseDataSourceConnection;
-import org.dbunit.dataset.DefaultDataSet;
-import org.dbunit.dataset.DefaultTable;
 import org.dbunit.dataset.ITable;
 import org.dbunit.dataset.xml.XmlDataSet;
 import org.dbunit.ext.mssql.MsSqlDataTypeFactory;
@@ -37,7 +34,6 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -47,13 +43,10 @@ import org.junit.runners.Parameterized;
  * {@code mvn -Dit.test=Mantis6166IntegrationTest -Dtest.onlyITs=true verify -Poracle > target/oracle.log}
  * voor bijvoorbeeld Oracle.
  *
- * <strong>NB. werkt niet op mssql, althans niet met de jTDS driver omdat die
- * geen JtdsPreparedStatement#setNull() methode heeft.</strong>
  *
  * @author mprins
  */
 @RunWith(Parameterized.class)
-@Category(JTDSDriverBasedFailures.class)
 public class Mantis6166IntegrationTest extends AbstractDatabaseIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(Mantis6166IntegrationTest.class);
@@ -109,8 +102,6 @@ public class Mantis6166IntegrationTest extends AbstractDatabaseIntegrationTest {
 
         rsgb = new DatabaseDataSourceConnection(dsRsgb);
         staging = new DatabaseDataSourceConnection(dsStaging);
-
-        // assumeTrue("Deze test werkt niet met de jTDS driver omdat die geen JtdsPreparedStatement#setNull() methode heeft.", !this.isMsSQL);
 
         if (this.isMsSQL) {
             rsgb.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new MsSqlDataTypeFactory());

--- a/brmo-loader/src/test/java/nl/b3p/Mantis6166IntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/Mantis6166IntegrationTest.java
@@ -110,7 +110,7 @@ public class Mantis6166IntegrationTest extends AbstractDatabaseIntegrationTest {
         rsgb = new DatabaseDataSourceConnection(dsRsgb);
         staging = new DatabaseDataSourceConnection(dsStaging);
 
-        assumeTrue("Deze test werkt niet met de jTDS driver omdat die geen JtdsPreparedStatement#setNull() methode heeft.", !this.isMsSQL);
+        // assumeTrue("Deze test werkt niet met de jTDS driver omdat die geen JtdsPreparedStatement#setNull() methode heeft.", !this.isMsSQL);
 
         if (this.isMsSQL) {
             rsgb.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new MsSqlDataTypeFactory());

--- a/brmo-loader/src/test/java/nl/b3p/Mantis6235IntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/Mantis6235IntegrationTest.java
@@ -8,7 +8,6 @@ import java.io.FileInputStream;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import nl.b3p.brmo.loader.BrmoFramework;
-import nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures;
 import nl.b3p.brmo.test.util.database.dbunit.CleanUtil;
 import nl.b3p.loader.jdbc.OracleConnectionUnwrapper;
 import org.apache.commons.dbcp.BasicDataSource;
@@ -32,7 +31,6 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
-import org.junit.experimental.categories.Category;
 
 /**
  * Testcases voor mantis-6235; incorrect parsen van VVE identificatie. Draaien
@@ -45,7 +43,6 @@ import org.junit.experimental.categories.Category;
  *
  * @author mprins
  */
-@Category(JTDSDriverBasedFailures.class)
 public class Mantis6235IntegrationTest extends AbstractDatabaseIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(Mantis6235IntegrationTest.class);

--- a/brmo-loader/src/test/java/nl/b3p/Mantis6380IntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/Mantis6380IntegrationTest.java
@@ -8,7 +8,6 @@ import java.io.FileInputStream;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import nl.b3p.brmo.loader.BrmoFramework;
-import nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures;
 import nl.b3p.brmo.test.util.database.dbunit.CleanUtil;
 import nl.b3p.loader.jdbc.OracleConnectionUnwrapper;
 import org.apache.commons.dbcp.BasicDataSource;
@@ -33,7 +32,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 /**
  * Testcases voor mantis-6380 / GH#332; incorrect verwerken van commanditair
@@ -41,12 +39,9 @@ import org.junit.experimental.categories.Category;
  * {@code mvn -Dit.test=Mantis6380IntegrationTest -Dtest.onlyITs=true verify -Poracle > target/oracle.log}
  * voor bijvoorbeeld Oracle of
  * {@code mvn -Dit.test=Mantis6380IntegrationTest -Dtest.onlyITs=true verify -Ppostgresql > target/postgresql.log}.
- * <strong>NB.</strong> werkt niet op mssql, althans niet met de jTDS driver
- * omdat die geen JtdsPreparedStatement#setNull() methode heeft.
  *
  * @author mprins
  */
-@Category(JTDSDriverBasedFailures.class)
 public class Mantis6380IntegrationTest extends AbstractDatabaseIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(Mantis6380IntegrationTest.class);

--- a/brmo-loader/src/test/java/nl/b3p/Oracle8000byteBugIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/Oracle8000byteBugIntegrationTest.java
@@ -14,7 +14,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import nl.b3p.brmo.loader.BrmoFramework;
 import nl.b3p.brmo.loader.entity.Bericht;
 import nl.b3p.brmo.loader.entity.LaadProces;
-import nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures;
+import nl.b3p.brmo.test.util.database.MSSqlServerDriverBasedFailures;
 import nl.b3p.brmo.test.util.database.PostgreSQLDriverBasedFailures;
 import nl.b3p.brmo.test.util.database.dbunit.CleanUtil;
 import nl.b3p.loader.jdbc.OracleConnectionUnwrapper;
@@ -24,8 +24,6 @@ import org.apache.commons.logging.LogFactory;
 import org.dbunit.database.DatabaseConfig;
 import org.dbunit.database.DatabaseConnection;
 import org.dbunit.database.IDatabaseConnection;
-import org.dbunit.dataset.DefaultDataSet;
-import org.dbunit.dataset.DefaultTable;
 import org.dbunit.dataset.IDataSet;
 import org.dbunit.dataset.ITable;
 import org.dbunit.dataset.xml.FlatXmlDataSetBuilder;
@@ -61,7 +59,7 @@ import org.junit.runners.Parameterized;
  * @author mprins
  */
 @RunWith(Parameterized.class)
-@Category({JTDSDriverBasedFailures.class, PostgreSQLDriverBasedFailures.class})
+@Category({MSSqlServerDriverBasedFailures.class, PostgreSQLDriverBasedFailures.class})
 public class Oracle8000byteBugIntegrationTest extends AbstractDatabaseIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(Oracle8000byteBugIntegrationTest.class);

--- a/brmo-loader/src/test/java/nl/b3p/TopNLIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/TopNLIntegrationTest.java
@@ -31,7 +31,7 @@ import nl.b3p.brmo.loader.RsgbProxy;
 import nl.b3p.brmo.loader.entity.Bericht;
 import nl.b3p.brmo.loader.entity.LaadProces;
 import nl.b3p.brmo.loader.util.BrmoException;
-import nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures;
+import nl.b3p.brmo.test.util.database.MSSqlServerDriverBasedFailures;
 import nl.b3p.brmo.test.util.database.dbunit.CleanUtil;
 import nl.b3p.loader.jdbc.OracleConnectionUnwrapper;
 import nl.b3p.topnl.TopNLType;
@@ -51,7 +51,6 @@ import org.dbunit.ext.oracle.Oracle10DataTypeFactory;
 import org.dbunit.ext.postgresql.PostgresqlDataTypeFactory;
 import org.dbunit.operation.DatabaseOperation;
 import org.junit.After;
-import static org.junit.Assume.assumeNotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -73,8 +72,8 @@ import static org.junit.Assume.assumeTrue;
  * @author Mark Prins
  */
 @RunWith(Parameterized.class)
-// overslaan op mssql
-@Category(JTDSDriverBasedFailures.class)
+// overslaan op mssql; daar is geen topnl ondersteuning, zie ook https://github.com/B3Partners/brmo/issues/773
+@Category({MSSqlServerDriverBasedFailures.class})
 public class TopNLIntegrationTest extends AbstractDatabaseIntegrationTest {
 
     private final static Log LOG = LogFactory.getLog(TopNLIntegrationTest.class);
@@ -144,6 +143,7 @@ public class TopNLIntegrationTest extends AbstractDatabaseIntegrationTest {
         brmo = new BrmoFramework(dsStaging, null, null, dsTopnl);
 
         if (this.isMsSQL) {
+            // TODO https://github.com/B3Partners/brmo/issues/773
             staging.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new MsSqlDataTypeFactory());
             topnl.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new MsSqlDataTypeFactory());
         } else if (this.isOracle) {

--- a/brmo-loader/src/test/java/nl/b3p/TopNLParserIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/TopNLParserIntegrationTest.java
@@ -16,25 +16,20 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures;
-import nl.b3p.brmo.test.util.database.MSSqlServerDriverBasedFailures;
 import nl.b3p.topnl.Processor;
 import nl.b3p.topnl.TopNLType;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import org.junit.experimental.categories.Category;
 
 /**
  * Deze test dient om onaangekondigde aanpassingen in het schema te vangen, pdok
  * heeft dat nu een paar keer gedaan. Draaien met:
- * {@code mvn -Dit.test=TopNLParserIntegrationTest -Dtest.onlyITs=true -Ppostgresql verify > target/TopNLParserIntegrationTest.log}
+ * {@code mvn -Dit.test=TopNLParserIntegrationTest -Dtest.onlyITs=true -Ppostgresql verify -pl brmo-loader > mvn.log}
  *
  * @author Mark Prins
  */
 @RunWith(Parameterized.class)
-// overslaan voor mssql profielen
-@Category({JTDSDriverBasedFailures.class, MSSqlServerDriverBasedFailures.class})
 public class TopNLParserIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(TopNLParserIntegrationTest.class);

--- a/brmo-loader/src/test/java/nl/b3p/brmo/loader/entity/BagBerichtIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/brmo/loader/entity/BagBerichtIntegrationTest.java
@@ -43,7 +43,7 @@ import static org.junit.Assume.assumeTrue;
 /**
  *
  * Draaien met:
- * {@code mvn -Dit.test=BagBerichtIntegrationTest -Dtest.onlyITs=true verify -Ppostgresql > target/postgresql.log}
+ * {@code mvn -Dit.test=BagBerichtIntegrationTest -Dtest.onlyITs=true verify -pl brmo-loader -Ppostgresql > target/postgresql.log}
  * voor bijvoorbeeld PostgreSQL.
  *
  * @author mprins

--- a/brmo-loader/src/test/resources/nl/b3p/brmo/loader/xml/BURBX01-ASN00-AA331-big-geom.xml
+++ b/brmo-loader/src/test/resources/nl/b3p/brmo/loader/xml/BURBX01-ASN00-AA331-big-geom.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- dit is een beekbedding ergens ten oosten van Assen, QGIS kan deze zonder probleem tonen -->
+<GemeenteGebaseerdeStand:GemeenteGebaseerdeStand xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:GemeenteGebaseerdeStand="http://www.kadaster.nl/schemas/brk-levering/product-gemeentegebaseerdestand/v20120901" xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201" xmlns:Snapshot="http://www.kadaster.nl/schemas/brk-levering/snapshot/v20120901" xmlns:GbaPersoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon/v20120901" xmlns:Adres="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-adres/v20120201" xmlns:Persoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon/v20120201" xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201" xmlns:BagAdres="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-bag-adres/v20120201" xmlns:KadastraalObject="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject/v20120701" xmlns:InOnderzoek="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-inonderzoek/v20120201" xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml" xmlns:smil20="http://www.w3.org/2001/SMIL20/" xmlns:smil20lang="http://www.w3.org/2001/SMIL20/Language" xmlns:NhrRechtspersoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-nhr-rechtspersoon/v20120201" xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201" xmlns:GbaPersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon-ref/v20120201" xmlns:PersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon-ref/v20120201" xmlns:NhrRechtspersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-nhr-rechtspersoon-ref/v20120201" xmlns:RechtRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht-ref/v20120201" xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201" xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201" xsi:schemaLocation="http://www.kadaster.nl/schemas/brk-levering/product-gemeentegebaseerdestand/v20120901 BRKLeveringGemeenteGebaseerdeStand_v1_1_4.xsd">
+    <GemeenteGebaseerdeStand:BRKDatum>2009-11-30</GemeenteGebaseerdeStand:BRKDatum>
+    <GemeenteGebaseerdeStand:naamBurgerlijkeGemeente>
+        <Typen:code>ASN00</Typen:code>
+        <Typen:waarde>Assen</Typen:waarde>
+    </GemeenteGebaseerdeStand:naamBurgerlijkeGemeente>
+    <GemeenteGebaseerdeStand:stand>
+        <Snapshot:KadastraalObjectSnapshot>
+            <Snapshot:referentie>30DDFF8A7650-1D3C7E1EEFF</Snapshot:referentie>
+            <Snapshot:toestandsdatum>2009-10-31</Snapshot:toestandsdatum>
+            <KadastraalObject:Perceel id="ID.50699008">
+                <KadastraalObject:identificatie>
+                    <NEN3610:namespace>NL.KAD.OnroerendeZaak</NEN3610:namespace>
+                    <NEN3610:lokaalId>53730033170000</NEN3610:lokaalId>
+                </KadastraalObject:identificatie>
+                <KadastraalObject:kadastraleAanduiding>
+                    <KadastraalObject:AKRKadastraleGemeenteCode>
+                        <Typen:code>106</Typen:code>
+                        <Typen:waarde>ASN00</Typen:waarde>
+                    </KadastraalObject:AKRKadastraleGemeenteCode>
+                    <KadastraalObject:naamKadastraleGemeente>
+                        <Typen:code>59</Typen:code>
+                        <Typen:waarde>Assen</Typen:waarde>
+                    </KadastraalObject:naamKadastraleGemeente>
+                    <KadastraalObject:sectie>AA</KadastraalObject:sectie>
+                    <KadastraalObject:perceelnummer>331</KadastraalObject:perceelnummer>
+                </KadastraalObject:kadastraleAanduiding>
+                <KadastraalObject:aardCultuurOnbebouwd>
+                    <Typen:code>89</Typen:code>
+                    <Typen:waarde>Water</Typen:waarde>
+                </KadastraalObject:aardCultuurOnbebouwd>
+                <KadastraalObject:begrenzingPerceel>
+                    <gml:Surface srsName="urn:ogc:def:crs:EPSG::28992">
+                        <gml:patches>
+                            <gml:PolygonPatch>
+                                <gml:exterior>
+                                    <gml:LinearRing>
+                                        <gml:posList srsDimension="2" count="544">238510.319 560225.328 238509.942 560225.021 238522.621 560213.046 238537.167 560199.423 238537.415 560199.191 238539.784 560198.151 238543.891 560193.921 238552.898 560186.639 238558.987 560183.617 238560.947 560182.093 238561.848 560180.481 238562.623 560178.22 238562.427 560176.072 238561.409 560173.929 238555.694 560162.32 238551.821 560153.393 238547.821 560144.089 238539.619 560126.983 238534.428 560116.124 238528.784 560108.795 238527.261 560098.877 238527.954 560096.965 238526.065 560079.053 238523.789 560062.407 238520.604 560053.256 238517.119 560039.845 238515.228 560027.656 238515.372 560025.477 238516.685 560022.118 238519.73 560013.764 238521.004 560009.246 238522.181 560006.651 238523.36 560005.312 238524.35 560004.171 238524.479 560004.041 238526.717 560002.86 238528.55 560000.958 238534.171 559997.044 238536.968 559994.21 238539.376 559989.861 238540.385 559986.164 238539.773 559982.708 238538.813 559979.717 238535.943 559974.781 238530.056 559967.52 238522.452 559957.954 238517.345 559951.762 238502.739 559937.228 238494.775 559929.976 238489.548 559926.191 238483.514 559920.837 238480.819 559918.804 238479.911 559917.359 238479.427 559915.807 238479.455 559914.939 238478.987 559910.236 238478.792 559908.361 238479.369 559906.186 238480.682 559904.082 238482.836 559902.196 238489.598 559896.056 238496.768 559891.384 238507.836 559885.944 238513.119 559883.589 238515.161 559881.715 238516.825 559878.711 238518.145 559875.191 238518.176 559872.041 238517.28 559867.219 238516.377 559864.098 238516.066 559862.929 238515.587 559858.435 238511.726 559846.403 238510.25 559840.974 238507.189 559832.2 238503.774 559824.052 238498.267 559812.468 238493.094 559802.542 238490.908 559799.344 238489.309 559797.575 238487.14 559796.565 238483.98 559794.187 238475.062 559790.214 238472.721 559788.81 238467.763 559786.985 238464.063 559785.43 238458.645 559782.826 238449.674 559779.269 238444.796 559776.821 238441.305 559775.567 238438.983 559774.115 238436.7 559771.862 238435.163 559769.517 238434.292 559766.722 238433.982 559763.329 238434.269 559757.989 238435.968 559753.364 238439.153 559746.045 238440.166 559741.642 238440.542 559736.772 238438.907 559727.138 238437.177 559714.958 238436.431 559709.05 238435.875 559701.962 238434.823 559690.7 238434.967 559688.794 238435.325 559685.226 238434.752 559679.44 238433.169 559668.135 238430.344 559654.435 238428.923 559643.14 238427.495 559638.002 238425.878 559634.045 238425.22 559632.957 238423.704 559629.979 238417.496 559620.468 238412.385 559612.475 238410.059 559608.24 238404.908 559598.814 238404.537 559595.016 238403.782 559585.507 238403.718 559579.811 238403.173 559574.363 238403.88 559569.861 238404.466 559568.543 238406.451 559563.046 238409.863 559555.708 238413.05 559549.646 238415.935 559544.775 238417.546 559539.677 238417.885 559537.411 238417.634 559535.404 238416.781 559533.817 238414.228 559531.839 238408.051 559528.391 238401.591 559524.126 238398.827 559522.829 238396.438 559522.66 238389.036 559519.553 238382.014 559516.594 238378.098 559512.938 238376.336 559510.888 238375.41 559509.56 238375.428 559507.829 238375.916 559505.543 238376.723 559502.641 238377.951 559497.123 238378.082 559489.814 238378.133 559480.892 238378.418 559471.787 238379.478 559466.421 238380.917 559462.185 238380.909 559458.854 238381.421 559455.729 238381.087 559454.071 238379.971 559452.6 238379.021 559451.683 238376.037 559450.247 238372.928 559449.415 238370.472 559449.001 238361.499 559446.426 238357.012 559444.73 238350.377 559441.813 238331.412 559437.737 238324.696 559435.388 238313.976 559431.422 238307.721 559430.125 238303.299 559428.181 238298.188 559427.168 238292.64 559423.366 238288.804 559420.343 238284.602 559416.304 238279.331 559410.811 238277.313 559408.36 238277.15 559408.161 238275.139 559404.377 238266.906 559394.184 238263.367 559390.403 238261.079 559388.583 238256.642 559385.979 238254.171 559384.633 238251.615 559383.636 238248.462 559383.331 238241.193 559382.675 238236.734 559383.062 238235.822 559383.47 238228.571 559387.346 238222.008 559391.163 238217.439 559393.088 238212.154 559395.169 238208.588 559396.34 238200.919 559397.546 238194.965 559398.548 238189.57 559398.678 238182.32 559397.975 238175.447 559396.165 238167.977 559394.068 238161.157 559392.823 238156.185 559391.591 238151.499 559389.489 238144.851 559386.131 238143.161 559384.872 238139.808 559383.285 238135.737 559381.265 238132.984 559380.355 238131.227 559380.106 238129.143 559379.019 238127.298 559377.318 238125.603 559375.238 238124.741 559373.539 238123.568 559371.936 238121.576 559370.612 238119.942 559369.212 238118.817 559367.627 238118.006 559365.512 238118.121 559363.266 238119.082 559359.552 238121.323 559355.628 238124.54 559350.886 238128.161 559346.084 238132.359 559341.341 238136.131 559336.434 238137.875 559332.807 238139.727 559326.114 238141.05 559319.379 238141.615 559314.582 238142.063 559310.504 238141.679 559308.282 238140.634 559306.347 238139.321 559304.963 238136.629 559302.221 238123.407 559289.59 238116.216 559282.313 238108.774 559276.518 238102.742 559272.419 238095.364 559267.575 238084.615 559261.036 238071.831 559252.72 238061.479 559247.534 238051.31 559241.602 238042.511 559235.932 238035.44 559230.719 238030.894 559226.164 238026.857 559223.661 238026.743 559223.493 238020.814 559214.704 238017.349 559211.007 238012.859 559205.056 238011.441 559202.267 238007.803 559195.668 238003.712 559189.109 237999.804 559184.039 237997.629 559182.209 237995.516 559181.057 237991.369 559179.11 237981.089 559174.716 237976.646 559173.527 237976.478 559173.378 237975.23 559172.266 237970.55 559170.985 237965.023 559169.918 237957.747 559169.422 237950.797 559167.528 237948.688 559166.923 237947.024 559165.183 237944.03 559162.379 237940.46 559158.259 237928.379 559142.147 237923.454 559136.261 237921.587 559133.989 237919.3 559132.442 237913.681 559130.358 237908.639 559129.862 237901.642 559130.185 237898.518 559128.692 237895.341 559127.889 237892.202 559125.737 237889.158 559122.641 237887.389 559120.75 237887.096 559119.546 237887.075 559114.575 237884.804 559103.22 237883.348 559098.017 237881.936 559092.557 237879.398 559086.496 237875.214 559078.92 237872.665 559073.999 237868.583 559068.144 237870.131 559068.483 237872.307 559069.333 237874.395 559070.966 237876.465 559072.647 237879.825 559078.702 237883.479 559084.981 237886.463 559091.163 237887.427 559094.974 237889.667 559110.733 237889.946 559115.041 237890.889 559117.373 237892.722 559119.941 237894.712 559122.245 237896.893 559123.641 237899.319 559125.244 237908.263 559126.498 237913.074 559126.468 237916.189 559126.593 237920.049 559128.154 237923.795 559130.434 237929.918 559135.277 237937.618 559144.88 237942.808 559152.25 237946.273 559156.22 237948.817 559159.339 237951.009 559160.849 237953.633 559162.364 237958.399 559163.843 237974.915 559167.071 237982.599 559170.017 237987.761 559171.595 237990.798 559172.618 237994.341 559174.436 237997.567 559176.785 238000.491 559179.071 238003.459 559182.084 238006.692 559186.509 238013.294 559198.082 238016.046 559202.483 238020.337 559208.247 238025.47 559214.232 238031.171 559219.456 238037.085 559225.254 238047.86 559232.568 238060.705 559241.562 238070.236 559246.753 238087.261 559255.797 238098.419 559263.806 238108.669 559270.369 238118.459 559278.389 238133.523 559291.194 238138.212 559296.078 238141.368 559299.164 238143.738 559302.87 238144.579 559305.325 238145.518 559308.363 238145.592 559311.663 238144.793 559317.895 238144.186 559322.238 238143.054 559326.813 238142.223 559331.451 238139.989 559336.468 238136.747 559342.671 238134.981 559344.818 238131.394 559349.253 238129.518 559351.683 238127.53 559354.397 238125.898 559356.759 238124.529 559360.26 238124.163 559362.734 238124.837 559365.615 238126.131 559368.028 238128.436 559370.782 238131.523 559373.623 238135.581 559376.079 238142.36 559379.106 238149.071 559381.89 238162.919 559387.894 238171.209 559389.984 238179.215 559391.964 238187.507 559393.074 238202.642 559392.439 238208.253 559390.921 238212.902 559389.627 238218.713 559387.315 238224.761 559383.841 238228.404 559381.773 238234.583 559379.495 238238.614 559378.67 238241.405 559378.505 238244.708 559378.704 238248.277 559379.061 238251.498 559379.609 238254.322 559380.057 238257.511 559381.246 238263.292 559384.594 238267.962 559388.271 238272.513 559393.373 238276.671 559398.922 238278.593 559402.234 238282.787 559407.689 238284.833 559409.851 238293.68 559417.775 238297.554 559420.978 238303.318 559423.39 238310.614 559425.094 238323.852 559430.15 238340.734 559435.65 238357.508 559440.451 238375.812 559446.777 238382.21 559449.383 238384.051 559450.811 238385.09 559452.198 238385.565 559454.892 238385.611 559458.128 238385.797 559461.417 238385.418 559466.013 238383.471 559474.905 238382.053 559501.559 238381.509 559505.326 238381.634 559508.212 238381.95 559509.916 238384.44 559512.197 238391.76 559515.654 238397.549 559518.84 238402.201 559520.056 238408.364 559522.843 238412.569 559524.92 238416.781 559527.819 238419.623 559530.454 238421.672 559533.163 238422.545 559534.976 238422.709 559537.766 238421.949 559541.668 238421.097 559544.825 238418.726 559550.334 238412.069 559561.368 238409.509 559566.803 238408.18 559569.229 238407.778 559572.071 238407.287 559574.442 238407.197 559578.443 238407.919 559586.085 238408.718 559592.831 238409.986 559597.962 238411.56 559602.447 238416.72 559610.731 238419.696 559616.092 238423.224 559622.976 238425.532 559626.277 238430.105 559631.878 238434.994 559635.89 238435.924 559640.857 238437.627 559654.5 238438.183 559662.568 238439.449 559668.678 238439.8 559676.013 238442.009 559685.709 238442.408 559691.807 238443.013 559696.953 238443.461 559704.596 238444.325 559709.787 238445.515 559717.066 238447.186 559723.18 238446.218 559724.756 238444.989 559728.039 238444.241 559732.328 238444.309 559740.807 238443.56 559745.094 238442.789 559748.882 238441.255 559752.809 238440.377 559756.174 238439.419 559759.181 238439.272 559762.069 238439.778 559765.101 238440.59 559767.49 238442.422 559770.06 238444.465 559771.948 238448.851 559774.26 238457.559 559777.93 238466.237 559781.262 238481.782 559788.094 238489.439 559792.5 238492.799 559795.065 238495.478 559798.674 238500.558 559808.837 238507.659 559822.624 238513.715 559837.964 238516.66 559845.221 238520.22 559857.462 238521.35 559865.318 238522.036 559869.84 238521.757 559873.765 238521.274 559877.231 238519.991 559880.655 238517.747 559884.306 238514.697 559887.367 238497.762 559896.517 238489.404 559902.415 238486.625 559905.202 238484.904 559907.093 238484.101 559909.288 238483.951 559911.628 238484.606 559914.556 238486.046 559916.59 238489.183 559920.704 238492.219 559922.981 238494.643 559924.035 238497.635 559926.567 238510.812 559938.198 238515.803 559942.873 238520.297 559948.116 238526.92 559956.427 238535.132 559966.394 238539.196 559972.178 238541.731 559976.44 238543.033 559979.947 238543.832 559984.458 238543.625 559987.92 238542.113 559992.347 238540.552 559995.228 238535.19 560000.714 238530.535 560004.95 238527.448 560008.107 238525.598 560010.329 238523.776 560013.598 238521.288 560019.825 238520.026 560023.749 238519.344 560026.755 238519.012 560030.115 238519.522 560033.695 238523.845 560049.286 238528.828 560068.353 238531.38 560087.779 238532.791 560098.963 238532.886 560104.999 238533.76 560108.065 238536.89 560112.614 238540.022 560118.416 238543.552 560124.593 238553.703 560145.786 238560.868 560160.523 238563.901 560166.997 238565.875 560172.129 238566.675 560175.386 238567.113 560178.174 238566.957 560179.967 238566.301 560181.784 238565.242 560183.66 238563.344 560185.864 238560.669 560187.545 238555.879 560190.038 238552.897 560192.365 238531.828 560211.677 238514.566 560228.784 238510.319 560225.328</gml:posList>
+                                    </gml:LinearRing>
+                                </gml:exterior>
+                            </gml:PolygonPatch>
+                        </gml:patches>
+                    </gml:Surface>
+                </KadastraalObject:begrenzingPerceel>
+                <KadastraalObject:indicatieDeelperceel>false</KadastraalObject:indicatieDeelperceel>
+                <KadastraalObject:kadastraleGrootte>
+                    <KadastraalObject:waarde>7700</KadastraalObject:waarde>
+                </KadastraalObject:kadastraleGrootte>
+                <KadastraalObject:soortGrootte>
+                    <Typen:code>1</Typen:code>
+                    <Typen:waarde>Vastgesteld</Typen:waarde>
+                </KadastraalObject:soortGrootte>
+                <KadastraalObject:perceelnummerRotatie>1.4014</KadastraalObject:perceelnummerRotatie>
+                <KadastraalObject:plaatscoordinaten>
+                    <gml:Point srsName="urn:ogc:def:crs:EPSG::28992">
+                        <gml:pos>238434.702 559659.328</gml:pos>
+                    </gml:Point>
+                </KadastraalObject:plaatscoordinaten>
+            </KadastraalObject:Perceel>
+            <Recht:ZakelijkRecht id="ID.51579209">
+                <Recht:identificatie>
+                    <NEN3610:namespace>NL.KAD.ZakelijkRecht</NEN3610:namespace>
+                    <NEN3610:lokaalId>AKR1.9534367</NEN3610:lokaalId>
+                </Recht:identificatie>
+                <Recht:aard>
+                    <Typen:code>2</Typen:code>
+                    <Typen:waarde>Eigendom (recht van)</Typen:waarde>
+                </Recht:aard>
+                <Recht:rustOp>
+                    <KadastraalObjectRef:PerceelRef xlink:href="#ID.50699008" />
+                </Recht:rustOp>
+            </Recht:ZakelijkRecht>
+            <Recht:Tenaamstelling id="ID.65437751">
+                <Recht:identificatie>
+                    <NEN3610:namespace>NL.KAD.Tenaamstelling</NEN3610:namespace>
+                    <NEN3610:lokaalId>AKR1.9534367</NEN3610:lokaalId>
+                </Recht:identificatie>
+                <Recht:isGebaseerdOp>
+                    <StukRef:StukdeelRef xlink:href="#ID.65444807" />
+                </Recht:isGebaseerdOp>
+                <Recht:vanPersoon>
+                    <PersoonRef:KADNietNatuurlijkPersoonRef xlink:href="#ID.65440017" />
+                </Recht:vanPersoon>
+                <Recht:aandeel>
+                    <Recht:teller>1</Recht:teller>
+                    <Recht:noemer>1</Recht:noemer>
+                </Recht:aandeel>
+                <Recht:van>
+                    <RechtRef:ZakelijkRechtRef xlink:href="#ID.51579209" />
+                </Recht:van>
+            </Recht:Tenaamstelling>
+            <Persoon:KADNietNatuurlijkPersoon id="ID.65440017">
+                <Persoon:identificatie>
+                    <NEN3610:namespace>NL.KAD.Persoon</NEN3610:namespace>
+                    <NEN3610:lokaalId>58202400</NEN3610:lokaalId>
+                </Persoon:identificatie>
+                <Persoon:postlocatie>
+                    <Adres:PostbusAdres>
+                        <Adres:postbusnummer>195</Adres:postbusnummer>
+                        <Adres:postcode>9640AD</Adres:postcode>
+                        <Adres:woonplaatsNaam>VEENDAM</Adres:woonplaatsNaam>
+                    </Adres:PostbusAdres>
+                </Persoon:postlocatie>
+                <Persoon:woonlocatie>
+                    <Adres:KADBinnenlandsAdres>
+                        <Adres:openbareRuimteNaam>Aquapark</Adres:openbareRuimteNaam>
+                        <Adres:huisNummer>5</Adres:huisNummer>
+                        <Adres:postcode>9641PJ</Adres:postcode>
+                        <Adres:woonplaatsNaam>VEENDAM</Adres:woonplaatsNaam>
+                    </Adres:KADBinnenlandsAdres>
+                </Persoon:woonlocatie>
+                <Persoon:naam>Waterschap Hunze en Aa's</Persoon:naam>
+                <Persoon:rechtsvorm>
+                    <Typen:code>10</Typen:code>
+                    <Typen:waarde>Publiekrechtelijke rechtspersoon</Typen:waarde>
+                </Persoon:rechtsvorm>
+                <Persoon:statutaireZetel>VEENDAM</Persoon:statutaireZetel>
+            </Persoon:KADNietNatuurlijkPersoon>
+            <Stuk:TerInschrijvingAangebodenStuk id="ID.65441555">
+                <Stuk:identificatie>
+                    <NEN3610:namespace>NL.KAD.TIAStuk</NEN3610:namespace>
+                    <NEN3610:lokaalId>17990529001506</NEN3610:lokaalId>
+                </Stuk:identificatie>
+                <Stuk:omvat>
+                    <Stuk:Stukdeel id="ID.65444807">
+                        <Stuk:identificatie>
+                            <NEN3610:namespace>NL.KAD.Stukdeel</NEN3610:namespace>
+                            <NEN3610:lokaalId>AKR1.10893739</NEN3610:lokaalId>
+                        </Stuk:identificatie>
+                        <Stuk:aardStukdeel nilReason="waardeOnbekend">
+                            <Typen:code>NIL</Typen:code>
+                            <Typen:waarde>NIL</Typen:waarde>
+                        </Stuk:aardStukdeel>
+                    </Stuk:Stukdeel>
+                </Stuk:omvat>
+                <Stuk:tijdstipAanbieding nilReason="waardeOnbekend">0001-01-01T00:00:00</Stuk:tijdstipAanbieding>
+                <Stuk:deelEnNummer>
+                    <Stuk:deel>7625</Stuk:deel>
+                    <Stuk:nummer>32</Stuk:nummer>
+                    <Stuk:reeks>
+                        <Typen:code>ASN</Typen:code>
+                        <Typen:waarde>Assen</Typen:waarde>
+                    </Stuk:reeks>
+                    <Stuk:registercode>
+                        <Typen:code>2</Typen:code>
+                        <Typen:waarde>Hyp4</Typen:waarde>
+                    </Stuk:registercode>
+                    <Stuk:soortRegister>
+                        <Typen:code>2</Typen:code>
+                        <Typen:waarde>Onroerende Zaken</Typen:waarde>
+                    </Stuk:soortRegister>
+                </Stuk:deelEnNummer>
+            </Stuk:TerInschrijvingAangebodenStuk>
+        </Snapshot:KadastraalObjectSnapshot>
+    </GemeenteGebaseerdeStand:stand>
+</GemeenteGebaseerdeStand:GemeenteGebaseerdeStand>

--- a/brmo-loader/src/test/resources/sqlserver.properties
+++ b/brmo-loader/src/test/resources/sqlserver.properties
@@ -1,6 +1,6 @@
 # evt. override met een local.sqlserver.properties
 #geotools
-dbtype=jtds-sqlserver
+dbtype=sqlserver
 
 rsgb.host=127.0.0.1
 rsgb.port=1433
@@ -10,20 +10,20 @@ rsgb.schema=dbo
 rsgb.user=sa
 rsgb.passwd=Password12!
 # regular jdbc
-rsgb.jdbc.driverClassName=net.sourceforge.jtds.jdbc.Driver
-rsgb.jdbc.url=jdbc:jtds:sqlserver://127.0.0.1:1433/rsgb;instance=${mssql.instancename}
+rsgb.jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
+rsgb.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;instance=${mssql.instancename}
 
-staging.jdbc.driverClassName=net.sourceforge.jtds.jdbc.Driver
-staging.jdbc.url=jdbc:jtds:sqlserver://127.0.0.1:1433/staging;instance=${mssql.instancename}
+staging.jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
+staging.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;instance=${mssql.instancename}
 staging.user=sa
 staging.passwd=Password12!
 
-rsgbbgt.jdbc.driverClassName=net.sourceforge.jtds.jdbc.Driver
-rsgbbgt.jdbc.url=jdbc:jtds:sqlserver://127.0.0.1:1433/bgttest;instance=${mssql.instancename}
+rsgbbgt.jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
+rsgbbgt.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;instance=${mssql.instancename}
 rsgbbgt.user=sa
 rsgbbgt.passwd=Password12!
 
-topnl.jdbc.driverClassName=net.sourceforge.jtds.jdbc.Driver
-topnl.jdbc.url=jdbc:jtds:sqlserver://127.0.0.1:1433/topnl;instance=${mssql.instancename}
+topnl.jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
+topnl.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=topnl;instance=${mssql.instancename}
 topnl.user=topnl
 topnl.passwd=topnl

--- a/brmo-loader/src/test/resources/sqlserver.properties
+++ b/brmo-loader/src/test/resources/sqlserver.properties
@@ -11,19 +11,19 @@ rsgb.user=sa
 rsgb.passwd=Password12!
 # regular jdbc
 rsgb.jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
-rsgb.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;instance=${mssql.instancename}
+rsgb.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;applicationName=brmo-loader-test;instance=${mssql.instancename}
 
 staging.jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
-staging.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;instance=${mssql.instancename}
+staging.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;applicationName=brmo-loader-test;instance=${mssql.instancename}
 staging.user=sa
 staging.passwd=Password12!
 
 rsgbbgt.jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
-rsgbbgt.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;instance=${mssql.instancename}
+rsgbbgt.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;applicationName=brmo-loader-test;instance=${mssql.instancename}
 rsgbbgt.user=sa
 rsgbbgt.passwd=Password12!
 
 topnl.jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
-topnl.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=topnl;instance=${mssql.instancename}
-topnl.user=topnl
-topnl.passwd=topnl
+topnl.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=topnl;applicationName=brmo-loader-test;instance=${mssql.instancename}
+topnl.user=sa
+topnl.passwd=Password12!

--- a/brmo-persistence/pom.xml
+++ b/brmo-persistence/pom.xml
@@ -33,8 +33,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.jtds</groupId>
-            <artifactId>jtds</artifactId>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/brmo-persistence/src/main/java/nl/b3p/brmo/persistence/staging/LaadProces.java
+++ b/brmo-persistence/src/main/java/nl/b3p/brmo/persistence/staging/LaadProces.java
@@ -229,7 +229,6 @@ public class LaadProces implements Serializable {
     public void setBeschikbaar_tot(Date beschikbaar_tot) {
         this.beschikbaar_tot = beschikbaar_tot;
     }
-    // </editor-fold>
 
     public String getBestand_naam_hersteld() {
         return bestand_naam_hersteld;
@@ -240,4 +239,28 @@ public class LaadProces implements Serializable {
     }
     // </editor-fold>
 
+    @Override
+    public String toString() {
+        return "LaadProces{" +
+                "id=" + id +
+                ", bestandNaam='" + bestand_naam + '\'' +
+                ", bestandNaamHersteld='" + bestand_naam_hersteld + '\'' +
+                ", bestandDatum=" + bestand_datum +
+                ", soort='" + soort + '\'' +
+                ", gebied='" + gebied + '\'' +
+                ", opmerking='" + opmerking + '\'' +
+                ", status=" + status +
+                ", statusDatum=" + status_datum +
+                ", contactEmail='" + contact_email + '\'' +
+                ", automatischProces=" + automatischProces +
+                ", klantafgiftenummer=" + klantafgiftenummer +
+                ", contractafgiftenummer=" + contractafgiftenummer +
+                ", artikelnummer='" + artikelnummer + '\'' +
+                ", contractnummer='" + contractnummer + '\'' +
+                ", afgifteid='" + afgifteid + '\'' +
+                ", afgiftereferentie='" + afgiftereferentie + '\'' +
+                ", bestandsreferentie='" + bestandsreferentie + '\'' +
+                ", beschikbaar_tot=" + beschikbaar_tot +
+                '}';
+    }
 }

--- a/brmo-persistence/src/test/resources/connections.properties
+++ b/brmo-persistence/src/test/resources/connections.properties
@@ -10,5 +10,7 @@ postgresql.driverClass=org.postgresql.Driver
 
 microsoftsqlserver.user=sa
 microsoftsqlserver.password=Password12!
-microsoftsqlserver.url=jdbc:jtds:sqlserver://127.0.0.1:1433/staging;instance=${mssql.instancename}
-microsoftsqlserver.driverClass=net.sourceforge.jtds.jdbc.Driver
+# microsoftsqlserver.url=jdbc:jtds:sqlserver://127.0.0.1:1433/staging;instance=${mssql.instancename}
+# microsoftsqlserver.driverClass=net.sourceforge.jtds.jdbc.Driver
+microsoftsqlserver.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;applicationName=brmo-loader-test;instance=${mssql.instancename}
+microsoftsqlserver.driverClass=com.microsoft.sqlserver.jdbc.SQLServerDriver

--- a/brmo-service/pom.xml
+++ b/brmo-service/pom.xml
@@ -87,8 +87,8 @@
                     <artifactId>postgis-jdbc</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>net.sourceforge.jtds</groupId>
-                    <artifactId>jtds</artifactId>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -466,8 +466,8 @@
             </properties>
             <dependencies>
                 <dependency>
-                    <groupId>net.sourceforge.jtds</groupId>
-                    <artifactId>jtds</artifactId>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
                 </dependency>
             </dependencies>
             <build>
@@ -546,11 +546,6 @@
                                 <artifactId>jakarta.mail</artifactId>
                                 <version>${jakarta.mail.version}</version>
                             </dependency>
-<!--                            <dependency>-->
-<!--                                <groupId>net.sourceforge.jtds</groupId>-->
-<!--                                <artifactId>jtds</artifactId>-->
-<!--                                <version>${sqlserver.jtds.version}</version>-->
-<!--                            </dependency>-->
                         </dependencies>
                     </plugin>
                     <plugin>

--- a/brmo-service/pom.xml
+++ b/brmo-service/pom.xml
@@ -554,7 +554,7 @@
                             <systemPropertyVariables>
                                 <database.properties.file>sqlserver.properties</database.properties.file>
                             </systemPropertyVariables>
-                            <excludedGroups>nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures</excludedGroups>
+                            <excludedGroups>nl.b3p.brmo.test.util.database.MSSqlServerDriverBasedFailures</excludedGroups>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/brmo-service/src/test/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsActionBeanCleanupIntegrationTest.java
+++ b/brmo-service/src/test/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsActionBeanCleanupIntegrationTest.java
@@ -12,10 +12,8 @@ import java.util.concurrent.locks.ReentrantLock;
 import nl.b3p.brmo.loader.BrmoFramework;
 import nl.b3p.brmo.loader.entity.Bericht;
 import nl.b3p.brmo.service.testutil.TestUtil;
-import nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures;
 import nl.b3p.brmo.test.util.database.dbunit.CleanUtil;
 import nl.b3p.loader.jdbc.OracleConnectionUnwrapper;
-import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.dbunit.database.DatabaseConfig;
@@ -33,7 +31,6 @@ import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import static org.junit.Assert.fail;
@@ -48,14 +45,9 @@ import static org.junit.Assume.assumeTrue;
  * {@code mvn -Dit.test=AdvancedFunctionsActionBeanCleanupIntegrationTest -Dtest.onlyITs=true verify -Poracle  -pl brmo-service > target/oracle.log}
  * voor Oracle.
  *
- * <strong>Deze test werkt niet met de jTDS driver omdat die geen
- * {@code PreparedStatement.setNull(int, int, String)} methode heeft
- * geimplementeerd.</strong>
- *
  * @author Mark Prins
  */
 @RunWith(Parameterized.class)
-@Category(JTDSDriverBasedFailures.class)
 public class AdvancedFunctionsActionBeanCleanupIntegrationTest extends TestUtil {
 
     private static final Log LOG = LogFactory.getLog(AdvancedFunctionsActionBeanCleanupIntegrationTest.class);

--- a/brmo-service/src/test/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsActionBeanIntegrationTest.java
+++ b/brmo-service/src/test/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsActionBeanIntegrationTest.java
@@ -103,8 +103,7 @@ public class AdvancedFunctionsActionBeanIntegrationTest extends TestUtil {
     public void setUp() throws Exception {
         assumeTrue("Het bestand met staging testdata zou moeten bestaan.", AdvancedFunctionsActionBeanIntegrationTest.class.getResource(sBestandsNaam) != null);
         assumeTrue("Het bestand met rsgb testdata zou moeten bestaan.", AdvancedFunctionsActionBeanIntegrationTest.class.getResource(rBestandsNaam) != null);
-        assumeTrue("Deze test werkt niet met de jTDS driver omdat die geen PreparedStatement.setNull(int, int, String) methode heeft geimplementeerd.",
-                !this.isMsSQL);
+        // assumeTrue("Deze test werkt niet met de jTDS driver omdat die geen PreparedStatement.setNull(int, int, String) methode heeft geimplementeerd.", !this.isMsSQL);
 
         bean = new AdvancedFunctionsActionBean();
         

--- a/brmo-service/src/test/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsActionBeanIntegrationTest.java
+++ b/brmo-service/src/test/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsActionBeanIntegrationTest.java
@@ -14,10 +14,8 @@ import net.sourceforge.stripes.action.ActionBeanContext;
 import nl.b3p.brmo.loader.BrmoFramework;
 import nl.b3p.brmo.loader.entity.Bericht;
 import nl.b3p.brmo.service.testutil.TestUtil;
-import nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures;
 import nl.b3p.brmo.test.util.database.dbunit.CleanUtil;
 import nl.b3p.loader.jdbc.OracleConnectionUnwrapper;
-import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.dbunit.database.DatabaseConfig;
@@ -53,14 +51,9 @@ import static org.mockito.Mockito.when;
  * {@code mvn -Dit.test=AdvancedFunctionsActionBeanIntegrationTest -Dtest.onlyITs=true verify -Ppostgresql > target/postgresql.log}
  * voor PostgreSQL.
  *
- * <strong>Deze test werkt niet met de jTDS driver omdat die geen
- * {@code PreparedStatement.setNull(int, int, String)} methode heeft
- * geimplementeerd.</strong>
- *
  * @author mprins
  */
 @RunWith(Parameterized.class)
-@Category(JTDSDriverBasedFailures.class)
 public class AdvancedFunctionsActionBeanIntegrationTest extends TestUtil {
 
     private static final Log LOG = LogFactory.getLog(AdvancedFunctionsActionBeanIntegrationTest.class);

--- a/brmo-service/src/test/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest.java
+++ b/brmo-service/src/test/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest.java
@@ -15,10 +15,8 @@ import net.sourceforge.stripes.action.ActionBeanContext;
 import nl.b3p.brmo.loader.BrmoFramework;
 import nl.b3p.brmo.loader.entity.Bericht;
 import nl.b3p.brmo.service.testutil.TestUtil;
-import nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures;
 import nl.b3p.brmo.test.util.database.dbunit.CleanUtil;
 import nl.b3p.loader.jdbc.OracleConnectionUnwrapper;
-import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.dbunit.database.DatabaseConfig;
@@ -56,14 +54,9 @@ import static org.mockito.Mockito.when;
  *
  * @see AdvancedFunctionsActionBeanIntegrationTest
  *
- * <strong>Deze test werkt niet met de jTDS driver omdat die geen
- * {@code PreparedStatement.setNull(int, int, String)} methode heeft
- * geimplementeerd.</strong>
- *
  * @author mprins
  */
 @RunWith(Parameterized.class)
-@Category(JTDSDriverBasedFailures.class)
 public class AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest extends TestUtil {
 
     private static final Log LOG = LogFactory.getLog(AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest.class);

--- a/brmo-service/src/test/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest.java
+++ b/brmo-service/src/test/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest.java
@@ -15,6 +15,7 @@ import net.sourceforge.stripes.action.ActionBeanContext;
 import nl.b3p.brmo.loader.BrmoFramework;
 import nl.b3p.brmo.loader.entity.Bericht;
 import nl.b3p.brmo.service.testutil.TestUtil;
+import nl.b3p.brmo.test.util.database.MSSqlServerDriverBasedFailures;
 import nl.b3p.brmo.test.util.database.dbunit.CleanUtil;
 import nl.b3p.loader.jdbc.OracleConnectionUnwrapper;
 import org.apache.commons.logging.Log;
@@ -59,6 +60,7 @@ import static org.mockito.Mockito.when;
  * @author mprins
  */
 @RunWith(Parameterized.class)
+@Category({ MSSqlServerDriverBasedFailures.class })
 public class AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest extends TestUtil {
 
     private static final Log LOG = LogFactory.getLog(AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest.class);

--- a/brmo-service/src/test/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest.java
+++ b/brmo-service/src/test/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest.java
@@ -106,8 +106,7 @@ public class AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest exte
     public void setUp() throws Exception {
         assumeTrue("Het bestand met staging testdata zou moeten bestaan.", AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest.class.getResource(sBestandsNaam) != null);
         assumeTrue("Het bestand met rsgb testdata zou moeten bestaan.", AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest.class.getResource(rBestandsNaam) != null);
-        assumeTrue("Deze test werkt niet met de jTDS driver omdat die geen PreparedStatement.setNull(int, int, String) methode heeft geimplementeerd.",
-                !this.isMsSQL);
+        // assumeTrue("Deze test werkt niet met de jTDS driver omdat die geen PreparedStatement.setNull(int, int, String) methode heeft geimplementeerd.", !this.isMsSQL);
 
         bean = new AdvancedFunctionsActionBean();
         

--- a/brmo-service/src/test/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest.java
+++ b/brmo-service/src/test/java/nl/b3p/brmo/service/stripes/AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest.java
@@ -50,7 +50,9 @@ import static org.mockito.Mockito.when;
  * {@code mvn -Dit.test=AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest -Dtest.onlyITs=true verify -Poracle > target/oracle.log}
  * voor bijvoorbeeld Oracle of
  * {@code mvn -Dit.test=AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest -Dtest.onlyITs=true verify -Ppostgresql -pl brmo-service > target/postgresql.log}
- * voor PostgreSQL.
+ * voor PostgreSQL of
+ * {@code mvn -Dit.test=AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest -Dtest.onlyITs=true verify -Pmssql -pl brmo-service > target/mssql.log}
+ * voor MS SQL.
  *
  * @see AdvancedFunctionsActionBeanIntegrationTest
  *
@@ -99,7 +101,6 @@ public class AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest exte
     public void setUp() throws Exception {
         assumeTrue("Het bestand met staging testdata zou moeten bestaan.", AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest.class.getResource(sBestandsNaam) != null);
         assumeTrue("Het bestand met rsgb testdata zou moeten bestaan.", AdvancedFunctionsAfterAddingBeginDateActionBeanIntegrationTest.class.getResource(rBestandsNaam) != null);
-        // assumeTrue("Deze test werkt niet met de jTDS driver omdat die geen PreparedStatement.setNull(int, int, String) methode heeft geimplementeerd.", !this.isMsSQL);
 
         bean = new AdvancedFunctionsActionBean();
         

--- a/brmo-service/src/test/java/nl/b3p/brmo/service/testutil/TestUtil.java
+++ b/brmo-service/src/test/java/nl/b3p/brmo/service/testutil/TestUtil.java
@@ -100,7 +100,7 @@ public abstract class TestUtil {
         }
 
         isOracle = "oracle".equalsIgnoreCase(DBPROPS.getProperty("dbtype"));
-        isMsSQL = "jtds-sqlserver".equalsIgnoreCase(DBPROPS.getProperty("dbtype"));
+        isMsSQL = "sqlserver".equalsIgnoreCase(DBPROPS.getProperty("dbtype"));
         isPostgis = "postgis".equalsIgnoreCase(DBPROPS.getProperty("dbtype"));
 
         try {

--- a/brmo-service/src/test/java/nl/b3p/brmo/service/testutil/TestUtil.java
+++ b/brmo-service/src/test/java/nl/b3p/brmo/service/testutil/TestUtil.java
@@ -55,6 +55,7 @@ public abstract class TestUtil {
     protected BasicDataSource dsStaging;
     protected BasicDataSource dsRsgb;
     protected BasicDataSource dsRsgbBgt;
+    protected BasicDataSource dsTopnl;
 
     /**
      * logging rule.
@@ -126,12 +127,18 @@ LOG.info("create ds staging");
         dsRsgb.setMaxActive(5);
 
         dsRsgbBgt = new BasicDataSource();
-        dsRsgbBgt.setUrl(DBPROPS.getProperty("rsgb.url"));
-        dsRsgbBgt.setUsername(DBPROPS.getProperty("rsgb.username"));
-        dsRsgbBgt.setPassword(DBPROPS.getProperty("rsgb.password"));
+        dsRsgbBgt.setUrl(DBPROPS.getProperty("rsgbbgt.url"));
+        dsRsgbBgt.setUsername(DBPROPS.getProperty("rsgbbgt.username"));
+        dsRsgbBgt.setPassword(DBPROPS.getProperty("rsgbbgt.password"));
         dsRsgbBgt.setAccessToUnderlyingConnectionAllowed(true);
         dsRsgbBgt.setInitialSize(1);
         dsRsgbBgt.setMaxActive(5);
+
+        dsTopnl= new BasicDataSource();
+        dsTopnl.setUrl(DBPROPS.getProperty("topnl.url"));
+        dsTopnl.setUsername(DBPROPS.getProperty("topnl.username"));
+        dsTopnl.setPassword(DBPROPS.getProperty("topnl.password"));
+        dsTopnl.setAccessToUnderlyingConnectionAllowed(true);
 
         setupJNDI();
     }
@@ -165,10 +172,11 @@ LOG.info("create ds staging");
      */
     protected void setupJNDI() {
         if (!haveSetupJNDI) {
+            System.setProperty(Context.INITIAL_CONTEXT_FACTORY, "org.apache.naming.java.javaURLContextFactory");
+            System.setProperty(Context.URL_PKG_PREFIXES, "org.apache.naming");
+            InitialContext ic;
             try {
-                System.setProperty(Context.INITIAL_CONTEXT_FACTORY, "org.apache.naming.java.javaURLContextFactory");
-                System.setProperty(Context.URL_PKG_PREFIXES, "org.apache.naming");
-                InitialContext ic = new InitialContext();
+                ic = new InitialContext();
                 ic.createSubcontext("java:");
                 ic.createSubcontext("java:comp");
                 ic.createSubcontext("java:comp/env");
@@ -176,12 +184,13 @@ LOG.info("create ds staging");
                 ic.createSubcontext("java:comp/env/jdbc/brmo");
                 ic.bind("java:comp/env/jdbc/brmo/rsgb", dsRsgb);
                 ic.bind("java:comp/env/jdbc/brmo/staging", dsStaging);
-                ic.bind("java:comp/env/jdbc/brmo/staging", dsRsgbBgt);
-                haveSetupJNDI = true;
-            } catch (NameAlreadyBoundException ex) {
-                LOG.trace("Opzetten van nieuwe datasource jndi is mislukt: " + ex.getLocalizedMessage());
+                ic.bind("java:comp/env/jdbc/brmo/rsgbbgt", dsRsgbBgt);
+                ic.bind("java:comp/env/jdbc/brmo/topnl", dsTopnl);
             } catch (NamingException ex) {
-                LOG.warn("Opzetten van datasource jndi is mislukt", ex);
+                LOG.warn("Opzetten van datasource jndi is mislukt: " + ex.getLocalizedMessage());
+                LOG.trace("Opzetten van datasource jndi is mislukt:", ex);
+            } finally {
+                haveSetupJNDI = true;
             }
         }
     }

--- a/brmo-service/src/test/resources/sqlserver.properties
+++ b/brmo-service/src/test/resources/sqlserver.properties
@@ -1,19 +1,18 @@
-dbtype=jtds-sqlserver
+dbtype=sqlserver
+jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
 
 rsgb.username=sa
 rsgb.password=Password12!
-rsgb.url=jdbc:jtds:sqlserver://127.0.0.1:1433/rsgb;instance=${mssql.instancename}
+rsgb.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;instance=${mssql.instancename}
 
 staging.username=sa
 staging.password=Password12!
-staging.url=jdbc:jtds:sqlserver://127.0.0.1:1433/staging;instance=${mssql.instancename}
+staging.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;instance=${mssql.instancename}
 
-jdbc.driverClassName=net.sourceforge.jtds.jdbc.Driver
-
-rsgbbgt.url=jdbc:jtds:sqlserver://127.0.0.1:1433/bgttest;instance=${mssql.instancename}
+rsgbbgt.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;instance=${mssql.instancename}
 rsgbbgt.username=sa
 rsgbbgt.password=Password12!
 
-topnl.url=jdbc:jtds:sqlserver://127.0.0.1:1433/topnl;instance=${mssql.instancename}
-topnl.username=topnl
-topnl.password=topnl
+topnl.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=topnl;instance=${mssql.instancename}
+topnl.username=sa
+topnl.password=Password12!

--- a/brmo-soap/pom.xml
+++ b/brmo-soap/pom.xml
@@ -41,8 +41,8 @@
                     <artifactId>postgis-jdbc</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>net.sourceforge.jtds</groupId>
-                    <artifactId>jtds</artifactId>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -69,8 +69,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.jtds</groupId>
-            <artifactId>jtds</artifactId>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -208,8 +208,8 @@
             </properties>
             <dependencies>
                 <dependency>
-                    <groupId>net.sourceforge.jtds</groupId>
-                    <artifactId>jtds</artifactId>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
                 </dependency>
             </dependencies>
             <build>

--- a/brmo-soap/pom.xml
+++ b/brmo-soap/pom.xml
@@ -220,7 +220,7 @@
                             <systemPropertyVariables>
                                 <database.properties.file>sqlserver.properties</database.properties.file>
                             </systemPropertyVariables>
-                            <excludedGroups>nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures</excludedGroups>
+                            <excludedGroups>nl.b3p.brmo.test.util.database.MSSqlServerDriverBasedFailures</excludedGroups>
                             <argLine>-XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
                         </configuration>
                     </plugin>

--- a/brmo-soap/src/main/java/nl/b3p/brmo/soap/db/BrkInfo.java
+++ b/brmo-soap/src/main/java/nl/b3p/brmo/soap/db/BrkInfo.java
@@ -167,7 +167,7 @@ public class BrkInfo {
                 sql.append(createWhereSQL(searchContext, dbType));
                 sql.append("LIMIT ");
                 sql.append(maxrows);
-                return sql;
+                break;
             case DB_ORACLE:
                 sql.append("SELECT ");
                 sql.append("    DISTINCT kad_onrrnd_zk.kad_identif AS identificatie ");
@@ -181,22 +181,23 @@ public class BrkInfo {
                 tempSql.append(" ) WHERE ROWNUM <= ");
                 tempSql.append(maxrows);
                 sql = tempSql;
-                return sql;
+                break;
             case DB_MSSQL:
-                sql.append("SELECT ");
+                sql.append("SELECT DISTINCT ");
                 sql.append("TOP ");
                 sql.append("( ");
                 sql.append(maxrows);
                 sql.append(") ");
-                sql.append("    DISTINCT kad_onrrnd_zk.kad_identif AS identificatie ");
+                sql.append("     kad_onrrnd_zk.kad_identif AS identificatie ");
                 sql.append("FROM ");
                 sql.append(createFromSQL());
                 sql.append("WHERE ");
                 sql.append(createWhereSQL(searchContext, dbType));
-                return sql;
+                break;
             default:
-                throw new UnsupportedOperationException("Unknown database!");
+                throw new UnsupportedOperationException("Unknown database! '" + dbType + "'");
         }
+        return sql;
     }
 
     private static StringBuilder createCountSQL(
@@ -394,20 +395,20 @@ public class BrkInfo {
             case DB_MSSQL:
                 if (bl != null) {
                     condition = "kad_perceel.begrenzing_perceel.STIntersects( "
-                            + "STGeomFromText('"
+                            + "geometry::STGeomFromText('"
                             + zg
                             + "',28992).STBuffer("
                             + bl
-                            + ") ) ";
+                            + ") ) = 1";
                 } else {
                     condition = "kad_perceel.begrenzing_perceel.STIntersects( "
-                            + "STGeomFromText('"
+                            + "geometry::STGeomFromText('"
                             + zg
-                            + "',28992) ) ";
-                    break;
+                            + "',28992) ) = 1";
                 }
+                break;
             default:
-                throw new UnsupportedOperationException("Unknown database!");
+                throw new UnsupportedOperationException("Unknown database! '" + dbType + "'");
         }
         if (!first) {
             sql.append("AND ");

--- a/brmo-soap/src/main/java/nl/b3p/brmo/soap/db/EigendomInfo.java
+++ b/brmo-soap/src/main/java/nl/b3p/brmo/soap/db/EigendomInfo.java
@@ -488,6 +488,9 @@ public class EigendomInfo {
             StringBuilder resultNames = new StringBuilder();
             resultNames.append(" gpa.perceel_identif as perceel_identif ");
             StringBuilder fromSQL = new StringBuilder(" mb_util_app_re_kad_perceel gpa ");
+            if (dbType.equalsIgnoreCase(DB_MSSQL)) {
+                fromSQL = new StringBuilder(" vb_util_app_re_kad_perceel gpa ");
+            }
             StringBuilder whereSQL = new StringBuilder(" gpa.app_re_identif = ? ");
 
             StringBuilder sql = createSelectSQL(resultNames, fromSQL, whereSQL, null, dbType);

--- a/brmo-soap/src/test/java/nl/b3p/brmo/soap/db/BrkInfoIntegrationTest.java
+++ b/brmo-soap/src/test/java/nl/b3p/brmo/soap/db/BrkInfoIntegrationTest.java
@@ -12,12 +12,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import nl.b3p.brmo.service.util.ConfigUtil;
 import nl.b3p.brmo.soap.brk.BrkInfoRequest;
 import nl.b3p.brmo.soap.brk.BrkInfoResponse;
 import nl.b3p.brmo.soap.brk.KadOnrndZkInfoRequest;
 import nl.b3p.brmo.soap.brk.KadOnrndZkInfoResponse;
-import nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures;
 import nl.b3p.brmo.test.util.database.dbunit.CleanUtil;
 import org.dbunit.database.DatabaseConfig;
 import org.dbunit.database.DatabaseDataSourceConnection;
@@ -32,12 +30,10 @@ import org.dbunit.operation.DatabaseOperation;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 
 /**
  *
@@ -45,17 +41,12 @@ import static org.junit.Assert.assertNotNull;
  * {@code mvn -Dit.test=BrkInfoIntegrationTest -Dtest.onlyITs=true verify -Ppostgresql > target/postgresql.log}
  * voor bijvoorbeeld PostgreSQL.
  *
- * <strong>Werkt niet met MS SQl server omdat de JTDS een
- * {@code java.lang.AbstractMethodError} opwerpt op aanroep van
- * {@code JtdsConnection.isValid(..)}</strong>
- *
  * @author mprins
  */
 @RunWith(Parameterized.class)
-@Category(JTDSDriverBasedFailures.class)
 public class BrkInfoIntegrationTest extends TestUtil {
 
-    @Parameterized.Parameters(name = "{index}: verwerken bestand: {0}")
+    @Parameterized.Parameters(name = "{index}: laden bestand: {0}")
     public static Collection params() {
         return Arrays.asList(new Object[][]{
             // {"sBestandsNaam", aantalPercelen, zoekLocatie, bufferAfstand,eersteKadId,oppPerceel,aardCultuurOnbebouwd, gemCode, perceelNummer},
@@ -102,8 +93,9 @@ public class BrkInfoIntegrationTest extends TestUtil {
         IDataSet rsgbDataSet = new XmlDataSet(new FileInputStream(new File(BrkInfoIntegrationTest.class.getResource(sBestandsNaam).toURI())));
 
         if (this.isMsSQL) {
-            // TODO kijken of en hoe dit op mssql werkt, vooralsnog problemen met jDTS driver
             rsgb.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new MsSqlDataTypeFactory());
+
+            rsgbDataSet = new XmlDataSet(new FileInputStream(new File(BrkInfoIntegrationTest.class.getResource("/mssql-" + sBestandsNaam.substring(1)).toURI())));
         } else if (this.isOracle) {
             rsgb = new DatabaseConnection(dsRsgb.getConnection().unwrap(oracle.jdbc.OracleConnection.class), DBPROPS.getProperty("rsgb.username").toUpperCase());
             rsgb.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new Oracle10DataTypeFactory());

--- a/brmo-soap/src/test/java/nl/b3p/brmo/soap/db/TestUtil.java
+++ b/brmo-soap/src/test/java/nl/b3p/brmo/soap/db/TestUtil.java
@@ -29,7 +29,7 @@ import org.junit.rules.TestName;
  */
 public abstract class TestUtil {
 
-    private static boolean haveSetupJNDI = false;
+    protected static boolean haveSetupJNDI = false;
 
     private static final Log LOG = LogFactory.getLog(TestUtil.class);
     /**
@@ -123,7 +123,7 @@ public abstract class TestUtil {
         dsStaging.setPassword(DBPROPS.getProperty("staging.password"));
         dsStaging.setAccessToUnderlyingConnectionAllowed(true);
 
-        this.setupJNDI(dsRsgb, dsStaging);
+        this.setupJNDI();
     }
 
     /**
@@ -143,17 +143,15 @@ public abstract class TestUtil {
     }
 
     /**
-     * setup jndi voor testcases.
-     *
-     * @param dsRsgb rsgb databron
-     * @param dsStaging staging databron
+     * setup jndi voor testcases, doet 1 poging om jndi context te initialiseren.
      */
-    protected void setupJNDI(final BasicDataSource dsRsgb, final BasicDataSource dsStaging) {
+    protected void setupJNDI() {
         if (!haveSetupJNDI) {
+            System.setProperty(Context.INITIAL_CONTEXT_FACTORY, "org.apache.naming.java.javaURLContextFactory");
+            System.setProperty(Context.URL_PKG_PREFIXES, "org.apache.naming");
+            InitialContext ic;
             try {
-                System.setProperty(Context.INITIAL_CONTEXT_FACTORY, "org.apache.naming.java.javaURLContextFactory");
-                System.setProperty(Context.URL_PKG_PREFIXES, "org.apache.naming");
-                InitialContext ic = new InitialContext();
+                ic = new InitialContext();
                 ic.createSubcontext("java:");
                 ic.createSubcontext("java:comp");
                 ic.createSubcontext("java:comp/env");
@@ -161,11 +159,11 @@ public abstract class TestUtil {
                 ic.createSubcontext("java:comp/env/jdbc/brmo");
                 ic.bind("java:comp/env/jdbc/brmo/rsgb", dsRsgb);
                 ic.bind("java:comp/env/jdbc/brmo/staging", dsStaging);
-                haveSetupJNDI = true;
-            } catch (NameAlreadyBoundException ex) {
-                LOG.trace("Opzetten van nieuwe datasource jndi is mislukt: " + ex.getLocalizedMessage());
             } catch (NamingException ex) {
-                LOG.warn("Opzetten van datasource jndi is mislukt", ex);
+                LOG.warn("Opzetten van datasource jndi is mislukt: " + ex.getLocalizedMessage());
+                LOG.trace("Opzetten van datasource jndi is mislukt", ex);
+            } finally {
+                haveSetupJNDI = true;
             }
         }
     }

--- a/brmo-soap/src/test/java/nl/b3p/brmo/soap/db/TestUtil.java
+++ b/brmo-soap/src/test/java/nl/b3p/brmo/soap/db/TestUtil.java
@@ -102,7 +102,7 @@ public abstract class TestUtil {
         }
 
         isOracle = "oracle".equalsIgnoreCase(DBPROPS.getProperty("dbtype"));
-        isMsSQL = "jtds-sqlserver".equalsIgnoreCase(DBPROPS.getProperty("dbtype"));
+        isMsSQL = "sqlserver".equalsIgnoreCase(DBPROPS.getProperty("dbtype"));
         isPostgis = "postgis".equalsIgnoreCase(DBPROPS.getProperty("dbtype"));
 
         try {

--- a/brmo-soap/src/test/resources/mssql-rsgb.xml
+++ b/brmo-soap/src/test/resources/mssql-rsgb.xml
@@ -1,0 +1,607 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+  <table name="kad_onrrnd_zk">
+    <column>dat_beg_geldh</column>
+    <column>kad_identif</column>
+    <column>clazz</column>
+    <column>datum_einde_geldh</column>
+    <column>typering</column>
+    <column>fk_7kdg_code</column>
+    <column>fk_10pes_sc_identif</column>
+    <column>cu_aard_bebouwing</column>
+    <column>cu_aard_cultuur_onbebouwd</column>
+    <column>cu_meer_culturen</column>
+    <column>ks_aard_bedrag</column>
+    <column>ks_bedrag</column>
+    <column>ks_koopjaar</column>
+    <column>ks_meer_onroerendgoed</column>
+    <column>ks_transactiedatum</column>
+    <column>ks_valutasoort</column>
+    <column>lr_aand_aard_liproject</column>
+    <column>lr_aard_bedrag</column>
+    <column>lr_bedrag</column>
+    <column>lr_eindjaar</column>
+    <column>lr_valutasoort</column>
+    <column>lo_cultuur_bebouwd</column>
+    <column>lo_loc__omschr</column>
+    <row>
+      <value>2015-12-19</value>
+      <value>66860489870000</value>
+      <value><![CDATA[KADASTRAAL PERCEEL]]></value>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <value>Wegen</value>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <value>N</value>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <value><![CDATA[BERGWG ,  MARKELO]]></value>
+    </row>
+  </table>
+  <table name="kad_onrrnd_zk_archief">
+    <column>dat_beg_geldh</column>
+    <column>kad_identif</column>
+    <column>clazz</column>
+    <column>datum_einde_geldh</column>
+    <column>typering</column>
+    <column>fk_7kdg_code</column>
+    <column>fk_10pes_sc_identif</column>
+    <column>cu_aard_bebouwing</column>
+    <column>cu_aard_cultuur_onbebouwd</column>
+    <column>cu_meer_culturen</column>
+    <column>ks_aard_bedrag</column>
+    <column>ks_bedrag</column>
+    <column>ks_koopjaar</column>
+    <column>ks_meer_onroerendgoed</column>
+    <column>ks_transactiedatum</column>
+    <column>ks_valutasoort</column>
+    <column>lr_aand_aard_liproject</column>
+    <column>lr_aard_bedrag</column>
+    <column>lr_bedrag</column>
+    <column>lr_eindjaar</column>
+    <column>lr_valutasoort</column>
+    <column>lo_cultuur_bebouwd</column>
+    <column>lo_loc__omschr</column>
+  </table>
+  <table name="kad_onrrnd_zk_his_rel">
+    <column>fk_sc_lh_koz_kad_identif</column>
+    <column>fk_sc_rh_koz_kad_identif</column>
+    <column>aard</column>
+    <column>overgangsgrootte</column>
+    <row>
+      <value>66860489870000</value>
+      <value>66860477740001</value>
+      <value>Vernummering</value>
+      <value>1050</value>
+    </row>
+  </table>
+  <table name="kad_perceel">
+    <column>sc_kad_identif</column>
+    <column>aand_soort_grootte</column>
+    <column>grootte_perceel</column>
+    <column>omschr_deelperceel</column>
+    <column>fk_7kdp_sc_kad_identif</column>
+    <column>ka_deelperceelnummer</column>
+    <column>ka_kad_gemeentecode</column>
+    <column>ka_perceelnummer</column>
+    <column>ka_sectie</column>
+    <column>begrenzing_perceel</column>
+    <column>plaatscoordinaten_perceel</column>
+    <row>
+      <value>66860489870000</value>
+      <value>2</value>
+      <value>1050</value>
+      <null/>
+      <null/>
+      <null/>
+      <value>MKL00</value>
+      <value>4898</value>
+      <value>I</value>
+      <!--
+      SRID=28992;
+      MULTIPOLYGON(((230327.011 472276.239,230310.03 472253.304,230339.42 472232.356,230348.708 472222.815,230356.724 472232.803,230354.168 472236.752,230343.558 472241.686,230322.094 472256.985,230348.24 472292.318,230381.278 472269.529,230383.865 472271.388,230344.43 472299.776,230327.011 472276.239)))
+       -->
+      <value><![CDATA[QHEAAAEEDQAAAAIrhxa4HQxBf2q89FDTHEHXo3A9MB0MQajGSzf10hxBw/UoXBseDEGWQ4tsodIc
+QW3n+6llHgxBKVyPQnvSHEESg8DKpR4MQcuhRTaj0hxBTmIQWJEeDEG6SQwCs9IcQTm0yHY8HgxB
+tMh2vsbSHEFvEoPAkB0MQQrXo/AD0xxBuB6F62EeDEHByqFFkdMcQWIQWDlqHwxBDi2yHTbTHEG4
+HoXrfh8MQTvfT4090xxBCtejcEMeDEF3vp8ar9McQQIrhxa4HQxBf2q89FDTHEEBAAAAAgAAAAAC
+AAAA/////wAAAAAGAAAAAAAAAAAD]]></value>
+      <!--
+      SRID=28992;
+      POINT(230341.934 472237.863)
+      -->
+      <value>QHEAAAEM9P3UeC8eDEGiRbZzt9IcQQ==</value>
+    </row>
+  </table>
+  <table name="kad_perceel_archief">
+    <column>sc_dat_beg_geldh</column>
+    <column>sc_kad_identif</column>
+    <column>aand_soort_grootte</column>
+    <column>grootte_perceel</column>
+    <column>omschr_deelperceel</column>
+    <column>fk_7kdp_sc_kad_identif</column>
+    <column>ka_deelperceelnummer</column>
+    <column>ka_kad_gemeentecode</column>
+    <column>ka_perceelnummer</column>
+    <column>ka_sectie</column>
+    <column>begrenzing_perceel</column>
+    <column>plaatscoordinaten_perceel</column>
+  </table>
+  <table name="subject">
+    <column>identif</column>
+    <column>clazz</column>
+    <column>adres_binnenland</column>
+    <column>adres_buitenland</column>
+    <column>emailadres</column>
+    <column>fax_nummer</column>
+    <column>kvk_nummer</column>
+    <column>naam</column>
+    <column>typering</column>
+    <column>telefoonnummer</column>
+    <column>website_url</column>
+    <column>fk_13wpl_identif</column>
+    <column>fk_14aoa_identif</column>
+    <column>fk_15aoa_identif</column>
+    <column>pa_postadres_postcode</column>
+    <column>pa_postadrestype</column>
+    <column>pa_postbus__of_antwoordnummer</column>
+    <column>fk_pa_4_wpl_identif</column>
+    <column>rn_bankrekeningnummer</column>
+    <column>rn_bic</column>
+    <column>rn_iban</column>
+    <column>vb_adres_buitenland_1</column>
+    <column>vb_adres_buitenland_2</column>
+    <column>vb_adres_buitenland_3</column>
+    <column>fk_vb_lnd_code_iso</column>
+    <row>
+      <value>NL.KAD.Persoon.317071845</value>
+      <value><![CDATA[INGESCHREVEN NIET-NATUURLIJK PERSOON]]></value>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <value>6050036</value>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+    </row>
+    <row>
+      <value>NL.KAD.Persoon.326751636</value>
+      <value><![CDATA[INGESCHREVEN NIET-NATUURLIJK PERSOON]]></value>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+    </row>
+  </table>
+  <table name="prs">
+    <column>sc_identif</column>
+    <column>clazz</column>
+    <row>
+      <value>NL.KAD.Persoon.317071845</value>
+      <value><![CDATA[INGESCHREVEN NIET-NATUURLIJK PERSOON]]></value>
+    </row>
+    <row>
+      <value>NL.KAD.Persoon.326751636</value>
+      <value><![CDATA[INGESCHREVEN NIET-NATUURLIJK PERSOON]]></value>
+    </row>
+  </table>
+  <table name="niet_nat_prs">
+    <column>sc_identif</column>
+    <column>clazz</column>
+    <column>naam</column>
+    <column>datum_aanvang</column>
+    <column>datum_beeindiging</column>
+    <column>verkorte_naam</column>
+    <row>
+      <value>NL.KAD.Persoon.317071845</value>
+      <value><![CDATA[INGESCHREVEN NIET-NATUURLIJK PERSOON]]></value>
+      <value><![CDATA[COGAS KABEL INFRA BV]]></value>
+      <null/>
+      <null/>
+      <null/>
+    </row>
+    <row>
+      <value>NL.KAD.Persoon.326751636</value>
+      <value><![CDATA[INGESCHREVEN NIET-NATUURLIJK PERSOON]]></value>
+      <value><![CDATA[Voor tenaamsteling mandelig perceel zie hoofdpercelen: betreft Plan Roosenburg  aan de Bergweg te Markelo (kavels 1 tot en met 5)]]></value>
+      <null/>
+      <null/>
+      <null/>
+    </row>
+  </table>
+  <table name="ingeschr_niet_nat_prs">
+    <column>sc_identif</column>
+    <column>typering</column>
+    <column>ovrg_privaatr_rechtsvorm</column>
+    <column>publiekrechtelijke_rechtsvorm</column>
+    <column>rechtstoestand</column>
+    <column>rechtsvorm</column>
+    <column>rsin</column>
+    <column>statutaire_zetel</column>
+    <column>fk_8aoa_identif</column>
+    <row>
+      <value>NL.KAD.Persoon.317071845</value>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <value><![CDATA[Besloten vennootschap]]></value>
+      <value>6403025</value>
+      <value>ALMELO</value>
+      <null/>
+    </row>
+    <row>
+      <value>NL.KAD.Persoon.326751636</value>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <value><![CDATA[Betreft mandeligheid]]></value>
+      <null/>
+      <value>MARKELO</value>
+      <null/>
+    </row>
+  </table>
+  <table name="herkomst_metadata">
+    <column>tabel</column>
+    <column>kolom</column>
+    <column>waarde</column>
+    <column>herkomst_br</column>
+    <column>datum</column>
+    <row>
+      <value>subject</value>
+      <value>identif</value>
+      <value>NL.KAD.Persoon.317071845</value>
+      <value>brk</value>
+      <value><![CDATA[2015-12-19 00:00:00.0]]></value>
+    </row>
+    <row>
+      <value>subject</value>
+      <value>identif</value>
+      <value>NL.KAD.Persoon.326751636</value>
+      <value>brk</value>
+      <value><![CDATA[2015-12-19 00:00:00.0]]></value>
+    </row>
+  </table>
+  <table name="kad_onrrnd_zk_aantek">
+    <column>begindatum_aantek_kad_obj</column>
+    <column>kadaster_identif_aantek</column>
+    <column>aard_aantek_kad_obj</column>
+    <column>beschrijving_aantek_kad_obj</column>
+    <column>eindd_aantek_kad_obj</column>
+    <column>fk_4koz_kad_identif</column>
+    <column>fk_5pes_sc_identif</column>
+    <row>
+      <value>2015-12-19</value>
+      <value>NL.KAD.Aantekening.AKR1.100000008509835</value>
+      <value><![CDATA[Kwalitatieve verplichting]]></value>
+      <null/>
+      <null/>
+      <value>66860489870000</value>
+      <null/>
+    </row>
+    <row>
+      <value>2015-12-19</value>
+      <value>NL.KAD.Aantekening.AKR1.100000008509855</value>
+      <value><![CDATA[Administratieve voorlopige (kadastrale) grens]]></value>
+      <null/>
+      <null/>
+      <value>66860489870000</value>
+      <null/>
+    </row>
+  </table>
+  <table name="kad_onrrnd_zk_aantek_archief">
+    <column>begindatum_aantek_kad_obj</column>
+    <column>kadaster_identif_aantek</column>
+    <column>aard_aantek_kad_obj</column>
+    <column>beschrijving_aantek_kad_obj</column>
+    <column>eindd_aantek_kad_obj</column>
+    <column>fk_4koz_kad_identif</column>
+    <column>fk_5pes_sc_identif</column>
+    <row>
+      <value>2015-12-19</value>
+      <value>NL.KAD.Aantekening.AKR1.100000008509835</value>
+      <value><![CDATA[Kwalitatieve verplichting]]></value>
+      <null/>
+      <null/>
+      <value>66860489870000</value>
+      <null/>
+    </row>
+    <row>
+      <value>2015-12-19</value>
+      <value>NL.KAD.Aantekening.AKR1.100000008509855</value>
+      <value><![CDATA[Administratieve voorlopige (kadastrale) grens]]></value>
+      <null/>
+      <null/>
+      <value>66860489870000</value>
+      <null/>
+    </row>
+  </table>
+  <table name="brondocument">
+    <column>tabel</column>
+    <column>tabel_identificatie</column>
+    <column>identificatie</column>
+    <column>gemeente</column>
+    <column>omschrijving</column>
+    <column>datum</column>
+    <column>ref_id</column>
+    <row>
+      <value>BRONDOCUMENT</value>
+      <value>NL.KAD.Kadasterstuk.AKR1.100000001867528</value>
+      <value>NL.KAD.Stukdeel.AKR1.100000006998026</value>
+      <null/>
+      <value><![CDATA[Metingstaat KAD 75 m.b.t. vernummering (matrix)]]></value>
+      <null/>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>BRONDOCUMENT</value>
+      <value>NL.KAD.TIAStuk.20091203001438</value>
+      <value>NL.KAD.Stukdeel.AKR1.100000001452526</value>
+      <null/>
+      <value><![CDATA[Akte van Koop en Verkoop]]></value>
+      <value>2009-12-03</value>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>BRONDOCUMENT</value>
+      <value>NL.KAD.TIAStuk.20091203001438</value>
+      <value>NL.KAD.Stukdeel.AKR1.100000001452527</value>
+      <null/>
+      <value><![CDATA[Akte van Koop en Verkoop]]></value>
+      <value>2009-12-03</value>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>BRONDOCUMENT</value>
+      <value>NL.KAD.TIAStuk.20091203001438</value>
+      <value>NL.KAD.Stukdeel.AKR1.100000001452528</value>
+      <null/>
+      <value><![CDATA[Stuk betreffende de bestemming van een onroerend goed tot gemeenschapp nut ivm mandeligheid (art. 1, Boek 5, BW)]]></value>
+      <value>2009-12-03</value>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>BRONDOCUMENT</value>
+      <value>NL.KAD.TIAStuk.20091203001438</value>
+      <value>NL.KAD.Stukdeel.AKR1.100000001452529</value>
+      <null/>
+      <value><![CDATA[Stuk betreffende de bestemming van een onroerend goed tot gemeenschapp nut ivm mandeligheid (art. 1, Boek 5, BW)]]></value>
+      <value>2009-12-03</value>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>BRONDOCUMENT</value>
+      <value>NL.KAD.TIAStuk.20091203001438</value>
+      <value>NL.KAD.Stukdeel.AKR1.100000001452530</value>
+      <null/>
+      <value><![CDATA[Akte van Vestiging Erfdienstbaarheden]]></value>
+      <value>2009-12-03</value>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>BRONDOCUMENT</value>
+      <value>NL.KAD.TIAStuk.20091203001438</value>
+      <value>NL.KAD.Stukdeel.AKR1.100000001452531</value>
+      <null/>
+      <value><![CDATA[Stuk betreffende bedingen inzake een kwalitatieve verbintenis (iets dulden of iets niet doen)]]></value>
+      <value>2009-12-03</value>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>BRONDOCUMENT</value>
+      <value>NL.KAD.TIAStuk.20091203001438</value>
+      <value>NL.KAD.Stukdeel.AKR1.100000001452751</value>
+      <null/>
+      <value><![CDATA[Akte van Koop en Verkoop]]></value>
+      <value>2009-12-03</value>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>BRONDOCUMENT</value>
+      <value>NL.KAD.TIAStuk.20091203001438</value>
+      <value>NL.KAD.Stukdeel.AKR1.100000001452752</value>
+      <null/>
+      <value><![CDATA[Stuk betreffende de bestemming van een onroerend goed tot gemeenschapp nut ivm mandeligheid (art. 1, Boek 5, BW)]]></value>
+      <value>2009-12-03</value>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>BRONDOCUMENT</value>
+      <value>NL.KAD.TIAStuk.20091203001438</value>
+      <value>NL.KAD.Stukdeel.AKR1.100000001452753</value>
+      <null/>
+      <value><![CDATA[Stuk betreffende de bestemming van een onroerend goed tot gemeenschapp nut ivm mandeligheid (art. 1, Boek 5, BW)]]></value>
+      <value>2009-12-03</value>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>BRONDOCUMENT</value>
+      <value>NL.KAD.TIAStuk.20120125000041</value>
+      <value>NL.KAD.Stukdeel.AKR1.100000004484132</value>
+      <null/>
+      <value>Redresstuk</value>
+      <value>2012-01-25</value>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>BRONDOCUMENT</value>
+      <value>NL.KAD.TIAStuk.20120125000041</value>
+      <value>NL.KAD.Stukdeel.AKR1.100000004484133</value>
+      <null/>
+      <value><![CDATA[Aanbr/doorh recht van opstal mbt het leggen/ houden van leidingen cq recht van BP ingev art. 5, lid 3 letter B]]></value>
+      <value>2012-01-25</value>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>KAD_ONRRND_ZAAK_AANTEK</value>
+      <value>NL.KAD.Aantekening.AKR1.100000008509835</value>
+      <value>NL.KAD.Stukdeel.AKR1.100000001452531</value>
+      <null/>
+      <value><![CDATA[isGebaseerdOp Aantekening]]></value>
+      <value>2009-12-03</value>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>KAD_ONRRND_ZAAK_AANTEK</value>
+      <value>NL.KAD.Aantekening.AKR1.100000008509855</value>
+      <value>NL.KAD.Stukdeel.AKR1.100000006998026</value>
+      <null/>
+      <value><![CDATA[isGebaseerdOp Aantekening]]></value>
+      <null/>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>KAD_PERCEEL</value>
+      <value>66860489870000</value>
+      <value>NL.KAD.Kadasterstuk.AKR1.100000001867528</value>
+      <null/>
+      <value><![CDATA[AKR Portefeuille Nr: 75 MKL0002014007]]></value>
+      <null/>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>KAD_PERCEEL</value>
+      <value>66860489870000</value>
+      <value>NL.KAD.TIAStuk.20091203001438</value>
+      <null/>
+      <value><![CDATA[deel: 57554, nummer: 56, registercode: Hyp4, soortregister: Onroerende Zaken]]></value>
+      <value>2009-12-03</value>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>KAD_PERCEEL</value>
+      <value>66860489870000</value>
+      <value>NL.KAD.TIAStuk.20120125000041</value>
+      <null/>
+      <value><![CDATA[deel: 61053, nummer: 70, registercode: Hyp4, soortregister: Onroerende Zaken]]></value>
+      <value>2012-01-25</value>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>ZAK_RECHT</value>
+      <value>NL.KAD.Tenaamstelling.AKR1.100000007911886</value>
+      <value>NL.KAD.Stukdeel.AKR1.100000004484132</value>
+      <null/>
+      <value><![CDATA[isGebaseerdOp Tenaamstelling]]></value>
+      <value>2012-01-25</value>
+      <value>66860489870000</value>
+    </row>
+    <row>
+      <value>ZAK_RECHT</value>
+      <value>NL.KAD.Tenaamstelling.AKR1.100000007911923</value>
+      <value>NL.KAD.Stukdeel.AKR1.100000006998026</value>
+      <null/>
+      <value><![CDATA[isGebaseerdOp Tenaamstelling]]></value>
+      <null/>
+      <value>66860489870000</value>
+    </row>
+  </table>
+  <table name="zak_recht">
+    <column>kadaster_identif</column>
+    <column>eindd_recht</column>
+    <column>indic_betrokken_in_splitsing</column>
+    <column>ingangsdatum_recht</column>
+    <column>fk_7koz_kad_identif</column>
+    <column>fk_8pes_sc_identif</column>
+    <column>ar_noemer</column>
+    <column>ar_teller</column>
+    <column>fk_2aard_recht_verkort_aand</column>
+    <column>fk_3avr_aand</column>
+    <row>
+      <value>NL.KAD.Tenaamstelling.AKR1.100000007911886</value>
+      <null/>
+      <value>Nee</value>
+      <null/>
+      <value>66860489870000</value>
+      <value>NL.KAD.Persoon.317071845</value>
+      <value>1</value>
+      <value>1</value>
+      <null/>
+      <value>14</value>
+    </row>
+    <row>
+      <value>NL.KAD.Tenaamstelling.AKR1.100000007911923</value>
+      <null/>
+      <value>Nee</value>
+      <null/>
+      <value>66860489870000</value>
+      <value>NL.KAD.Persoon.326751636</value>
+      <value>1</value>
+      <value>1</value>
+      <null/>
+      <value>2</value>
+    </row>
+    <row>
+      <value>NL.KAD.ZakelijkRecht.AKR1.100000007911886</value>
+      <null/>
+      <value>Nee</value>
+      <null/>
+      <value>66860489870000</value>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <value>14</value>
+    </row>
+    <row>
+      <value>NL.KAD.ZakelijkRecht.AKR1.100000007911923</value>
+      <null/>
+      <value>Nee</value>
+      <null/>
+      <value>66860489870000</value>
+      <null/>
+      <null/>
+      <null/>
+      <null/>
+      <value>2</value>
+    </row>
+  </table>
+</dataset>

--- a/brmo-soap/src/test/resources/sqlserver.properties
+++ b/brmo-soap/src/test/resources/sqlserver.properties
@@ -1,11 +1,11 @@
-dbtype=jtds-sqlserver
+dbtype=sqlserver
 
 rsgb.username=sa
 rsgb.password=Password12!
-rsgb.url=jdbc:jtds:sqlserver://127.0.0.1:1433/rsgb;instance=${mssql.instancename}
+rsgb.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;instance=${mssql.instancename}
 
 staging.username=sa
 staging.password=Password12!
-staging.url=jdbc:jtds:sqlserver://127.0.0.1:1433/staging;instance=${mssql.instancename}
+staging.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;instance=${mssql.instancename}
 
-jdbc.driverClassName=net.sourceforge.jtds.jdbc.Driver
+jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver

--- a/brmo-stufbg204/pom.xml
+++ b/brmo-stufbg204/pom.xml
@@ -471,7 +471,7 @@
                             <systemPropertyVariables>
                                 <database.properties.file>sqlserver.properties</database.properties.file>
                             </systemPropertyVariables>
-                            <excludedGroups>nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures</excludedGroups>
+                            <excludedGroups>nl.b3p.brmo.test.util.database.MSSqlServerDriverBasedFailures</excludedGroups>
                             <argLine>-XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
                         </configuration>
                     </plugin>

--- a/brmo-stufbg204/pom.xml
+++ b/brmo-stufbg204/pom.xml
@@ -59,8 +59,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.jtds</groupId>
-            <artifactId>jtds</artifactId>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -390,8 +390,8 @@
             </properties>
             <dependencies>
                 <dependency>
-                    <groupId>net.sourceforge.jtds</groupId>
-                    <artifactId>jtds</artifactId>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
                 </dependency>
             </dependencies>
             <build>
@@ -463,11 +463,6 @@
                             </execution>
                         </executions>
                         <dependencies>
-<!--                            <dependency>-->
-<!--                                <groupId>net.sourceforge.jtds</groupId>-->
-<!--                                <artifactId>jtds</artifactId>-->
-<!--                                <version>${sqlserver.jtds.version}</version>-->
-<!--                            </dependency>-->
                         </dependencies>
                     </plugin>
                     <plugin>

--- a/brmo-stufbg204/src/test/java/nl/b3p/brmo/stufbg204/TestStub.java
+++ b/brmo-stufbg204/src/test/java/nl/b3p/brmo/stufbg204/TestStub.java
@@ -96,7 +96,7 @@ public abstract class TestStub {
         }
 
         isOracle = "oracle".equalsIgnoreCase(DBPROPS.getProperty("dbtype"));
-        isMsSQL = "jtds-sqlserver".equalsIgnoreCase(DBPROPS.getProperty("dbtype"));
+        isMsSQL = "sqlserver".equalsIgnoreCase(DBPROPS.getProperty("dbtype"));
         isPostgis = "postgis".equalsIgnoreCase(DBPROPS.getProperty("dbtype"));
 
         try {

--- a/brmo-stufbg204/src/test/resources/sqlserver.properties
+++ b/brmo-stufbg204/src/test/resources/sqlserver.properties
@@ -1,11 +1,11 @@
-dbtype=jtds-sqlserver
+dbtype=sqlserver
 
 rsgb.username=sa
 rsgb.password=Password12!
-rsgb.url=jdbc:jtds:sqlserver://127.0.0.1:1433/rsgb;instance=${mssql.instancename}
+rsgb.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;instance=${mssql.instancename}
 
 staging.username=sa
 staging.password=Password12!
-staging.url=jdbc:jtds:sqlserver://127.0.0.1:1433/staging;instance=${mssql.instancename}
+staging.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;instance=${mssql.instancename}
 
-jdbc.driverClassName=net.sourceforge.jtds.jdbc.Driver
+jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver

--- a/brmo-test-util/pom.xml
+++ b/brmo-test-util/pom.xml
@@ -37,8 +37,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.jtds</groupId>
-            <artifactId>jtds</artifactId>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/brmo-test-util/src/main/java/nl/b3p/brmo/test/util/database/HSQLDBDriverBasedFailures.java
+++ b/brmo-test-util/src/main/java/nl/b3p/brmo/test/util/database/HSQLDBDriverBasedFailures.java
@@ -2,11 +2,11 @@ package nl.b3p.brmo.test.util.database;
 
 /**
  * Een marker interface om integratie tests die mislukken vanwege manco's in de
- * HSQLDB driver aan te geven. Zie {@link JTDSDriverBasedFailures} voor
+ * HSQLDB driver aan te geven. Zie {@link PostgreSQLDriverBasedFailures} voor
  * gebruiksinstructie.
  *
  * @author mprins
- * @see JTDSDriverBasedFailures
+ * @see PostgreSQLDriverBasedFailures
  * @note marker interface
  * @see org.junit.experimental.categories.Category
  */

--- a/brmo-test-util/src/main/java/nl/b3p/brmo/test/util/database/JTDSDriverBasedFailures.java
+++ b/brmo-test-util/src/main/java/nl/b3p/brmo/test/util/database/JTDSDriverBasedFailures.java
@@ -50,7 +50,10 @@ package nl.b3p.brmo.test.util.database;
  * @author mprins
  * @note marker interface
  * @see org.junit.experimental.categories.Category
+ *
+ * @deprecated gebruik van de jTDS driver wordt afgeraden vanwege tal van ontbrekende functies in de driver.
  */
+@Deprecated
 public interface JTDSDriverBasedFailures {
 
 }

--- a/brmo-test-util/src/main/java/nl/b3p/brmo/test/util/database/MSSqlServerDriverBasedFailures.java
+++ b/brmo-test-util/src/main/java/nl/b3p/brmo/test/util/database/MSSqlServerDriverBasedFailures.java
@@ -18,11 +18,11 @@ package nl.b3p.brmo.test.util.database;
 
 /**
  * Een marker interface om integratie tests die mislukken vanwege manco's in de
- * MS SQL driver aan te geven. Zie {@link JTDSDriverBasedFailures} voor
+ * MS SQL driver aan te geven. Zie {@link PostgreSQLDriverBasedFailures} voor
  * gebruiksinstructie.
  *
  * @author mprins
- * @see JTDSDriverBasedFailures
+ * @see PostgreSQLDriverBasedFailures
  * @note marker interface
  * @see org.junit.experimental.categories.Category
  */

--- a/brmo-test-util/src/main/java/nl/b3p/brmo/test/util/database/OracleDriverBasedFailures.java
+++ b/brmo-test-util/src/main/java/nl/b3p/brmo/test/util/database/OracleDriverBasedFailures.java
@@ -18,11 +18,11 @@ package nl.b3p.brmo.test.util.database;
 
 /**
  * Een marker interface om integratie tests die mislukken vanwege manco's in de
- * Oracle driver aan te geven. Zie {@link JTDSDriverBasedFailures} voor
+ * Oracle driver aan te geven. Zie {@link PostgreSQLDriverBasedFailures} voor
  * gebruiksinstructie.
  *
  * @author mprins
- * @see JTDSDriverBasedFailures
+ * @see PostgreSQLDriverBasedFailures
  * @note marker interface
  * @see org.junit.experimental.categories.Category
  */

--- a/brmo-test-util/src/main/java/nl/b3p/brmo/test/util/database/dbunit/CleanUtil.java
+++ b/brmo-test-util/src/main/java/nl/b3p/brmo/test/util/database/dbunit/CleanUtil.java
@@ -86,8 +86,37 @@ public final class CleanUtil {
             new DefaultTable("zak_recht_archief"),
             new DefaultTable("zak_recht_aantek"),
             new DefaultTable("benoemd_obj_kad_onrrnd_zk"),
-            new DefaultTable("herkomst_metadata")}
-        ));
+            new DefaultTable("herkomst_metadata"),
+            // schemaspy geeft de volgende volgorde
+            //  new DefaultTable("subject"),
+            //  new DefaultTable("prs"),
+            //  new DefaultTable("kad_onrrnd_zk"),
+            //  new DefaultTable("kad_perceel"),
+            //  new DefaultTable("niet_nat_prs"),
+            //  new DefaultTable("nat_prs"),
+            //  new DefaultTable("ingeschr_nat_prs"),
+            //  new DefaultTable("app_re"),
+            //  new DefaultTable("zak_recht"),
+            //  new DefaultTable("ander_btnlnds_niet_nat_prs"),
+            //  new DefaultTable("ander_nat_prs"),
+            //  new DefaultTable("benoemd_obj_kad_onrrnd_zk"),
+            //  new DefaultTable("ingeschr_niet_nat_prs"),
+            //  new DefaultTable("kad_onrrnd_zk_his_rel"),
+            //  new DefaultTable("niet_ingezetene"),
+            //  new DefaultTable("app_re_kad_perceel"),
+            //  new DefaultTable("ingezetene"),
+            //  new DefaultTable("kad_onrrnd_zk_aantek"),
+            //  new DefaultTable("kad_onrrnd_zk_kad_onrrnd_zk"),
+            //  new DefaultTable("zak_recht_aantek"),
+            //  new DefaultTable("app_re_archief"),
+            //  new DefaultTable("app_re_kad_perceel_archief"),
+            ////  new DefaultTable("brondocument"),
+            //  new DefaultTable("kad_onrrnd_zk_aantek_archief"),
+            //  new DefaultTable("kad_onrrnd_zk_archief"),
+            //  new DefaultTable("kad_onrrnd_zk_kad_onrr_archief"),
+            //  new DefaultTable("kad_perceel_archief"),
+            //  new DefaultTable("zak_recht_archief"),
+        }));
     }
 
     /**

--- a/brmo-test-util/src/test/java/nl/b3p/brmo/test/util/database/dbunit/DBUnitExportRSGB.java
+++ b/brmo-test-util/src/test/java/nl/b3p/brmo/test/util/database/dbunit/DBUnitExportRSGB.java
@@ -37,15 +37,23 @@ public class DBUnitExportRSGB {
     private static final String _dbFile2 = "rsgb.xml";
 
     // postgis
-    private static final String _driverClass = "org.postgresql.Driver";
-    private static final String _jdbcConnection = "jdbc:postgresql://localhost:5434/itest_rsgb";
-    private static final String _user = "rsgb";
-    private static final String _passwd = "rsgb";
-    // ms sql
+//    private static final String _driverClass = "org.postgresql.Driver";
+//    private static final String _jdbcConnection = "jdbc:postgresql://localhost:5434/itest_rsgb";
+//    private static final String _user = "rsgb";
+//    private static final String _passwd = "rsgb";
+    // ms sql / jtds
     // private static final String _driverClass = "net.sourceforge.jtds.jdbc.Driver";
     // private static final String _jdbcConnection = "jdbc:jtds:sqlserver://192.168.1.15:1433/itest_brmo_rsgb;instance=SQLEXPRESS";
     // private static final String _user = "brmotest";
     // private static final String _passwd = "brmotest";
+
+    // ms sql
+     private static final String _driverClass = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
+     private static final String _jdbcConnection = "jdbc:sqlserver://localhost:1401;databaseName=rsgb;instance=sql1";
+     private static final String _user = "sa";
+     private static final String _passwd = "YourStrong!Passw0rd";
+
+
     // oracle
     // private static final String _driverClass = "oracle.jdbc.OracleDriver";
     // private static final String _jdbcConnection = "jdbc:oracle:thin:@127.0.0.1:1521:XE";
@@ -76,8 +84,8 @@ public class DBUnitExportRSGB {
         IDatabaseConnection connection = new DatabaseConnection(jdbcConnection);
 
         // connection.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new PostgresqlDataTypeFactory());
-        // connection.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new MsSqlDataTypeFactory());
-        connection.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new Oracle10DataTypeFactory());
+         connection.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new MsSqlDataTypeFactory());
+//        connection.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new Oracle10DataTypeFactory());
 
         // voor alle tabellen:
         // ITableFilter filter = new DatabaseSequenceFilter(connection);

--- a/datamodel/pom.xml
+++ b/datamodel/pom.xml
@@ -58,8 +58,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.jtds</groupId>
-            <artifactId>jtds</artifactId>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/datamodel/src/test/java/nl/b3p/brmo/datamodel/DatabaseUpgradeTest.java
+++ b/datamodel/src/test/java/nl/b3p/brmo/datamodel/DatabaseUpgradeTest.java
@@ -228,7 +228,7 @@ public class DatabaseUpgradeTest {
             // negeren; het override bestand is normaal niet aanwezig
         }
         isOracle = "oracle".equalsIgnoreCase(params.getProperty("dbtype"));
-        isMsSQL = "jtds-sqlserver".equalsIgnoreCase(params.getProperty("dbtype"));
+        isMsSQL = "sqlserver".equalsIgnoreCase(params.getProperty("dbtype"));
         isPostgis = "postgis".equalsIgnoreCase(params.getProperty("dbtype"));
 
         try {

--- a/datamodel/src/test/java/nl/b3p/brmo/datamodel/MaterializedViewsTest.java
+++ b/datamodel/src/test/java/nl/b3p/brmo/datamodel/MaterializedViewsTest.java
@@ -192,7 +192,7 @@ public class MaterializedViewsTest {
             // negeren; het override bestand is normaal niet aanwezig
         }
         isOracle = "oracle".equalsIgnoreCase(params.getProperty("dbtype"));
-        isMsSQL = "jtds-sqlserver".equalsIgnoreCase(params.getProperty("dbtype"));
+        isMsSQL = "sqlserver".equalsIgnoreCase(params.getProperty("dbtype"));
         isPostgis = "postgis".equalsIgnoreCase(params.getProperty("dbtype"));
 
         try {

--- a/datamodel/src/test/resources/sqlserver.properties
+++ b/datamodel/src/test/resources/sqlserver.properties
@@ -1,15 +1,15 @@
 # evt. override met een local.sqlserver.properties
-jdbc.driverClassName=net.sourceforge.jtds.jdbc.Driver
-dbtype=jtds-sqlserver
+jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
+dbtype=sqlserver
 
-rsgb.url=jdbc:jtds:sqlserver://127.0.0.1:1433/rsgb;instance=${mssql.instancename}
+rsgb.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;instance=${mssql.instancename}
 rsgb.username=sa
 rsgb.password=Password12!
 
-staging.url=jdbc:jtds:sqlserver://127.0.0.1:1433/staging;instance=${mssql.instancename}
+staging.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;instance=${mssql.instancename}
 staging.username=sa
 staging.password=Password12!
 
-rsgbbgt.url=jdbc:jtds:sqlserver://127.0.0.1:1433/bgttest;instance=${mssql.instancename}
+rsgbbgt.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;instance=${mssql.instancename}
 rsgbbgt.username=sa
 rsgbbgt.password=Password12!

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <oracle.jdbc.version>19.6.0.0</oracle.jdbc.version>
         <!-- <oracle.jdbc.version>18.3.0.0</oracle.jdbc.version> -->
         <!-- <oracle.jdbc.version>19.3.0.0</oracle.jdbc.version> -->
-        <sqlserver.jdbc.version>8.1.1.jre8-preview</sqlserver.jdbc.version>
+        <sqlserver.jdbc.version>8.2.1.jre8</sqlserver.jdbc.version>
         <mssql.instancename />
         <javasimon.version>4.2.0</javasimon.version>
         <jakarta.mail.version>1.6.5</jakarta.mail.version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <hibernate.version>5.4.17.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
         <geotools.version>23.1</geotools.version>
-        <jdbc-util.version>5.2</jdbc-util.version>
+        <jdbc-util.version>6.0-SNAPSHOT</jdbc-util.version>
         <jts.version>1.16.1</jts.version>
         <itextpdf.version>7.1.11</itextpdf.version>
         <postgresql.jdbc.version>42.2.13</postgresql.jdbc.version>
@@ -70,7 +70,7 @@
         <oracle.jdbc.version>19.6.0.0</oracle.jdbc.version>
         <!-- <oracle.jdbc.version>18.3.0.0</oracle.jdbc.version> -->
         <!-- <oracle.jdbc.version>19.3.0.0</oracle.jdbc.version> -->
-        <sqlserver.jdbc.version>8.2.2.jre8</sqlserver.jdbc.version>
+        <sqlserver.jdbc.version>8.3.1.jre8-preview</sqlserver.jdbc.version>
         <mssql.instancename />
         <javasimon.version>4.2.0</javasimon.version>
         <jakarta.mail.version>1.6.5</jakarta.mail.version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <hibernate.version>5.4.17.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
         <geotools.version>23.1</geotools.version>
-        <jdbc-util.version>6.0-SNAPSHOT</jdbc-util.version>
+        <jdbc-util.version>6.0</jdbc-util.version>
         <jts.version>1.16.1</jts.version>
         <itextpdf.version>7.1.11</itextpdf.version>
         <postgresql.jdbc.version>42.2.13</postgresql.jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <oracle.jdbc.version>19.6.0.0</oracle.jdbc.version>
         <!-- <oracle.jdbc.version>18.3.0.0</oracle.jdbc.version> -->
         <!-- <oracle.jdbc.version>19.3.0.0</oracle.jdbc.version> -->
-        <sqlserver.jtds.version>1.3.1</sqlserver.jtds.version>
+        <sqlserver.jdbc.version>8.1.0.jre8-preview</sqlserver.jdbc.version>
         <mssql.instancename />
         <javasimon.version>4.2.0</javasimon.version>
         <jakarta.mail.version>1.6.5</jakarta.mail.version>
@@ -301,26 +301,21 @@
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${postgresql.jdbc.version}</version>
-                <!-- Bij JNDI db verbinding moeten postgis jars in tomcat lib samen
-                met postgresql jdbc driver staan -->
             </dependency>
             <dependency>
                 <groupId>net.postgis</groupId>
                 <artifactId>postgis-jdbc</artifactId>
                 <version>${postgresql.postgis-jdbc.version}</version>
-                <!-- Bij JNDI db voor postgis verbinding moeten postgis jars in tomcat lib staan -->
             </dependency>
             <dependency>
                 <groupId>com.oracle.database.jdbc</groupId>
                 <artifactId>ojdbc8</artifactId>
                 <version>${oracle.jdbc.version}</version>
-                <!-- Bij JNDI db verbinding moeten Oracle jars in tomcat lib staan -->
             </dependency>
             <dependency>
-                <groupId>net.sourceforge.jtds</groupId>
-                <artifactId>jtds</artifactId>
-                <version>${sqlserver.jtds.version}</version>
-                <!-- Bij JNDI db verbinding moeten jtds jars in tomcat lib staan -->
+                <groupId>com.microsoft.sqlserver</groupId>
+                <artifactId>mssql-jdbc</artifactId>
+                <version>${sqlserver.jdbc.version}</version>
             </dependency>
             <dependency>
                 <groupId>nl.b3p</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <oracle.jdbc.version>19.6.0.0</oracle.jdbc.version>
         <!-- <oracle.jdbc.version>18.3.0.0</oracle.jdbc.version> -->
         <!-- <oracle.jdbc.version>19.3.0.0</oracle.jdbc.version> -->
-        <sqlserver.jdbc.version>8.2.1.jre8</sqlserver.jdbc.version>
+        <sqlserver.jdbc.version>8.2.2.jre8</sqlserver.jdbc.version>
         <mssql.instancename />
         <javasimon.version>4.2.0</javasimon.version>
         <jakarta.mail.version>1.6.5</jakarta.mail.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <oracle.jdbc.version>19.6.0.0</oracle.jdbc.version>
         <!-- <oracle.jdbc.version>18.3.0.0</oracle.jdbc.version> -->
         <!-- <oracle.jdbc.version>19.3.0.0</oracle.jdbc.version> -->
-        <sqlserver.jdbc.version>8.1.0.jre8-preview</sqlserver.jdbc.version>
+        <sqlserver.jdbc.version>8.1.1.jre8-preview</sqlserver.jdbc.version>
         <mssql.instancename />
         <javasimon.version>4.2.0</javasimon.version>
         <jakarta.mail.version>1.6.5</jakarta.mail.version>
@@ -276,6 +276,12 @@
                 <groupId>org.geotools.jdbc</groupId>
                 <artifactId>gt-jdbc-sqlserver</artifactId>
                 <version>${geotools.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>net.sourceforge.jtds</groupId>
+                        <artifactId>jtds</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools.jdbc</groupId>

--- a/topparser/pom.xml
+++ b/topparser/pom.xml
@@ -87,8 +87,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.jtds</groupId>
-            <artifactId>jtds</artifactId>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/topparser/src/main/resources/nl/b3p/topnl/database/sqlserver.sql
+++ b/topparser/src/main/resources/nl/b3p/topnl/database/sqlserver.sql
@@ -1,2 +1,6 @@
--- dummy
 select 1;
+-- create schema top250nl;
+-- create schema top100nl;
+-- create schema top50nl;
+-- create schema top10nl;
+

--- a/topparser/src/test/resources/log4j.xml
+++ b/topparser/src/test/resources/log4j.xml
@@ -12,7 +12,7 @@ LEVELS: debug, info, warn, error, fatal en off, all -->
     </appender>
     <appender name="file" class="org.apache.log4j.RollingFileAppender">
         <param name="append" value="false" />
-        <param name="maxFileSize" value="10KB" />
+        <param name="maxFileSize" value="1MB" />
         <param name="maxBackupIndex" value="5" />
         <!-- For Tomcat -->
         <param name="file" value="target/topparser.log" />


### PR DESCRIPTION
- [x] update jdbc-util naar 5.0-SNAPSHOT
- [x] update/release jdbc-util 6.0, depends: https://github.com/B3Partners/jdbc-util/pull/68
- [x] vervang `net.sourceforge.jtds:jtds` door `com.microsoft.sqlserver:mssql-jdbc`
- [x] verwijder `nl.b3p.brmo.test.util.database.JTDSDriverBasedFailures` markering uit test cases
- [x] **upgrade instructie**
 
  Bij een Upgrade moet de jTDS database driver (`jtds-1.3.1.jar`) in de Tomcat "lib" directory worden vervangen door de nieuwe (`mssql-jdbc-<N.N.N>.jre8.jar`). tevens dienen de database urls aangepast te worden voor de nieuwe driver. In de Tomcat `server.xml` staan de databron URLs gedefinieerd, bijvoorbeeld `jdbc:jtds:sqlserver://127.0.0.1:1433/bgttest` moet aangepast worden naar `jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest` dat geldt voor alle SQL Server databronnen. De "driverClassName" moet aangepast worden van `driverClassName="net.sourceforge.jtds.jdbc.Driver"` naar `driverClassName="com.microsoft.sqlserver.jdbc.SQLServerDriver"` (zie ook: https://github.com/B3Partners/brmo/wiki/Installatiehandleiding#ms-sql-server)

close #363 