### PR TITLE
bump tomcat 7.0.96 -> 7.0.99 [CVE-2019-17563 en CVE-2019-12418]

### DIFF
--- a/.mvn/owasp-suppression.xml
+++ b/.mvn/owasp-suppression.xml
@@ -3,11 +3,11 @@
     <suppress>
         <notes>
             <![CDATA[
-                     Negeer meldingen mbt tomcat-catalina-7.0.96.jar omdat we geen tomcat mee leveren en deze
+                     Negeer meldingen mbt tomcat-catalina-7.0.99.jar omdat we geen tomcat mee leveren en deze
                      alleen voor bepaalde deployments geldt.
             ]]>
         </notes>
-        <filePath regex="true">.*\btomcat-catalina-7\.0\.96\.jar</filePath>
+        <filePath regex="true">.*\btomcat-catalina-7\.0\.99\.jar</filePath>
         <cve>CVE-2016-5388</cve>
         <cve>CVE-2016-5425</cve>
         <cve>CVE-2016-6325</cve>

--- a/datamodel/upgrade_scripts/2.0.0-2.0.1/oracle/staging.sql
+++ b/datamodel/upgrade_scripts/2.0.0-2.0.1/oracle/staging.sql
@@ -3,6 +3,18 @@
 --
 
 
+
+
+-- #761 vul de bestand_naam_hersteld uit afgifte gegevens
+UPDATE
+    laadproces
+SET
+    bestand_naam_hersteld = SUBSTR(bestand_naam, 1, INSTR(bestand_naam, '.zip')+ 4)
+WHERE
+    soort = 'brk'
+    AND opmerking LIKE 'GDS2 download van%'
+    AND bestand_naam_hersteld IS NULL;
+
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.0.0_naar_2.0.1','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';
 -- versienummer update

--- a/datamodel/upgrade_scripts/2.0.0-2.0.1/postgresql/staging.sql
+++ b/datamodel/upgrade_scripts/2.0.0-2.0.1/postgresql/staging.sql
@@ -3,6 +3,18 @@
 --
 
 
+
+
+-- #761 vul de bestand_naam_hersteld uit afgifte gegevens
+UPDATE
+    laadproces
+SET
+    bestand_naam_hersteld = SUBSTRING(bestand_naam, 1, POSITION('.zip' IN bestand_naam)+ 4)
+WHERE
+    soort = 'brk'
+    AND opmerking LIKE 'GDS2 download van%'
+    AND bestand_naam_hersteld IS NULL;
+
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.0.0_naar_2.0.1','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';
 -- versienummer update

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <jaxb.impl.version>2.3.2</jaxb.impl.version>
         <activation.api.version>1.2.1</activation.api.version>
         <!-- bij ophogen van tomcat versie evt. ook de .mvn/owasp-suppression.xml file bijwerken -->
-        <tomcat.version>7.0.96</tomcat.version>
+        <tomcat.version>7.0.99</tomcat.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- om unit tests met postgres te draaien gebruik je


### PR DESCRIPTION
resolves CVE-2019-17563 en CVE-2019-12418

NB brmo als zodanig is geen kwetsbaar product, maar kan wel kwetsbaar zijn als het in een kwetsbare, verouderde tomcat container draait