### PR TITLE
Voeg een optie toe om automatisch transformeren van berichten te blokkeren

### DIFF
--- a/brmo-persistence/src/main/java/nl/b3p/brmo/persistence/staging/AfgifteNummerScannerProces.java
+++ b/brmo-persistence/src/main/java/nl/b3p/brmo/persistence/staging/AfgifteNummerScannerProces.java
@@ -27,7 +27,7 @@ public class AfgifteNummerScannerProces extends AutomatischProces {
 
     private static final String CONTRACTNUMMER = "contractnummer";
     private static final String AFGIFTENUMMERTYPE = "afgiftenummertype";
-    private static final String MISSINGNUMBERSFOUND = "ontbrekendenummersgevonden";
+    public static final String MISSINGNUMBERSFOUND = "ontbrekendenummersgevonden";
 
     /**
      * Zoekt het geconfigureerde contractnummer op.

--- a/brmo-persistence/src/main/java/nl/b3p/brmo/persistence/staging/BerichtTransformatieProces.java
+++ b/brmo-persistence/src/main/java/nl/b3p/brmo/persistence/staging/BerichtTransformatieProces.java
@@ -12,4 +12,14 @@ import javax.persistence.Entity;
 @Entity
 public class BerichtTransformatieProces extends AutomatischProces {
 
+    private static final String BLOCK_ON_MISSINGNUMBERSFOUND = "blokkeer_transformatie";
+
+    public void setBlockOnMissingNumbers(boolean block) {
+        this.getConfig().put(BLOCK_ON_MISSINGNUMBERSFOUND, new ClobElement(Boolean.toString(block)));
+    }
+
+    public boolean getBlockOnMissingNumbers() {
+        String s = ClobElement.nullSafeGet(this.getConfig().get(BLOCK_ON_MISSINGNUMBERSFOUND));
+        return (s == null ? false : Boolean.parseBoolean(s));
+    }
 }

--- a/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/edittransformatieproces.jsp
+++ b/brmo-service/src/main/webapp/WEB-INF/jsp/beheer/edittransformatieproces.jsp
@@ -5,6 +5,9 @@
         <td><stripes:text name="config['label']"/></td>
     </tr>
     <tr>
+        <td>Blokkeer automatische transformatie bij ontbrekende afgiftenummers:</td>
+        <td><label><stripes:checkbox name="config['blokkeer_transformatie']"/> <strong>NB.</strong> handmatig transformatie starten is wel mogelijk</label></td></tr>
+    <tr>
         <td><stripes:label name="">Planning <a href="http://cronmaker.com" target="_blank">(cron expressie)</a></stripes:label></td>
         <td>
             <stripes:text name="proces.cronExpressie"/>


### PR DESCRIPTION
Voeg een optie toe om automatisch transformeren van berichten te blokkeren als er ontbrekende afgiftenummers zijn geconstateerd door een "AfgifteNummerScannerProces"

- [x] wiki bijwerken [BerichtTransformatieUitvoeren](https://github.com/B3Partners/brmo/wiki/BerichtTransformatieUitvoeren)

close #730