### PR TITLE
Bump Tomcat test dependencies 7.0.99 ⇨ 7.0.100

### DIFF
--- a/.mvn/owasp-suppression.xml
+++ b/.mvn/owasp-suppression.xml
@@ -3,11 +3,11 @@
     <suppress>
         <notes>
             <![CDATA[
-                     Negeer meldingen mbt tomcat-catalina-7.0.99.jar
+                     Negeer meldingen mbt tomcat-catalina-7.0.100.jar
                      omdat we geen tomcat mee leveren en deze alleen voor bepaalde deployments geldt.
             ]]>
         </notes>
-        <filePath regex="true">.*\btomcat-catalina-7\.0\.99\.jar</filePath>
+        <filePath regex="true">.*\btomcat-catalina-7\.0\.100\.jar</filePath>
         <cve>CVE-2016-5388</cve>
         <cve>CVE-2016-5425</cve>
         <cve>CVE-2016-6325</cve>

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,10 @@ before_install:
   - sudo service postgresql stop
   # installeer postgresql of mssql
   - if [ "$PROFILE" == "postgresql" ]; then
-       sudo apt-get remove postgresql* -y;
+       sudo apt-get --purge remove postgresql* -y;
+       sudo rm -rf /etc/postgresql/
+       sudo rm /etc/init.d/postgresql
+       sudo rm /lib/systemd/system/postgresql.service
        sudo apt-get install -y --allow-unauthenticated --no-install-recommends --no-install-suggests postgresql-$POSTGRESQL_VERSION postgresql-client-$POSTGRESQL_VERSION postgresql-common;
        sudo apt-get install -y --allow-unauthenticated postgresql-$POSTGRESQL_VERSION-postgis-$POSTGIS_VERSION postgresql-$POSTGRESQL_VERSION-postgis-$POSTGIS_VERSION-scripts postgis;
        sudo pg_dropcluster --stop $POSTGRESQL_VERSION main;

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <jaxb.impl.version>2.3.2</jaxb.impl.version>
         <activation.api.version>1.2.2</activation.api.version>
         <!-- bij ophogen van tomcat versie evt. ook de .mvn/owasp-suppression.xml file bijwerken -->
-        <tomcat.version>7.0.99</tomcat.version>
+        <tomcat.version>7.0.100</tomcat.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- om unit tests met postgres te draaien gebruik je


### PR DESCRIPTION
resolves:
- CVE-2020-1935
- CVE-2020-1938
- CVE-2019-17569


**NB** Tomcat is geen onderdeel van het product, dus als zodanig is BRMO niet kwetsbaar, mogelijk wel de Tomcat service waarop de brmo-service draait