### PR TITLE
Relocate Oracle driver com.oracle.jdbc ➜ com.oracle.database.jdbc

### DIFF
--- a/bgt-gml-loader/pom.xml
+++ b/bgt-gml-loader/pom.xml
@@ -256,7 +256,7 @@
             </properties>
             <dependencies>
                 <dependency>
-                    <groupId>com.oracle.jdbc</groupId>
+                    <groupId>com.oracle.database.jdbc</groupId>
                     <artifactId>ojdbc8</artifactId>
                 </dependency>
             </dependencies>

--- a/brmo-commandline/README.md
+++ b/brmo-commandline/README.md
@@ -11,9 +11,6 @@ usage: java -jar brmo-commandline.jar --<actie> --dbprops <db-props>
 usage: [Oracle] java -cp "bin/brmo-commandline.jar;lib/*"
                 nl.b3p.brmo.commandline.Main --<actie> --dbprops <db-props>
 
-                [Omdat de Oracle jdbc driver niet gedistribueerd mag worden
-                 dient deze zelf op de commando regel te worden opgegeven.]
-
 Acties:
   -v,--versieinfo <[format]>                                 Versie informatie van de verschillende
                                                              schema's
@@ -54,8 +51,6 @@ De `[error-state]` is optioneel, default is "ignore".
 De `[loadingUpdate]` optie is optioneel met een default waarde van "false".
 
 __De `--afgiftelijst` is beschikbaar vanaf versie 2.0.0__
-
-Omdat de Oracle jdbc driver niet gedistribueerd mag worden dient deze zelf in de lib directory te worden gezet met de aangepaste commando regel zal deze worden opgepikt.
 
 De transformatie naar rsgb wordt normaal met de "ignore" `error-state` optie gestart om te voorkomen dat het proces afbreekt als er een transformatie fout optreed bij de verwerking van een bericht, om dit te voorkomen kan er een andere waarde worden opgegeven, bijvoorbeeld "false".
 Na afloop van een transformatie kan de status van de berichten worden gecontroleerd met de `--berichtstatus` optie.

--- a/brmo-commandline/pom.xml
+++ b/brmo-commandline/pom.xml
@@ -11,8 +11,6 @@
     <name>BRMO commandline</name>
     <description>BRMO commandline tool</description>
     <properties>
-        <!-- de oracle driver van zip file uitsluiten-->
-        <exclude.groupIds.fromPackaging>com.oracle.jdbc</exclude.groupIds.fromPackaging>
         <include.scope.inPackaging>runtime</include.scope.inPackaging>
     </properties>
     <dependencies>
@@ -87,9 +85,8 @@
             <artifactId>jtds</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.oracle.jdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>nl.b3p</groupId>
@@ -290,7 +287,7 @@
             </properties>
             <dependencies>
                 <dependency>
-                    <groupId>com.oracle.jdbc</groupId>
+                    <groupId>com.oracle.database.jdbc</groupId>
                     <artifactId>ojdbc8</artifactId>
                 </dependency>
             </dependencies>

--- a/brmo-dist/assembly.xml
+++ b/brmo-dist/assembly.xml
@@ -61,6 +61,7 @@
             <includes>
                 <include>com.sun.mail:jakarta.mail</include>
                 <include>jakarta.activation:jakarta.activation-api</include>
+                <include>com.oracle.database.jdbc:ojdbc8</include>
             </includes>
             <outputFileNameMapping>${artifact.artifactId}-${artifact.version}.${artifact.extension}</outputFileNameMapping>
         </dependencySet>

--- a/brmo-dist/pom.xml
+++ b/brmo-dist/pom.xml
@@ -86,6 +86,10 @@
             <groupId>net.sourceforge.jtds</groupId>
             <artifactId>jtds</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+        </dependency>
         <!-- niet nodig; zitten in de webapps 
         <dependency>
             <groupId>jakarta.xml.bind</groupId>

--- a/brmo-dist/src/site/markdown/drivers.md
+++ b/brmo-dist/src/site/markdown/drivers.md
@@ -6,6 +6,134 @@ Ten behoeve van een snelle installatie worden de volgende drivers meegepakt (voo
 
   - PostgreSQL JDBC, Postgis en mail drivers
   - jTDS JDBC driver voor MSSQL en mail drivers
-  - mail drivers, de Oracle driver is te vinden op https://www.oracle.com/technetwork/database/application-development/jdbc/downloads/index.html
+  - Oracle JDBC en mail drivers (De Oracle JDBC driver wordt beschikbaar gesteld onder de "Oracle Free Use Terms and Conditions (FUTC)", zie hieronder.)
 
 De bestanden dienen in de `lib` directory van Tomcat te worden geplaatst zodat ze gebruikt kunnen worden in de verschillende JNDI bronnen.
+
+
+---
+
+### Oracle Free Use Terms and Conditions
+
+    Definitions
+    
+    "Oracle" refers to Oracle America, Inc. "You" and "Your" refers to (a)
+    a company or organization (each an "Entity") accessing the Programs,
+    if use of the Programs will be on behalf of such Entity; or (b) an
+    individual accessing the Programs, if use of the Programs will not be
+    on behalf of an Entity. "Program(s)" refers to Oracle software
+    provided by Oracle pursuant to the following terms and any updates,
+    error corrections, and/or Program Documentation provided by
+    Oracle. "Program Documentation" refers to Program user manuals and
+    Program installation manuals, if any. If available, Program
+    Documentation may be delivered with the Programs and/or may be
+    accessed from www.oracle.com/documentation. "Separate Terms" refers to
+    separate license terms that are specified in the Program
+    Documentation, readmes or notice files and that apply to Separately
+    Licensed Technology. "Separately Licensed Technology" refers to Oracle
+    or third party technology that is licensed under Separate Terms and
+    not under the terms of this license.
+    
+    Separately Licensed Technology
+    
+    Oracle may provide certain notices to You in Program Documentation,
+    readmes or notice files in connection with Oracle or third party
+    technology provided as or with the Programs. If specified in the
+    Program Documentation, readmes or notice files, such technology will
+    be licensed to You under Separate Terms. Your rights to use Separately
+    Licensed Technology under Separate Terms are not restricted in any way
+    by the terms herein. For clarity, notwithstanding the existence of a
+    notice, third party technology that is not Separately Licensed
+    Technology shall be deemed part of the Programs licensed to You under
+    the terms of this license.
+    
+    Source Code for Open Source Software
+    
+    For software that You receive from Oracle in binary form that is
+    licensed under an open source license that gives You the right to
+    receive the source code for that binary, You can obtain a copy of the
+    applicable source code from https://oss.oracle.com/sources/ or
+    http://www.oracle.com/goto/opensourcecode. If the source code for such
+    software was not provided to You with the binary, You can also receive
+    a copy of the source code on physical media by submitting a written
+    request pursuant to the instructions in the "Written Offer for Source
+    Code" section of the latter website.
+    
+    -------------------------------------------------------------------------------
+    
+    The following license terms apply to those Programs that are not
+    provided to You under Separate Terms.
+    
+    License Rights and Restrictions
+    
+    Oracle grants to You, as a recipient of this Program, a nonexclusive,
+    nontransferable, limited license to, subject to the conditions stated
+    herein, (a) internally use the unmodified Programs for the purposes of
+    developing, testing, prototyping and demonstrating your applications,
+    and running the Programs for your own internal business operations;
+    and (b) redistribute unmodified Programs and Programs Documentation,
+    under the terms of this License, provided that You do not charge Your
+    end users any additional fees for the use of the Programs. You may
+    make copies of the Programs to the extent reasonably necessary for
+    exercising the license rights granted herein and for backup
+    purposes. You are granted the right to use the Programs to provide
+    third party training in the use of the Programs and associated
+    Separately Licensed Technology only if there is express authorization
+    of such use by Oracle on the Program's download page or in the Program
+    Documentation.
+    
+    Your license is contingent on Your compliance with the following conditions:
+    
+        - You include a copy of this license with any distribution by You
+          of the Programs;
+    
+        - You do not remove markings or notices of either Oracle's or a
+          licensor's proprietary rights from the Programs or Program
+          Documentation;
+    
+        - You comply with all U.S. and applicable export control and
+          economic sanctions laws and regulations that govern Your use of
+          the Programs (including technical data);
+    
+        - You do not cause or permit reverse engineering, disassembly or
+          decompilation of the Programs (except as allowed by law) by You
+          nor allow an associated party to do so.
+    
+    For clarity, any source code that may be included in the distribution
+    with the Programs is provided solely for reference purposes and may
+    not be modified, unless such source code is under Separate Terms
+    permitting modification.
+    
+    Ownership
+    
+    Oracle or its licensors retain all ownership and intellectual property
+    rights to the Programs.
+    
+    Information Collection
+    
+    The Programs' installation and/or auto-update processes, if any, may
+    transmit a limited amount of data to Oracle or its service provider
+    about those processes to help Oracle understand and optimize
+    them. Oracle does not associate the data with personally identifiable
+    information. Refer to Oracle's Privacy Policy at
+    www.oracle.com/privacy.
+    
+    Disclaimer of Warranties; Limitation of Liability
+    
+    THE PROGRAMS ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND. ORACLE
+    FURTHER DISCLAIMS ALL WARRANTIES, EXPRESS AND IMPLIED, INCLUDING
+    WITHOUT LIMITATION, ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE, OR NONINFRINGEMENT.
+    
+    IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW WILL ORACLE BE LIABLE TO
+    YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+    CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+    PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+    RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+    FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF
+    SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+    DAMAGES.
+    
+    Last updated:  8 October 2018
+
+---

--- a/brmo-loader/pom.xml
+++ b/brmo-loader/pom.xml
@@ -91,16 +91,8 @@
             <!-- Bij JNDI db verbinding moet de jtds driver jar in tomcat lib staan -->
             <scope>provided</scope>
         </dependency>
-        <!--
-            Bij gebruik van oracle met maven moet je de oracle jdbc driver
-            handmatig toevoegen aan je locale mvn repo (licentie blabla): Dit
-            kan met: mvn install:install-file
-            -Dfile=/mnt/x_b3p_install/Databases/JDBC\ drivers/ojdbc5.jar
-            -DgroupId=com.oracle -DartifactId=ojdbc5 -Dversion=11.1.0.7.0
-            -Dpackaging=jar -DgeneratePom=true
-        -->
         <dependency>
-            <groupId>com.oracle.jdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <!-- Bij JNDI db verbinding moeten Oracle jars in tomcat lib staan -->
             <scope>provided</scope>
@@ -130,7 +122,7 @@
             <artifactId>bgt-gml-loader</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>com.oracle.jdbc</groupId>
+                    <groupId>com.oracle.database.jdbc</groupId>
                     <artifactId>ojdbc8</artifactId>
                 </exclusion>
                 <exclusion>
@@ -187,11 +179,6 @@
         <profile>
             <id>oracle</id>
             <properties>
-                <!--
-                <oracle.jdbc.groupId>com.oracle</oracle.jdbc.groupId>
-                <oracle.jdbc.artifactId>ojdbc7</oracle.jdbc.artifactId>
-                <oracle.jdbc.version>12.1.0.2.0</oracle.jdbc.version>
-                -->
             </properties>
             <build>
                 <plugins>

--- a/brmo-persistence/pom.xml
+++ b/brmo-persistence/pom.xml
@@ -28,7 +28,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.jdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/brmo-service/pom.xml
+++ b/brmo-service/pom.xml
@@ -75,7 +75,7 @@
             <artifactId>brmo-loader</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>com.oracle.jdbc</groupId>
+                    <groupId>com.oracle.database.jdbc</groupId>
                     <artifactId>ojdbc8</artifactId>
                 </exclusion>
                 <exclusion>
@@ -143,7 +143,7 @@
         </dependency>
         <dependency>
             <!-- voor database integratie tests -->
-            <groupId>com.oracle.jdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <scope>test</scope>
         </dependency>
@@ -365,7 +365,7 @@
             </properties>
             <dependencies>
                 <dependency>
-                    <groupId>com.oracle.jdbc</groupId>
+                    <groupId>com.oracle.database.jdbc</groupId>
                     <artifactId>ojdbc8</artifactId>
                 </dependency>
             </dependencies>
@@ -444,11 +444,6 @@
                                 <artifactId>jakarta.mail</artifactId>
                                 <version>${jakarta.mail.version}</version>
                             </dependency>
-<!--                            <dependency>-->
-<!--                                <groupId>com.oracle.jdbc</groupId>-->
-<!--                                <artifactId>ojdbc8</artifactId>-->
-<!--                                <version>${oracle.jdbc.version}</version>-->
-<!--                            </dependency>-->
                         </dependencies>
                     </plugin>
                     <plugin>

--- a/brmo-soap/pom.xml
+++ b/brmo-soap/pom.xml
@@ -29,7 +29,7 @@
             <artifactId>brmo-loader</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>com.oracle.jdbc</groupId>
+                    <groupId>com.oracle.database.jdbc</groupId>
                     <artifactId>ojdbc8</artifactId>
                 </exclusion>
                 <exclusion>
@@ -74,7 +74,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.jdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -182,7 +182,7 @@
             </properties>
             <dependencies>
                 <dependency>
-                    <groupId>com.oracle.jdbc</groupId>
+                    <groupId>com.oracle.database.jdbc</groupId>
                     <artifactId>ojdbc8</artifactId>
                 </dependency>
             </dependencies>

--- a/brmo-stufbg204/pom.xml
+++ b/brmo-stufbg204/pom.xml
@@ -64,7 +64,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.jdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -296,7 +296,7 @@
             </properties>
             <dependencies>
                 <dependency>
-                    <groupId>com.oracle.jdbc</groupId>
+                    <groupId>com.oracle.database.jdbc</groupId>
                     <artifactId>ojdbc8</artifactId>
                 </dependency>
             </dependencies>
@@ -368,11 +368,6 @@
                             </execution>
                         </executions>
                         <dependencies>
-<!--                            <dependency>-->
-<!--                                <groupId>com.oracle.jdbc</groupId>-->
-<!--                                <artifactId>ojdbc8</artifactId>-->
-<!--                                <version>${oracle.jdbc.version}</version>-->
-<!--                            </dependency>-->
                         </dependencies>
                     </plugin>
                     <plugin>

--- a/brmo-test-util/pom.xml
+++ b/brmo-test-util/pom.xml
@@ -32,7 +32,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.jdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/datamodel/pom.xml
+++ b/datamodel/pom.xml
@@ -53,7 +53,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.oracle.jdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <hibernate.version>3.6.10.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
         <geotools.version>22.2</geotools.version>
-        <jdbc-util.version>4.4</jdbc-util.version>
+        <jdbc-util.version>4.5</jdbc-util.version>
         <jts.version>1.16.1</jts.version>
         <itextpdf.version>7.1.10</itextpdf.version>
         <postgresql.jdbc.version>42.2.10</postgresql.jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <postgresql.jdbc.version>42.2.10</postgresql.jdbc.version>
         <postgresql.postgis-jdbc.version>2.3.0</postgresql.postgis-jdbc.version>
         <oracle.jdbc.version>12.2.0.1</oracle.jdbc.version>
+        <!-- <oracle.jdbc.version>18.3.0.0</oracle.jdbc.version> -->
         <!-- <oracle.jdbc.version>19.3.0.0</oracle.jdbc.version> -->
         <sqlserver.jtds.version>1.3.1</sqlserver.jtds.version>
         <mssql.instancename />
@@ -87,7 +88,7 @@
         -Dtest.persistence.unit=brmo.persistence.postgresql
         voor oracle:
         -Dtest.persistence.unit=brmo.persistence.oracle
-        de schema's voor posgresql en oracle worden niet automatisch aangemaakt.
+        de schema's voor postgresql en oracle worden niet automatisch aangemaakt.
         -->
         <test.persistence.unit>brmo.persistence.h2</test.persistence.unit>
         <test.h2.version>1.4.200</test.h2.version>
@@ -333,7 +334,7 @@
                 <!-- Bij JNDI db voor postgis verbinding moeten postgis jars in tomcat lib staan -->
             </dependency>
             <dependency>
-                <groupId>com.oracle.jdbc</groupId>
+                <groupId>com.oracle.database.jdbc</groupId>
                 <artifactId>ojdbc8</artifactId>
                 <version>${oracle.jdbc.version}</version>
                 <!-- Bij JNDI db verbinding moeten Oracle jars in tomcat lib staan -->
@@ -1182,18 +1183,16 @@
             <!-- actief voor Travis-CI builds -->
             <id>postgresql</id>
             <properties>
-                <oracle.jdbc.groupId>com.oracle.jdbc</oracle.jdbc.groupId>
+                <oracle.jdbc.groupId>com.oracle.database.jdbc</oracle.jdbc.groupId>
                 <oracle.jdbc.artifactId>ojdbc8</oracle.jdbc.artifactId>
-                <oracle.jdbc.version>12.2.0.1</oracle.jdbc.version>
             </properties>
         </profile>
         <profile>
             <!-- actief voor AppVeyor builds -->
             <id>mssql</id>
             <properties>
-                <oracle.jdbc.groupId>com.oracle.jdbc</oracle.jdbc.groupId>
+                <oracle.jdbc.groupId>com.oracle.database.jdbc</oracle.jdbc.groupId>
                 <oracle.jdbc.artifactId>ojdbc8</oracle.jdbc.artifactId>
-                <oracle.jdbc.version>12.2.0.1</oracle.jdbc.version>
                 <mssql.instancename>SQL2016</mssql.instancename>
             </properties>
         </profile>

--- a/topparser/pom.xml
+++ b/topparser/pom.xml
@@ -82,7 +82,7 @@
             <artifactId>postgis-jdbc</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.oracle.jdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
De driver is nu beschikbaar op Maven Central en we kunnen de driver her-distribueren als we de licentie erbij doen.

- [x] update groupId
- [x] licentie toevoegen


zie: https://medium.com/@kuassimensah/all-in-and-new-groupids-oracle-jdbc-drivers-on-maven-central-a76d545954c6