### PR TITLE
simple logging voor sql server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - PGUSER=postgres
     - PGDATABASE=postgres
     - PGOPTIONS='-c client_min_messages=NOTICE'
+    - BRMO_LOADER_ITEST="true"
 
 addons:
   apt:
@@ -23,7 +24,6 @@ jobs:
     # vanwege build timeout (soms)
     - name: "MS SQL server 2019"
   include:
-      # final release van 9.4 (==EOL): Feb 13, 2020
       # https://www.postgresql.org/support/versioning/
     - name: "PostgreSQL 9.5 (oudste)"
       env: POSTGRESQL_VERSION="9.5" POSTGIS_VERSION="2.4" PROFILE="postgresql"
@@ -49,11 +49,18 @@ jobs:
     - name: "MS SQL server 2017"
       jdk: openjdk8
       dist: xenial
+      env: MSSQL_VERSION="2017" POSTGRESQL_VERSION="" POSTGIS_VERSION="" PROFILE="mssql" MVN_ARGS="-Dmssql.instancename='' -Dit.test=!TopNLIntegrationTest" BRMO_LOADER_ITEST="false"
+    - name: "MS SQL server 2017 brmo-loader"
+      jdk: openjdk8
+      dist: xenial
       env: MSSQL_VERSION="2017" POSTGRESQL_VERSION="" POSTGIS_VERSION="" PROFILE="mssql" MVN_ARGS="-Dmssql.instancename='' -Dit.test=!TopNLIntegrationTest"
     - name: "MS SQL server 2019"
       jdk: openjdk11
       dist: xenial
-      env: MSSQL_VERSION="2019" POSTGRESQL_VERSION="" POSTGIS_VERSION="" PROFILE="mssql" MVN_ARGS="-Dmssql.instancename='' -Dit.test=!TopNLIntegrationTest"
+      env: MSSQL_VERSION="2019" POSTGRESQL_VERSION="" POSTGIS_VERSION="" PROFILE="mssql" MVN_ARGS="-Dmssql.instancename='' -Dit.test=!TopNLIntegrationTest" BRMO_LOADER_ITEST="false"
+    - name: "JavaDoc"
+      jdk: openjdk8
+      env: PROFILE="default"
 
 cache:
   directories:
@@ -136,7 +143,7 @@ before_script:
 script:
   # run unit tests voor alle modules
   # datamodel is een pom module die heeft geen test phase
-  - if [ "$TRAVIS_JOB_NAME" != "database upgrades" ]; then
+  - if [ "$TRAVIS_JOB_NAME" != "database upgrades" ] && [ "$BRMO_LOADER_ITEST" != "true" ]; then
        travis_wait 20 mvn --settings .travis/settings.xml -e test -B -Pstandard-with-extra-repos,$PROFILE -pl '!brmo-dist' -Dtest.onlyITs=false;
        mvn resources:testResources compiler:testCompile surefire:test -P$PROFILE -pl datamodel -Dtest='!*UpgradeTest,!P8*';
     fi
@@ -150,11 +157,13 @@ script:
     fi
   #
   # run integratie tests voor brmo-loader module of alleen topnl, afhankelijk van $MVN_ARGS
-  - printf %'s\n\n' 'start integratie tests voor brmo-loader module'
-  - travis_wait 40 mvn -e verify -B -P$PROFILE $MVN_ARGS -Dtest.onlyITs=true -pl 'brmo-loader'
+  - if [ "$BRMO_LOADER_ITEST" == "true" ]; then
+        printf %'s\n\n' 'start integratie tests voor brmo-loader module';
+        travis_wait 40 mvn -e verify -B -P$PROFILE $MVN_ARGS -Dtest.onlyITs=true -pl 'brmo-loader';
+    fi
   #
   # run integratie tests voor brmo-service module
-  - if [ "$TRAVIS_JOB_NAME" != "TopNL tests" ]; then
+  - if [ "$PROFILE" == "postgresql" ] && [ "$TRAVIS_JOB_NAME" != "TopNL tests" ]; then
         printf %'s\n\n'  'start integratie tests voor brmo-service module';
         mvn -e verify -B -P$PROFILE $MVN_ARGS -Dtest.onlyITs=true -pl 'brmo-service';
     fi
@@ -182,23 +191,20 @@ script:
         printf %'s\n\n' 'start integratie tests voor brmo-commandline module';
         mvn -e verify -B -P$PROFILE $MVN_ARGS -Dtest.onlyITs=true -pl 'brmo-commandline';
     fi
-  #
-  # Linting
   # test of de javadoc compliant is met java-8 strict checks, noodzakelijk voor succesvolle release
-  #
-  - if [ "$TRAVIS_JOB_NAME" == "PostgreSQL 10" ]; then
+  - if [ "$TRAVIS_JOB_NAME" == "JavaDoc" ]; then
         printf %'s\n\n' 'Javadoc checks';
         travis_wait 30 mvn javadoc:javadoc;
     fi
-  - if [ "$TRAVIS_JOB_NAME" == "PostgreSQL 10" ]; then
+  - if [ "$TRAVIS_JOB_NAME" == "JavaDoc" ]; then
         printf %'s\n\n' 'Test Javadoc checks';
         travis_wait 30 mvn javadoc:test-javadoc;
     fi
 
 after_script:
   # deploy maven site van master branch test succes
-  - if [ "$TRAVIS_JOB_NAME" == "PostgreSQL 10" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_TEST_RESULT" == 0 ]; then
-    travis_wait 30 mvn -B -e -T1 site site:stage --settings .travis/settings.xml;
+  - if [ "$TRAVIS_JOB_NAME" == "JavaDoc" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_TEST_RESULT" == 0 ]; then
+        travis_wait 30 mvn -B -e -T1 site site:stage --settings .travis/settings.xml;
     fi
 
 #before_deploy:

--- a/.travis/setup-mssql.sh
+++ b/.travis/setup-mssql.sh
@@ -2,17 +2,21 @@
 export PATH="$PATH:/opt/mssql-tools/bin"
 export SQLCMDINI=.appveyor/init.sql
 # set up staging db
-sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE staging" -d "master"
+sqlcmd -S localhost -U sa -P Password12! -d "master" -Q "CREATE DATABASE staging"
+sqlcmd -S localhost -U sa -P Password12! -d "master" -Q "ALTER DATABASE staging SET RECOVERY SIMPLE"
 sqlcmd -S localhost -U sa -P Password12! -d staging -i ./brmo-persistence/db/create-brmo-persistence-sqlserver.sql
 sqlcmd -S localhost -U sa -P Password12! -d staging -i ./brmo-persistence/db/01_create_indexes.sql
 sqlcmd -S localhost -U sa -P Password12! -d staging -i ./brmo-persistence/db/02_insert_default_user.sql
 sqlcmd -S localhost -U sa -P Password12! -d staging -i ./brmo-persistence/db/05_create_brmo_metadata_sqlserver.sql
 # set up rsgb tabellen
-sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE rsgb" -d "master"
+sqlcmd -S localhost -U sa -P Password12! -d "master" -Q "CREATE DATABASE rsgb"
+sqlcmd -S localhost -U sa -P Password12! -d "master" -Q "ALTER DATABASE rsgb SET RECOVERY SIMPLE"
 sqlcmd -r0 -x -b -S localhost -U sa -P Password12! -d "rsgb" -I -i ./datamodel/generated_scripts/datamodel_sqlserver.sql
 # set up rsgbbgt tabellen
-sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE bgttest" -d "master"
+sqlcmd -S localhost -U sa -P Password12! -d "master" -Q "CREATE DATABASE bgttest"
+sqlcmd -S localhost -U sa -P Password12! -d "master" -Q "ALTER DATABASE bgttest SET RECOVERY SIMPLE"
 sqlcmd -r0 -b -S localhost -I -U sa -P Password12! -d "bgttest" -i ./bgt-gml-loader/target/generated-resources/ddl/sqlserver/create_rsgb_bgt.sql
 # set up topnl tabellen
-sqlcmd -S localhost -U sa -P Password12! -Q "CREATE DATABASE topnl" -d "master"
+sqlcmd -S localhost -U sa -P Password12! -d "master" -Q "CREATE DATABASE topnl"
+sqlcmd -S localhost -U sa -P Password12! -d "master" -Q "ALTER DATABASE topnl SET RECOVERY SIMPLE"
 sqlcmd -r0 -b -S localhost -I -U sa -P Password12! -d "topnl" -i ./topparser/src/main/resources/nl/b3p/topnl/database/sqlserver.sql

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,32 +4,50 @@ pull_requests:
 clone_folder: c:\projects\brmo
 clone_script: echo skip
 skip_tags: true
-max_jobs: 2
+max_jobs: 4
+image: Visual Studio 2019
+
+environment:
+  BGT_ONLY_ITESTS : false
+  LOADER_ONLY_ITESTS : false
+  OTHER_ITESTS : true
+  SQL: MSSQL$SQL2017
+  INSTANCENAME: SQL2017
+  # Microsoft SQL Server 2016 Service Pack 2 heeft een EOL (einde basisondersteuning) van 13-7-2021
+  # wegens in de views gebruikte functies wordt mssql 2016 niet meer ondersteund voor brmo
+  # Microsoft SQL Server 2019 is de jongst-beschikbare release op AppVeyor, maar testen we (ook) op Travis-CI (veel sneller)
+  matrix:
+    - JAVA_HOME: C:\Program Files\Java\jdk11
+      SQL: MSSQL$SQL2019
+      INSTANCENAME: SQL2019
+
+    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+
+    - BGT_ONLY_ITESTS : true
+      JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+      OTHER_ITESTS : false
+
+    - LOADER_ONLY_ITESTS : true
+      JAVA_HOME: C:\Program Files\Java\jdk11
+      SQL: MSSQL$SQL2019
+      INSTANCENAME: SQL2019
+      OTHER_ITESTS : false
+
+    - LOADER_ONLY_ITESTS : true
+      JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+      OTHER_ITESTS : false
+
+matrix:
+  fast_finish: false
 
 init:
   - git config --global core.autocrlf input
   - git config --global core.safecrlf true
   - cmd: net start %SQL%
 
-environment:
-  BGT_ONLY_ITESTS : false
-  SQL: MSSQL$SQL2017
-  INSTANCENAME: SQL2017
-  # Microsoft SQL Server 2016 Service Pack 2 heeft een EOL (einde basisondersteuning) van 13-7-2021
-  # wegens in de views gebruikte functies wordt mssql 2016 niet meer ondersteund voor brmo
-  # Microsoft SQL Server 2017 is de jongst-beschikbare release op AppVeyor, maar testen we (ook) op Travis-CI (veel sneller)
-  matrix:
-    - JAVA_HOME: C:\Program Files\Java\jdk11
-    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-    - BGT_ONLY_ITESTS : true
-      JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-
-matrix:
-  fast_finish: false
-
 install:
   - choco install codecov
-  #- choco install maven
+  - choco install maven
   - cmd: echo %PATH%
   - cmd: java -version
   - cmd: mvn -v
@@ -51,14 +69,14 @@ install:
 
 # initial build/code generation, no testing
 build_script:
-  - mvn install -Dmaven.test.skip=true -B -V -fae -q -Pmssql -pl "!brmo-dist"
+  - mvn install -Dmaven.test.skip=true -Dtest.onlyITs= -B -V -fae -q -Pmssql -pl "!brmo-dist"
 
 # services worden na install gestart en we hebben gegenereerde sql nodig
 after_build:
   - cmd: echo "aanmaken en opzetten STAGING DB"
   - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "master" -Q "CREATE DATABASE staging"
   - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "master" -Q "ALTER DATABASE staging SET RECOVERY SIMPLE"
-  - dir -w .\brmo-persistence\db\
+  - dir .\brmo-persistence\db\
   - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "staging" -i .\brmo-persistence\db\create-brmo-persistence-sqlserver.sql
   - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "staging" -i .\brmo-persistence\db\01_create_indexes.sql
   - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "staging" -i .\brmo-persistence\db\02_insert_default_user.sql
@@ -70,7 +88,7 @@ after_build:
   - cmd: SET SQLCMDINI=.\.appveyor\init.sql
   - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "master" -Q "CREATE DATABASE rsgb"
   - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "master" -Q "ALTER DATABASE rsgb SET RECOVERY SIMPLE"
-  - dir -w .\datamodel\generated_scripts\
+  - dir .\datamodel\generated_scripts\
   - sqlcmd -r0 -x -b -S (local)\%INSTANCENAME% -U sa -P Password12! -d "rsgb" -I -i .\datamodel\generated_scripts\datamodel_sqlserver.sql
 # duurt lang en gemeente/wijk geom hebben we niet echt nodig voor de tests
 #  - sqlcmd -r0 -x -b -S (local)\%INSTANCENAME% -U sa -P Password12! -d "rsgb" -I -i .\datamodel\utility_scripts\sqlserver\111a_update_gemeente_geom.sql
@@ -80,13 +98,13 @@ after_build:
   - cmd: echo "aanmaken en opzetten RSGBBGT DB"
   - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "master" -Q "CREATE DATABASE bgttest"
   - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "master" -Q "ALTER DATABASE bgttest SET RECOVERY SIMPLE"
-  - dir -w .\bgt-gml-loader\target\generated-resources\ddl\sqlserver\
+  - dir .\bgt-gml-loader\target\generated-resources\ddl\sqlserver\
   - sqlcmd -r0 -b -S (local)\%INSTANCENAME% -I -U sa -P Password12! -d "bgttest" -i .\bgt-gml-loader\target\generated-resources\ddl\sqlserver\create_rsgb_bgt.sql
 #
   - cmd: echo "aanmaken en opzetten TOPNL DB"
   - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "master" -Q "CREATE DATABASE topnl"
   - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "master" -Q "ALTER DATABASE topnl SET RECOVERY SIMPLE"
-  - dir -w .\topparser\src\main\resources\nl\b3p\topnl\database
+  - dir .\topparser\src\main\resources\nl\b3p\topnl\database
   - sqlcmd -r0 -b -S (local)\%INSTANCENAME% -I -U sa -P Password12! -d "topnl" -i .\topparser\src\main\resources\nl\b3p\topnl\database\sqlserver.sql
 #
   - cmd: echo "computer name:" %COMPUTERNAME%
@@ -96,21 +114,22 @@ after_build:
 
 test_script:
   # unit tests
-  - mvn -e test -fae -B -Pmssql -pl "!brmo-dist"
-  - mvn -e -B -Pmssql -pl "datamodel" resources:testResources compiler:testCompile surefire:test -Dtest="!*UpgradeTest,!P8*"
+  - if "%OTHER_ITESTS%"=="true" mvn -e test -fae -B -Pmssql -pl "!brmo-dist"
+  - if "%OTHER_ITESTS%"=="true" mvn -e -B -Pmssql -pl "datamodel" resources:testResources compiler:testCompile surefire:test -Dtest="!*UpgradeTest,!P8*"
   # integratie tests
+  # run integratie tests voor brmo-loader module
+  - if "%LOADER_ONLY_ITESTS%"=="true" mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-loader" -Dmssql.instancename=%INSTANCENAME%
   # run integratie tests voor bgt-gml-loader module (30min)
   - if "%BGT_ONLY_ITESTS%"=="true" mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "bgt-gml-loader" -Dmssql.instancename=%INSTANCENAME%
-  # run integratie tests voor brmo-loader module
-  - if "%BGT_ONLY_ITESTS%"=="false" mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-loader" -Dmssql.instancename=%INSTANCENAME%
   # run integratie tests voor brmo-service module
-  - if "%BGT_ONLY_ITESTS%"=="false" mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-service" -Dmssql.instancename=%INSTANCENAME%
+  - if "%OTHER_ITESTS%"=="true" mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-service" -Dmssql.instancename=%INSTANCENAME%
   # run integratie tests voor brmo-soap module
-  - if "%BGT_ONLY_ITESTS%"=="false" mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-soap" -Dmssql.instancename=%INSTANCENAME%
+  - if "%OTHER_ITESTS%"=="true" mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-soap" -Dmssql.instancename=%INSTANCENAME%
   # run integratie tests voor brmo-stufbg204 module
-  - if "%BGT_ONLY_ITESTS%"=="false" mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-stufbg204" -Dmssql.instancename=%INSTANCENAME%
+  - if "%OTHER_ITESTS%"=="true" mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-stufbg204" -Dmssql.instancename=%INSTANCENAME%
   # run integratie tests voor brmo-commandline module
-  - if "%BGT_ONLY_ITESTS%"=="false" mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-commandline" -Dmssql.instancename=%INSTANCENAME%
+  - if "%OTHER_ITESTS%"=="true" mvn -e verify -B -Pmssql -Dtest.onlyITs=true -pl "brmo-commandline" -Dmssql.instancename=%INSTANCENAME%
+  # report code coverage
   - codecov -f target/site/jacoco-it/jacoco.xml target/site/jacoco/jacoco.xml
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,8 @@ build_script:
 # services worden na install gestart en we hebben gegenereerde sql nodig
 after_build:
   - cmd: echo "aanmaken en opzetten STAGING DB"
-  - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -Q "CREATE DATABASE staging" -d "master"
+  - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "master" -Q "CREATE DATABASE staging"
+  - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "master" -Q "ALTER DATABASE staging SET RECOVERY SIMPLE"
   - dir -w .\brmo-persistence\db\
   - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "staging" -i .\brmo-persistence\db\create-brmo-persistence-sqlserver.sql
   - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "staging" -i .\brmo-persistence\db\01_create_indexes.sql
@@ -67,7 +68,8 @@ after_build:
 #
   - cmd: echo "aanmaken en opzetten RSGB DB"
   - cmd: SET SQLCMDINI=.\.appveyor\init.sql
-  - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -Q "CREATE DATABASE rsgb" -d "master"
+  - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "master" -Q "CREATE DATABASE rsgb"
+  - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "master" -Q "ALTER DATABASE rsgb SET RECOVERY SIMPLE"
   - dir -w .\datamodel\generated_scripts\
   - sqlcmd -r0 -x -b -S (local)\%INSTANCENAME% -U sa -P Password12! -d "rsgb" -I -i .\datamodel\generated_scripts\datamodel_sqlserver.sql
 # duurt lang en gemeente/wijk geom hebben we niet echt nodig voor de tests
@@ -76,12 +78,14 @@ after_build:
 #  - sqlcmd -r0 -x -b -S (local)\%INSTANCENAME% -U sa -P Password12! -d "rsgb" -I -i .\datamodel\utility_scripts\sqlserver\113a_update_wijk_geom.sql
 #
   - cmd: echo "aanmaken en opzetten RSGBBGT DB"
-  - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -Q "CREATE DATABASE bgttest" -d "master"
+  - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "master" -Q "CREATE DATABASE bgttest"
+  - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "master" -Q "ALTER DATABASE bgttest SET RECOVERY SIMPLE"
   - dir -w .\bgt-gml-loader\target\generated-resources\ddl\sqlserver\
   - sqlcmd -r0 -b -S (local)\%INSTANCENAME% -I -U sa -P Password12! -d "bgttest" -i .\bgt-gml-loader\target\generated-resources\ddl\sqlserver\create_rsgb_bgt.sql
 #
   - cmd: echo "aanmaken en opzetten TOPNL DB"
-  - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -Q "CREATE DATABASE topnl" -d "master"
+  - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "master" -Q "CREATE DATABASE topnl"
+  - sqlcmd -S (local)\%INSTANCENAME% -U sa -P Password12! -d "master" -Q "ALTER DATABASE topnl SET RECOVERY SIMPLE"
   - dir -w .\topparser\src\main\resources\nl\b3p\topnl\database
   - sqlcmd -r0 -b -S (local)\%INSTANCENAME% -I -U sa -P Password12! -d "topnl" -i .\topparser\src\main\resources\nl\b3p\topnl\database\sqlserver.sql
 #


### PR DESCRIPTION
om te zien of performance van tests beter wordt, timeout voor een build is 60 min bij AppVeyor en 50 min bij Travis-CI (NB variatie is in de orde van een paar minuten)


build | voor /master | simple logging
-- | -- | --
travis mssql 2017 PR | 00:48:34 | 00:49:16
travis mssql 2019 PR | 00:50:00 | 00:48:42
travis mssql 2017 branch | 00:48:34 | 00:47:45
travis mssql 2019 branch | 00:50:00 | 00:48:49
appveyor java 8 PR | 00:58:55 |  00::58:53
appveyor java 11 PR | 01:00:00 | 00:58:56
appveyor BGT PR | 00:42:00 |  00:40:14
appveyor java 8 branch | 00:58:55 | 00:57:50
appveyor java 11 branch | 01:00:00 | 00:57:31
appveyor BGT branch | 00:42:00 | 00:40:57

uitsplitsen van de lang-lopende jobs geeft meer lucht