### PR TITLE
GeoTools upgrade naar 24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <hibernate.version>5.4.21.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
         <geotools.version>24.0</geotools.version>
-        <jdbc-util.version>7.0-SNAPSHOT</jdbc-util.version>
+        <jdbc-util.version>7.0</jdbc-util.version>
         <jts.version>1.17.1</jts.version>
         <itextpdf.version>7.1.12</itextpdf.version>
         <postgresql.jdbc.version>42.2.16</postgresql.jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <netbeans.hint.license>gpl30</netbeans.hint.license>
         <hibernate.version>5.4.21.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
-        <geotools.version>24-RC</geotools.version>
+        <geotools.version>24.0</geotools.version>
         <jdbc-util.version>7.0-SNAPSHOT</jdbc-util.version>
         <jts.version>1.17.1</jts.version>
         <itextpdf.version>7.1.12</itextpdf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <hibernate.version>5.4.21.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
         <geotools.version>24.0</geotools.version>
-        <jdbc-util.version>7.0</jdbc-util.version>
+        <jdbc-util.version>7.1</jdbc-util.version>
         <jts.version>1.17.1</jts.version>
         <itextpdf.version>7.1.12</itextpdf.version>
         <postgresql.jdbc.version>42.2.16</postgresql.jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,9 +62,9 @@
         <netbeans.hint.license>gpl30</netbeans.hint.license>
         <hibernate.version>5.4.21.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
-        <geotools.version>23.2</geotools.version>
-        <jdbc-util.version>6.1</jdbc-util.version>
-        <jts.version>1.16.1</jts.version>
+        <geotools.version>24-RC</geotools.version>
+        <jdbc-util.version>7.0-SNAPSHOT</jdbc-util.version>
+        <jts.version>1.17.1</jts.version>
         <itextpdf.version>7.1.12</itextpdf.version>
         <postgresql.jdbc.version>42.2.16</postgresql.jdbc.version>
         <postgresql.postgis-jdbc.version>2.5.0</postgresql.postgis-jdbc.version>


### PR DESCRIPTION
- [x] Bump GeoTools 23.2 ➜ 24-RC
- [x] Bump JTS 1.16.1 ➜ 1.17.1 (close #910 )
- [x] Bump jdbc-util 6.1 ➜ 7.0-SNAPSHOT
- [x] Bump GeoTools 24-RC ➜ 24.0
- [x] Bump jdbc-util 7.0-SNAPSHOT ➜ 7.0 (depends https://github.com/B3Partners/jdbc-util/pull/138)
- [x] Bump jdbc-util 7.0 ➜ 7.1