### PR TITLE
Voorkom aangeven van detached AutomatischProces in foutafhandeling van een duplicaat GDS2 BRK bericht

### DIFF
--- a/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/GDS2OphalenProces.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/GDS2OphalenProces.java
@@ -638,6 +638,7 @@ public class GDS2OphalenProces extends AbstractExecutableProces {
         }
         lp.setSoort("brk");
         lp.setStatus(LaadProces.STATUS.STAGING_OK);
+        lp.setStatus_datum(new Date());
         SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss");
         lp.setOpmerking("GDS2 download van " + url + " op " + sdf.format(new Date()));
         lp.setAutomatischProces(em.find(AutomatischProces.class, config.getId()));

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/GDS2OphalenProces.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/scanner/GDS2OphalenProces.java
@@ -488,9 +488,7 @@ public class GDS2OphalenProces extends AbstractExecutableProces {
      * @param a de afgifte uit het soap verzoek
      * @param url te downloaden bestand
      * @throws Exception if any
-     * @see
-     * #laadAfgifte(nl.kadaster.schemas.gds2.afgifte_bestandenlijstgbresultaat.afgifte.v20130701.AfgifteGBType,
-     * java.lang.String)
+     * @see #laadAfgifte(AfgifteType, String)
      */
     private void laadBagAfgifte(AfgifteType a, String url) throws Exception {
         String msg = "Downloaden " + url;
@@ -714,14 +712,15 @@ public class GDS2OphalenProces extends AbstractExecutableProces {
             lp.setId(null);
             log.warn("Opslaan van bericht uit laadproces " + lp.getBestand_naam() + " is mislukt.", pe);
             log.warn("Duplicaat bericht: " + b.getObject_ref() + ":" + b.getBr_orgineel_xml() + "(" + b.getBr_xml() + ")");
+            lp.setOpmerking(lp.getOpmerking() + ": Fout, duplicaat bericht. Berichtinhoud: \n\n" + b.getBr_xml());
+            b = null;
             lp.setStatus(LaadProces.STATUS.STAGING_DUPLICAAT);
-            lp.setOpmerking(lp.getOpmerking() + ": Fout, duplicaat bericht. Inhoud: \n" + b.getBr_xml());
+            lp.setAutomatischProces(em.find(AutomatischProces.class, this.config.getId()));
             em.merge(this.config);
             em.persist(lp);
             em.flush();
             em.getTransaction().commit();
             em.clear();
-            b = null;
         }
         return b;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -631,7 +631,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
             <dependency>
                 <groupId>nl.b3p</groupId>
                 <artifactId>kadaster-gds2</artifactId>
-                <version>2.2</version>
+                <version>2.3</version>
             </dependency>
             <!-- J2EE dependencies en stripes -->
             <dependency>


### PR DESCRIPTION
Zoek het bijbehorende automatisch proces opnieuw op omdat de bestaande "detached" is geraakt door de nieuwe transactie

close #924
