### PR TITLE
Bump nl.b3p:kadaster-gds2 van 2.3 naar 2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,7 +328,7 @@
             <dependency>
                 <groupId>nl.b3p</groupId>
                 <artifactId>kadaster-gds2</artifactId>
-                <version>2.3</version>
+                <version>2.4</version>
             </dependency>
             <!-- J2EE dependencies en stripes -->
             <dependency>


### PR DESCRIPTION
In deze update worden een aantal PKI Overheid root certifcaten bijgewerkt.

> ### release notes kadaster-gds2
> :rocket: Nieuw en Verbeterd
> - Toevoegen van "Staat der Nederlanden Private Root" certificaat keten (B3Partners/kadaster-gds2/pull/74) 
>
> https://github.com/B3Partners/kadaster-gds2/releases/tag/v2.4

zie ook: 
- B3Partners/kadaster-gds2/issues/73
- https://www.logius.nl/actueel/blog-pkioverheid-certificaat-vervangingsplan
- https://logius.nl/diensten/pkioverheid/pkioverheid-update/certificaat-vervangingsplan-veelgestelde-vragen
- https://www.ncsc.nl/documenten/factsheets/2020/september/4/factsheet-pkioverheid-verandert