### PR TITLE
neem `net.postgis:postgis-geometry` ook mee in de distributie fileset voor PostgreSQL omgevingen

### DIFF
--- a/brmo-dist/assembly.xml
+++ b/brmo-dist/assembly.xml
@@ -38,6 +38,7 @@
                 <include>com.sun.activation:jakarta.activation</include>
                 <include>org.postgresql:postgresql</include>
                 <include>net.postgis:postgis-jdbc</include>
+                <include>net.postgis:postgis-geometry</include>
             </includes>
             <outputFileNameMapping>${artifact.artifactId}-${artifact.version}.${artifact.extension}</outputFileNameMapping>
         </dependencySet>

--- a/brmo-dist/pom.xml
+++ b/brmo-dist/pom.xml
@@ -83,6 +83,10 @@
             <artifactId>postgis-jdbc</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.postgis</groupId>
+            <artifactId>postgis-geometry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -316,6 +316,11 @@
                 <version>${postgresql.postgis-jdbc.version}</version>
             </dependency>
             <dependency>
+                <groupId>net.postgis</groupId>
+                <artifactId>postgis-geometry</artifactId>
+                <version>${postgresql.postgis-jdbc.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.oracle.database.jdbc</groupId>
                 <artifactId>ojdbc8</artifactId>
                 <version>${oracle.jdbc.version}</version>


### PR DESCRIPTION
dat moet sinds de upgrade naar versie 2.5.0 van de postgis driver

zie:
- https://github.com/postgis/postgis-java/releases/tag/postgis-java-aggregator-2.5.0
- #822