### PR TITLE
Maak de command-line tool runnable op java 11

### DIFF
--- a/brmo-commandline/pom.xml
+++ b/brmo-commandline/pom.xml
@@ -24,6 +24,13 @@
             <artifactId>commons-cli</artifactId>
         </dependency>
         <dependency>
+            <!-- deze is eigenlijk alleen nodig voor java 11, maar
+            omdat we een runnable jar met classpath maken makkelijk om ook voor java 8 er bij te stoppen -->
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jaxb.api.version}</version>
+        </dependency>
+        <dependency>
             <!-- voor jndi / geotools -->
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-catalina</artifactId>
@@ -340,10 +347,11 @@
                 <jdk>[11,)</jdk>
             </activation>
             <dependencies>
-                <dependency>
-                    <groupId>jakarta.xml.bind</groupId>
-                    <artifactId>jakarta.xml.bind-api</artifactId>
-                </dependency>
+<!--   is ook voor java 8 opgenomen             -->
+<!--                <dependency>-->
+<!--                    <groupId>jakarta.xml.bind</groupId>-->
+<!--                    <artifactId>jakarta.xml.bind-api</artifactId>-->
+<!--                </dependency>-->
             </dependencies>
         </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,12 @@
                 <groupId>org.geotools.jdbc</groupId>
                 <artifactId>gt-jdbc-oracle</artifactId>
                 <version>${geotools.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.oracle.database.jdbc</groupId>
+                        <artifactId>ojdbc8</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools.jdbc</groupId>
@@ -282,12 +288,22 @@
                         <groupId>net.sourceforge.jtds</groupId>
                         <artifactId>jtds</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>com.microsoft.sqlserver</groupId>
+                        <artifactId>mssql-jdbc</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools.jdbc</groupId>
                 <artifactId>gt-jdbc-postgis</artifactId>
                 <version>${geotools.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
@@ -1217,8 +1233,8 @@
                 <java.version>8</java.version>
                 <project.build.targetVersion>1.8</project.build.targetVersion>
                 <maven.compiler.target>1.8</maven.compiler.target>
-                <sqlserver.jdbc.version>8.4.1.jre11</sqlserver.jdbc.version>
-                <oracle.jdbc.artifact>ojdbc11</oracle.jdbc.artifact>
+<!--                <sqlserver.jdbc.version>8.4.1.jre11</sqlserver.jdbc.version>-->
+<!--                <oracle.jdbc.artifact>ojdbc11</oracle.jdbc.artifact>-->
             </properties>
             <dependencyManagement>
                 <dependencies>


### PR DESCRIPTION
en voorkom dat we transitief verschillende varsies van database drivers opnemen