### PR TITLE
Upgrade GeoTools van 24.x naar 25.x

### DIFF
--- a/bgt-gml-loader/src/main/java/nl/b3p/brmo/loader/gml/BGTGMLLightLoader.java
+++ b/bgt-gml-loader/src/main/java/nl/b3p/brmo/loader/gml/BGTGMLLightLoader.java
@@ -127,7 +127,7 @@ public class BGTGMLLightLoader {
      * lukt
      */
     public void truncateTables() throws IOException {
-        final JDBCDataStore dataStore = (JDBCDataStore) DataStoreFinder.getDataStore(dbConnProps);
+        final JDBCDataStore dataStore = (JDBCDataStore) DataStoreFinder.getDataStore(DataUtilities.toConnectionParameters(dbConnProps));
         if (dataStore == null) {
             throw new IllegalStateException("Datastore mag niet 'null' zijn voor wissen van data.");
         }
@@ -278,7 +278,7 @@ public class BGTGMLLightLoader {
      */
     private int storeFeatureCollection(InputStream in, String gmlFileName) throws IOException, IllegalStateException, SAXException, ParserConfigurationException {
         int inserts = 0, updates = 0, deletes = 0, features = 0;
-        JDBCDataStore dataStore = (JDBCDataStore) DataStoreFinder.getDataStore(dbConnProps);
+        JDBCDataStore dataStore = (JDBCDataStore) DataStoreFinder.getDataStore(DataUtilities.toConnectionParameters(dbConnProps));
         if (dataStore == null) {
             throw new IllegalStateException("Datastore mag niet 'null' zijn voor opslaan van data.");
         }

--- a/bgt-gml-loader/src/test/java/nl/b3p/brmo/loader/gml/Mantis11620GmlLightLoaderIntegrationTest.java
+++ b/bgt-gml-loader/src/test/java/nl/b3p/brmo/loader/gml/Mantis11620GmlLightLoaderIntegrationTest.java
@@ -1,6 +1,7 @@
 package nl.b3p.brmo.loader.gml;
 
 import org.geotools.data.DataStoreFinder;
+import org.geotools.data.DataUtilities;
 import org.geotools.data.FeatureStore;
 import org.geotools.jdbc.JDBCDataStore;
 import org.junit.jupiter.api.AfterEach;
@@ -78,7 +79,7 @@ public class Mantis11620GmlLightLoaderIntegrationTest extends TestingBase {
         // doublecheck met geotools want die hebben we toch al
         JDBCDataStore dataStore = null;
         try {
-            dataStore = (JDBCDataStore) DataStoreFinder.getDataStore(params);
+            dataStore = (JDBCDataStore) DataStoreFinder.getDataStore(DataUtilities.toConnectionParameters(params));
             FeatureStore store = (FeatureStore) dataStore.getFeatureSource(isOracle ? "wegdeel".toUpperCase() : "wegdeel");
             assertEquals(expected, store.getFeatures().size(), "Aantal features is groter dan verwacht. ");
             dataStore.dispose();

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <hibernate.version>5.4.29.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
-        <geotools.version>24.2</geotools.version>
-        <jdbc-util.version>7.5</jdbc-util.version>
+        <geotools.version>25-RC</geotools.version>
+        <jdbc-util.version>8.0-SNAPSHOT</jdbc-util.version>
         <jts.version>1.18.1</jts.version>
         <itextpdf.version>7.1.14</itextpdf.version>
         <postgresql.jdbc.version>42.2.19</postgresql.jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <hibernate.version>5.4.29.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
         <geotools.version>25.0</geotools.version>
-        <jdbc-util.version>8.0-SNAPSHOT</jdbc-util.version>
+        <jdbc-util.version>8.0</jdbc-util.version>
         <jts.version>1.18.1</jts.version>
         <itextpdf.version>7.1.14</itextpdf.version>
         <postgresql.jdbc.version>42.2.19</postgresql.jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <hibernate.version>5.4.29.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
-        <geotools.version>25-RC</geotools.version>
+        <geotools.version>25.0</geotools.version>
         <jdbc-util.version>8.0-SNAPSHOT</jdbc-util.version>
         <jts.version>1.18.1</jts.version>
         <itextpdf.version>7.1.14</itextpdf.version>


### PR DESCRIPTION
Upgrade notes: https://docs.geotools.org/latest/userguide/welcome/upgrade.html#geotools-25-x

- [x] Bump GeoTools van 24.2 naar 25-RC en jdbc-util van 7.5 naar 8.0-SNAPSHOT
- [x] Bump GeoTools van 25-RC naar 25.0
- [x] Bump jdbc-util van 8.0-SNAPSHOT naar 8.0

depends https://github.com/B3Partners/jdbc-util/pull/192