### PR TITLE
Fix java 11 Windows CI builds

### DIFF
--- a/.github/workflows/windows-sqlserver.yml
+++ b/.github/workflows/windows-sqlserver.yml
@@ -8,6 +8,9 @@ jobs:
   build:
     name: MS SQL developer online test
     runs-on: windows-2019
+    strategy:
+      matrix:
+        java: [ 8, 11 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -22,6 +25,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+# voor TopNL en upgrade test
 #      - name: Cache test data
 #        uses: actions/cache@v2.1.4
 #        with:
@@ -29,15 +33,15 @@ jobs:
 #          key: downloads-${{ hashFiles('**/pom.xml') }}
 #          restore-keys: |
 #            downloads-
+#
+#      - name: Install extra software
+#        run: |
+#          choco install xmlstarlet
 
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 8
-
-#      - name: Install extra software
-#        run: |
-#          choco install xmlstarlet
+          java-version: ${{ matrix.java }}
 
       - name: Priming build
         run: |
@@ -58,8 +62,6 @@ jobs:
         run: mvn --% -e verify -B -Pmssql -Dtest.onlyITs=true -pl "bgt-gml-loader"
 
       - name: Verify brmo-loader
-      # uitzoeken waarom deze op windows faalt
-      #  continue-on-error: true
         run: mvn --% -e verify -B -Pmssql -T1 -Dtest.onlyITs=true -pl "brmo-loader"
 
       - name: Verify brmo-service
@@ -81,5 +83,5 @@ jobs:
 
       - name: Cleanup build artifacts en snapshots
         run: |
-          # mvn --% clean build-helper:remove-project-artifact
-          cmd --% /c for /f %i in ('dir /a:d /s /b %userprofile%\*SNAPSHOT*') do rd /s /q %i
+          mvn --% clean build-helper:remove-project-artifact
+          # cmd --% /c for /f %i in ('dir /a:d /s /b %userprofile%\*SNAPSHOT*') do rd /s /q %i

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,11 +33,11 @@ environment:
       JAVA_HOME: C:\Program Files\Java\jdk1.8.0
       OTHER_ITESTS : false
 
-    #- LOADER_ONLY_ITESTS: true
-    #  JAVA_HOME: C:\Program Files\Java\jdk11
-    #  OTHER_ITESTS: false
-    #  SQL: MSSQL$SQL2019
-    #  INSTANCENAME: SQL2019
+    - LOADER_ONLY_ITESTS: true
+      JAVA_HOME: C:\Program Files\Java\jdk11
+      OTHER_ITESTS: false
+      SQL: MSSQL$SQL2019
+      INSTANCENAME: SQL2019
 
 matrix:
   fast_finish: false

--- a/brmo-loader/pom.xml
+++ b/brmo-loader/pom.xml
@@ -239,11 +239,25 @@
                                 <database.properties.file>sqlserver.properties</database.properties.file>
                                 <project.version>${project.version}</project.version>
                             </systemPropertyVariables>
+                            <!-- tests die falen op windows+java11+maven maar niet op
+                            linux+java8 of java11 of windows+java8+maven -->
                             <excludedGroups>skip-mssql ${skip-windows}</excludedGroups>
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>jdk11+</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+<!--            <dependencies>-->
+<!--                <dependency>-->
+<!--                    <groupId>org.glassfish.jaxb</groupId>-->
+<!--                    <artifactId>jaxb-runtime</artifactId>-->
+<!--                </dependency>-->
+<!--            </dependencies>-->
         </profile>
     </profiles>
 </project>

--- a/brmo-loader/src/test/java/nl/b3p/AbstractDatabaseIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/AbstractDatabaseIntegrationTest.java
@@ -30,6 +30,9 @@ public abstract class AbstractDatabaseIntegrationTest {
      */
     @BeforeAll
     public static void checkDatabaseIsProvided() {
+        // als je vanuit de IDE wilt draaien kun je hier de props instellen
+        // System.setProperty("database.properties.file", "sqlserver.properties");
+        LOG.info("Running with Java version: " + System.getProperty("java.version"));
         assumeNotNull("Verwacht database omgeving te zijn aangegeven.", System.getProperty("database.properties.file"));
     }
 

--- a/brmo-loader/src/test/java/nl/b3p/BRKLocatiebeschrijvingIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/BRKLocatiebeschrijvingIntegrationTest.java
@@ -52,8 +52,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
  *
  * @author mprins
  */
-@Tag("skip-windows") /* test faalt op windows+java11 met windows sql server,
-maar niet op linux+java8 of java11 met dezelfde windows sql server tijdens transformatie... */
+@Tag("skip-windows-java11")
 public class BRKLocatiebeschrijvingIntegrationTest extends AbstractDatabaseIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(BRKLocatiebeschrijvingIntegrationTest.class);
@@ -129,7 +128,7 @@ public class BRKLocatiebeschrijvingIntegrationTest extends AbstractDatabaseInteg
     @ParameterizedTest(name = "Locatie beschrijving #{index}: bestand: {0}")
     @MethodSource("argumentsProvider")
     public void testLocatieBeschrijving(String bestandNaam, long aantalBerichten, String lo_loc__omschr) throws Exception {
-        IDataSet stagingDataSet = new XmlDataSet(new FileInputStream(new File(Mantis6166IntegrationTest.class.getResource(bestandNaam).toURI())));
+        IDataSet stagingDataSet = new XmlDataSet(new FileInputStream(new File(BRKLocatiebeschrijvingIntegrationTest.class.getResource(bestandNaam).toURI())));
 
         if(this.isMsSQL){
             InsertIdentityOperation.CLEAN_INSERT.execute(staging, stagingDataSet);

--- a/brmo-loader/src/test/java/nl/b3p/BrkToStagingToRsgbIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/BrkToStagingToRsgbIntegrationTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -50,6 +51,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
  * @author Boy de Wit
  * @author mprins
  */
+@Tag("skip-windows-java11")
 public class BrkToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(BrkToStagingToRsgbIntegrationTest.class);

--- a/brmo-loader/src/test/java/nl/b3p/GH789GroteWaardeIDIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/GH789GroteWaardeIDIntegrationTest.java
@@ -20,6 +20,7 @@ import org.dbunit.ext.postgresql.PostgresqlDataTypeFactory;
 import org.dbunit.operation.DatabaseOperation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -42,6 +43,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *
  * @author mprins
  */
+@Tag("skip-windows-java11")
 public class GH789GroteWaardeIDIntegrationTest  extends AbstractDatabaseIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(GH789GroteWaardeIDIntegrationTest.class);

--- a/brmo-loader/src/test/java/nl/b3p/Mantis10315IntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/Mantis10315IntegrationTest.java
@@ -20,6 +20,7 @@ import org.dbunit.ext.postgresql.PostgresqlDataTypeFactory;
 import org.dbunit.operation.DatabaseOperation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -39,6 +40,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *
  * @author mprins
  */
+@Tag("skip-windows-java11")
 public class Mantis10315IntegrationTest extends AbstractDatabaseIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(Mantis10315IntegrationTest.class);
@@ -82,7 +84,7 @@ public class Mantis10315IntegrationTest extends AbstractDatabaseIntegrationTest 
             staging.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new PostgresqlDataTypeFactory());
         }
 
-        IDataSet stagingDataSet = new XmlDataSet(new FileInputStream(new File(Mantis6380IntegrationTest.class.getResource("/mantis10315/staging.xml").toURI())));
+        IDataSet stagingDataSet = new XmlDataSet(new FileInputStream(new File(Mantis10315IntegrationTest.class.getResource("/mantis10315/staging.xml").toURI())));
 
         sequential.lock();
 

--- a/brmo-loader/src/test/java/nl/b3p/Mantis10547IntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/Mantis10547IntegrationTest.java
@@ -24,6 +24,7 @@ import org.dbunit.operation.DatabaseOperation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -50,6 +51,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
  *
  * @author mprins
  */
+@Tag("skip-windows-java11")
 public class Mantis10547IntegrationTest extends AbstractDatabaseIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(Mantis10547IntegrationTest.class);
@@ -135,9 +137,9 @@ public class Mantis10547IntegrationTest extends AbstractDatabaseIntegrationTest 
     @ParameterizedTest(name = "{index}: verwerken bestand: {0}")
     @MethodSource("argumentsProvider")
     public void testAll(final String bestandsNaam, final long aantalProcessen, final long aantalBerichten) throws Exception {
-        assumeTrue(Mantis6166IntegrationTest.class.getResource(bestandsNaam) != null,
+        assumeTrue(Mantis10547IntegrationTest.class.getResource(bestandsNaam) != null,
                 "Het bestand met testdata zou moeten bestaan.");
-        IDataSet stagingDataSet = new XmlDataSet(new FileInputStream(new File(Mantis6166IntegrationTest.class.getResource(bestandsNaam).toURI())));
+        IDataSet stagingDataSet = new XmlDataSet(new FileInputStream(new File(Mantis10547IntegrationTest.class.getResource(bestandsNaam).toURI())));
         if (this.isMsSQL) {
             // SET IDENTITY_INSERT op ON
             InsertIdentityOperation.CLEAN_INSERT.execute(staging, stagingDataSet);

--- a/brmo-loader/src/test/java/nl/b3p/Mantis11180IntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/Mantis11180IntegrationTest.java
@@ -21,6 +21,7 @@ import org.dbunit.operation.DatabaseOperation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -44,6 +45,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *
  * @author mprins
  */
+@Tag("skip-windows-java11")
 public class Mantis11180IntegrationTest extends AbstractDatabaseIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(Mantis11180IntegrationTest.class);

--- a/brmo-loader/src/test/java/nl/b3p/Mantis6098IntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/Mantis6098IntegrationTest.java
@@ -39,6 +39,7 @@ import static org.junit.jupiter.api.Assumptions.*;
  *
  * @author mprins
  */
+@Tag("skip-windows-java11")
 public class Mantis6098IntegrationTest extends AbstractDatabaseIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(Mantis6098IntegrationTest.class);

--- a/brmo-loader/src/test/java/nl/b3p/Mantis6166IntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/Mantis6166IntegrationTest.java
@@ -23,9 +23,9 @@ import org.dbunit.ext.oracle.Oracle10DataTypeFactory;
 import org.dbunit.ext.postgresql.PostgresqlDataTypeFactory;
 import org.dbunit.operation.DatabaseOperation;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -37,6 +37,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -49,6 +50,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
  *
  * @author mprins
  */
+@Tag("skip-windows-java11")
 public class Mantis6166IntegrationTest extends AbstractDatabaseIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(Mantis6166IntegrationTest.class);
@@ -102,7 +104,7 @@ public class Mantis6166IntegrationTest extends AbstractDatabaseIntegrationTest {
             rsgb.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new PostgresqlDataTypeFactory());
             staging.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new PostgresqlDataTypeFactory());
         } else {
-            Assertions.fail("Geen ondersteunde database aangegegeven.");
+            fail("Geen ondersteunde database aangegegeven.");
         }
 
         brmo = new BrmoFramework(dsStaging, dsRsgb);
@@ -184,8 +186,7 @@ public class Mantis6166IntegrationTest extends AbstractDatabaseIntegrationTest {
      *
      * @throws Exception if any
      */
-    @DisplayName("Stand en mutatie")
-    @ParameterizedTest(name = "{index}: verwerken bestand: {0}")
+    @ParameterizedTest(name = "Stand en mutatie #{index}: verwerken bestand: {0}")
     @MethodSource("argumentsProvider")
     public void testStandMutatie(final String bestandsNaam, final long aantalProcessen, final long aantalBerichten, final long stand, final long verwijder, final long[] mutaties) throws Exception {
         loadData( bestandsNaam,   aantalProcessen,   aantalBerichten);
@@ -222,8 +223,7 @@ public class Mantis6166IntegrationTest extends AbstractDatabaseIntegrationTest {
      *
      * @throws Exception if any
      */
-    @DisplayName("All")
-    @ParameterizedTest(name = "{index}: verwerken bestand: {0}")
+    @ParameterizedTest(name = "All #{index}: verwerken bestand: {0}")
     @MethodSource("argumentsProvider")
     public void testAll(final String bestandsNaam, final long aantalProcessen, final long aantalBerichten, final long stand, final long verwijder, final long[] mutaties) throws Exception {
         loadData( bestandsNaam,   aantalProcessen,   aantalBerichten);
@@ -256,8 +256,7 @@ public class Mantis6166IntegrationTest extends AbstractDatabaseIntegrationTest {
      *
      * @throws Exception if any
      */
-    @DisplayName("Stand en delete")
-    @ParameterizedTest(name = "{index}: verwerken bestand: {0}")
+    @ParameterizedTest(name = "Stand en delete #{index}: verwerken bestand: {0}")
     @MethodSource("argumentsProvider")
     public void testStandDelete(final String bestandsNaam, final long aantalProcessen, final long aantalBerichten, final long stand, final long verwijder, final long[] mutaties) throws Exception {
         loadData( bestandsNaam,   aantalProcessen,   aantalBerichten);
@@ -294,8 +293,7 @@ public class Mantis6166IntegrationTest extends AbstractDatabaseIntegrationTest {
      *
      * @throws Exception if any
      */
-    @DisplayName("Stand en delete en mutatie")
-    @ParameterizedTest(name = "{index}: verwerken bestand: {0}")
+    @ParameterizedTest(name = "Stand en delete en mutatie #{index}: verwerken bestand: {0}")
     @MethodSource("argumentsProvider")
     public void testStandDeleteMutatie(final String bestandsNaam, final long aantalProcessen, final long aantalBerichten, final long stand, final long verwijder, final long[] mutaties) throws Exception {
         loadData( bestandsNaam,   aantalProcessen,   aantalBerichten);

--- a/brmo-loader/src/test/java/nl/b3p/Mantis6380IntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/Mantis6380IntegrationTest.java
@@ -24,6 +24,7 @@ import org.dbunit.operation.DatabaseOperation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -42,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @author mprins
  */
+@Tag("skip-windows-java11")
 public class Mantis6380IntegrationTest extends AbstractDatabaseIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(Mantis6380IntegrationTest.class);

--- a/brmo-loader/src/test/java/nl/b3p/TopNLParserTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/TopNLParserTest.java
@@ -28,9 +28,9 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
  *
  * @author Mark Prins
  */
-public class TopNLParserIntegrationTest {
+public class TopNLParserTest {
 
-    private static final Log LOG = LogFactory.getLog(TopNLParserIntegrationTest.class);
+    private static final Log LOG = LogFactory.getLog(TopNLParserTest.class);
 
     static Stream<Arguments> argumentsProvider() {
         return Stream.of(
@@ -79,10 +79,10 @@ public class TopNLParserIntegrationTest {
     public void testParse(final TopNLType bestandType, final String bestandNaam) throws Exception {
 
         // omdat soms de bestandsnaam wordt aangepast moet dit een harde test fout zijn, dus geen assumeNotNull
-        assertNotNull(TopNLParserIntegrationTest.class.getResource(bestandNaam),
+        assertNotNull(TopNLParserTest.class.getResource(bestandNaam),
                 "Het opgehaalde test bestand moet er zijn in deze omgeving.");
 
-        URL in = TopNLParserIntegrationTest.class.getResource(bestandNaam);
+        URL in = TopNLParserTest.class.getResource(bestandNaam);
         List jaxb = instance.parse(in);
         assertNotNull(jaxb);
         assertTrue(jaxb.size() > 1, "Er moet meer dan 1 element in de parse lijst zitten");

--- a/brmo-loader/src/test/java/nl/b3p/VerminderenStukdelenIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/VerminderenStukdelenIntegrationTest.java
@@ -21,6 +21,7 @@ import org.dbunit.ext.postgresql.PostgresqlDataTypeFactory;
 import org.dbunit.operation.DatabaseOperation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -43,6 +44,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *
  * @author mprins
  */
+@Tag("skip-windows-java11")
 public class VerminderenStukdelenIntegrationTest extends AbstractDatabaseIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(VerminderenStukdelenIntegrationTest.class);

--- a/brmo-loader/src/test/java/nl/b3p/ZakRechtArchiefIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/ZakRechtArchiefIntegrationTest.java
@@ -21,6 +21,7 @@ import org.dbunit.operation.DatabaseOperation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -35,15 +36,15 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * Testcases voor creeeren van zak_recht_archief tabel
 
  * Draaien met:
- * {@code mvn -Dit.test=ZakRechtArchiefIntegrationTest -Dtest.onlyITs=true verify -Poracle > target/oracle.log}
+ * {@code mvn -Dit.test=ZakRechtArchiefIntegrationTest -Dtest.onlyITs=true verify -Poracle -pl brmo-loader > target/oracle.log}
  * voor bijvoorbeeld Oracle of
- * {@code mvn -Dit.test=ZakRechtArchiefIntegrationTest -Dtest.onlyITs=true verify -Ppostgresql > target/postgresql.log}
+ * {@code mvn -Dit.test=ZakRechtArchiefIntegrationTest -Dtest.onlyITs=true verify -Ppostgresql -pl brmo-loader > target/postgresql.log}
  * of
- * {@code mvn -Dit.test=ZakRechtArchiefIntegrationTest -Dtest.onlyITs=true verify -Pmssql > target/mssql.log}.
+ * {@code mvn -Dit.test=ZakRechtArchiefIntegrationTest -Dtest.onlyITs=true verify -Pmssql -pl brmo-loader > target/mssql.log}.
  *
  * @author meine
  */
-
+@Tag("skip-windows-java11")
 public class ZakRechtArchiefIntegrationTest extends AbstractDatabaseIntegrationTest{
 
     private static final Log LOG = LogFactory.getLog(ZakRechtArchiefIntegrationTest.class);
@@ -88,7 +89,7 @@ public class ZakRechtArchiefIntegrationTest extends AbstractDatabaseIntegrationT
             rsgb.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new PostgresqlDataTypeFactory());
             staging.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new PostgresqlDataTypeFactory());
         }
-        IDataSet stagingDataSet = new XmlDataSet(new FileInputStream(new File(Mantis6380IntegrationTest.class.getResource("/zak_recht_archief/staging.xml").toURI())));
+        IDataSet stagingDataSet = new XmlDataSet(new FileInputStream(new File(ZakRechtArchiefIntegrationTest.class.getResource("/zak_recht_archief/staging.xml").toURI())));
 
         sequential.lock();
 

--- a/brmo-loader/src/test/java/nl/b3p/brmo/loader/entity/BagBerichtIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/brmo/loader/entity/BagBerichtIntegrationTest.java
@@ -23,6 +23,7 @@ import org.dbunit.ext.postgresql.PostgresqlDataTypeFactory;
 import org.dbunit.operation.DatabaseOperation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -48,6 +49,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  *
  * @author mprins
  */
+@Tag("skip-windows-java11")
 public class BagBerichtIntegrationTest extends AbstractDatabaseIntegrationTest {
 
     private static final Log LOG = LogFactory.getLog(BagBerichtIntegrationTest.class);

--- a/brmo-loader/src/test/resources/topnl/readme.md
+++ b/brmo-loader/src/test/resources/topnl/readme.md
@@ -1,5 +1,6 @@
-Bestanden voor de TopNL integratie tests.
+Bestanden voor de TopNL (integratie) tests.
 
 deze files worden op de build servers overschreven door zojuist van pdok opgehaalde bestanden.
 
-zie /.jenkins/data-prepare-topnl.sh
+zie:
+- .build/ci/data-prepare-topnl.sh

--- a/brmo-stufbg204/pom.xml
+++ b/brmo-stufbg204/pom.xml
@@ -93,6 +93,11 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-dbcp2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/brmo-topnl-loader/pom.xml
+++ b/brmo-topnl-loader/pom.xml
@@ -17,30 +17,20 @@
             <artifactId>jdbc-util</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.geotools.xsd</groupId>
-            <artifactId>gt-xsd-gml3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-epsg-hsql</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.geotools.jdbc</groupId>
-            <artifactId>gt-jdbc-oracle</artifactId>
+            <groupId>org.geotools.xsd</groupId>
+            <artifactId>gt-xsd-gml3</artifactId>
         </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.geotools.jdbc</groupId>-->
+<!--            <artifactId>gt-jdbc-oracle</artifactId>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jdom</groupId>
@@ -49,14 +39,6 @@
         <dependency>
             <groupId>commons-dbutils</groupId>
             <artifactId>commons-dbutils</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-dbcp2</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hsqldb</groupId>
-            <artifactId>hsqldb</artifactId>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -69,11 +51,25 @@
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>${oracle.jdbc.artifact}</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hsqldb</groupId>
+            <artifactId>hsqldb</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>
@@ -129,61 +125,10 @@
         </activation>
             <dependencies>
                 <dependency>
-                    <groupId>jakarta.xml.bind</groupId>
-                    <artifactId>jakarta.xml.bind-api</artifactId>
-                    <scope>provided</scope>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.activation</groupId>
-                    <artifactId>jakarta.activation-api</artifactId>
-                </dependency>
-                <dependency>
                     <groupId>org.glassfish.jaxb</groupId>
                     <artifactId>jaxb-runtime</artifactId>
                 </dependency>
             </dependencies>
-<!--            <build>-->
-<!--                <pluginManagement>-->
-<!--                    <plugins>-->
-<!--                        <plugin>-->
-<!--                            <artifactId>maven-compiler-plugin</artifactId>-->
-<!--                            <executions>-->
-<!--                                <execution>-->
-<!--                                    <id>default-compile</id>-->
-<!--                                    <configuration>-->
-<!--                                        &lt;!&ndash; compile everything to ensure module-info contains right entries &ndash;&gt;-->
-<!--                                        <release>9</release>-->
-<!--                                    </configuration>-->
-<!--                                </execution>-->
-<!--                                <execution>-->
-<!--                                    <id>base-compile</id>-->
-<!--                                    <goals>-->
-<!--                                        <goal>compile</goal>-->
-<!--                                    </goals>-->
-<!--                                    &lt;!&ndash; recompile everything for target VM except the module-info.java &ndash;&gt;-->
-<!--                                    <configuration>-->
-<!--                                        <excludes>-->
-<!--                                            <exclude>module-info.java</exclude>-->
-<!--                                        </excludes>-->
-<!--                                        <source>${java.version}</source>-->
-<!--                                        <target>${java.version}</target>-->
-<!--                                    </configuration>-->
-<!--                                </execution>-->
-<!--                            </executions>-->
-<!--                            <configuration>-->
-<!--                                <source>${java.version}</source>-->
-<!--                                <target>${java.version}</target>-->
-<!--                            </configuration>-->
-<!--                        </plugin>-->
-<!--                        <plugin>-->
-<!--                            <artifactId>maven-surefire-plugin</artifactId>-->
-<!--                            <configuration>-->
-<!--                                <argLine>&#45;&#45;add-opens java.ws.rs/javax.ws.rs.core=java.xml.bind</argLine>-->
-<!--                            </configuration>-->
-<!--                        </plugin>-->
-<!--                    </plugins>-->
-<!--                </pluginManagement>-->
-<!--            </build>-->
         </profile>
     </profiles>
 </project>

--- a/brmo-topnl-loader/src/main/java/nl/b3p/topnl/Processor.java
+++ b/brmo-topnl-loader/src/main/java/nl/b3p/topnl/Processor.java
@@ -25,8 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.sql.DataSource;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;

--- a/brmo-topnl-loader/src/src-main/java/nl/b3p/topnl/Main.java
+++ b/brmo-topnl-loader/src/src-main/java/nl/b3p/topnl/Main.java
@@ -37,7 +37,13 @@ import org.xml.sax.SAXException;
  */
 public class Main {
     protected final static Log log = LogFactory.getLog(Main.class);
-    
+
+    // voeg deze dependency toe als je wilt draaien
+    // <dependency>
+    //     <groupId>org.apache.commons</groupId>
+    //     <artifactId>commons-dbcp2</artifactId>
+    // </dependency>
+
     public static void main (String[] args) throws IOException, JAXBException, ParseException, SQLException, JDOMException{
         try {
             BasicDataSource ds = new BasicDataSource();

--- a/pom.xml
+++ b/pom.xml
@@ -1242,15 +1242,20 @@
             </activation>
         </profile>
         <profile>
-            <id>windows</id>
+            <id>windows-java11-mvn</id>
             <activation>
                 <os>
                     <family>Windows</family>
                 </os>
+                <jdk>[11,)</jdk>
+                <property>
+                    <name>maven.version</name>
+                    <value>3.6.3</value>
+                </property>
             </activation>
             <properties>
                 <!-- zodat we getaggede tests kunnen skippen met failsafe -->
-                <skip-windows>,skip-windows</skip-windows>
+                <skip-windows>,skip-windows-java11</skip-windows>
             </properties>
         </profile>
         <profile>
@@ -1262,8 +1267,6 @@
                 <java.version>8</java.version>
                 <project.build.targetVersion>1.8</project.build.targetVersion>
                 <maven.compiler.target>1.8</maven.compiler.target>
-<!--                <sqlserver.jdbc.version>8.4.1.jre11</sqlserver.jdbc.version>-->
-<!--                <oracle.jdbc.artifact>ojdbc11</oracle.jdbc.artifact>-->
             </properties>
             <dependencyManagement>
                 <dependencies>


### PR DESCRIPTION
workaround voor testcases:

- [x] `BRKLocatiebeschrijvingIntegrationTest`
- [x] `BrkToStagingToRsgbIntegrationTest`
- [x] `GH789GroteWaardeIDIntegrationTest`
- [x] `Mantis6098IntegrationTest`
- [x] `Mantis6166IntegrationTest`
- [x] `Mantis6380IntegrationTest`
- [x] `Mantis10315IntegrationTest`
- [x] `Mantis10547IntegrationTest`
- [x] `Mantis11180IntegrationTest`
- [x] `VerminderenStukdelenIntegrationTest`
- [x] `ZakRechtArchiefIntegrationTest`
- [x] `BagBerichtIntegrationTest`

Deze test wordt voorlopig overgeslagen als testcases vanuit Maven op Windows met Java 11 draaien omdat het pad naar de `gml.xsd` ongeldig is / verkeer geconstrueerd wordt.

close #1028