### PR TITLE
sla brekende brmo-loader windows/java 11 integratie tests over

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1178,11 +1178,13 @@
                     <family>Windows</family>
                 </os>
                 <jdk>[11,)</jdk>
+                <!-- de versie van Maven op de github runner; als er een update is geweest kan het zijn dat de tests weer proberen te draaien...
+                     appveyor heeft een andere versie...
                 <property>
-                    <!-- de versie van Maven op de github runner; als er een update is geweest kan het zijn dat de tests weer proberen te draaien... -->
                     <name>maven.version</name>
                     <value>3.8.1</value>
                 </property>
+                     -->
             </activation>
             <properties>
                 <!-- zodat we getaggede tests kunnen skippen met failsafe -->


### PR DESCRIPTION
typische melding in de stack trace:

```
java.nio.file.InvalidPathException: Illegal char <:> at index 21: org\geotools\gml3\jar:file:\C:\Users\appveyor\.m2\repository\org\geotools\xsd\gt-xsd-gml3\25.1\gt-xsd-gml3-25.1.jar!\org\geotools\gml3\gml.xsd
	at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
	at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
```