### PR TITLE
Bump nl.b3p:kadaster-gds2 van 2.4 naar 2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
             <dependency>
                 <groupId>nl.b3p</groupId>
                 <artifactId>kadaster-gds2</artifactId>
-                <version>2.4</version>
+                <version>2.5</version>
             </dependency>
             <!-- J2EE dependencies en stripes -->
             <dependency>


### PR DESCRIPTION
release notes: https://github.com/B3Partners/kadaster-gds2/releases/tag/v2.5