### PR TITLE
[BRMO-74] gebruik generieke fout pagina's

### DIFF
--- a/brmo-proxyservice/src/main/webapp/WEB-INF/web.xml
+++ b/brmo-proxyservice/src/main/webapp/WEB-INF/web.xml
@@ -50,5 +50,30 @@
         <servlet-name>BAG_file</servlet-name>
         <!-- <servlet-name>BAG_proxy</servlet-name> -->
         <url-pattern>/post/bag</url-pattern>
-    </servlet-mapping>       
+    </servlet-mapping>
+
+    <error-page>
+        <error-code>400</error-code>
+        <location>/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>403</error-code>
+        <location>/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>404</error-code>
+        <location>/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>415</error-code>
+        <location>/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>500</error-code>
+        <location>/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>503</error-code>
+        <location>/error.jsp</location>
+    </error-page>
 </web-app>

--- a/brmo-proxyservice/src/main/webapp/error.jsp
+++ b/brmo-proxyservice/src/main/webapp/error.jsp
@@ -1,0 +1,21 @@
+<%@page contentType="text/html" pageEncoding="UTF-8" isErrorPage="true" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>BRMO Proxy Service: Fout</title>
+    <meta charset="utf-8">
+</head>
+<body class="x-body">
+
+<div class="header">
+    <h1>B3Partners BRMO</h1>
+</div>
+
+<div class="content">
+    <h1>Fout</h1>
+    <p>Er is een fout opgetreden. Neem contact op met de beheerder als deze zich voor blijft doen.</p>
+    <p>Fout code: ${requestScope['javax.servlet.error.status_code']}</p>
+    <p><i>${requestScope['javax.servlet.error.message']}</i></p>
+</div>
+</body>
+</html>

--- a/brmo-service/src/main/webapp/WEB-INF/jsp/error.jsp
+++ b/brmo-service/src/main/webapp/WEB-INF/jsp/error.jsp
@@ -1,0 +1,30 @@
+<%@page contentType="text/html" pageEncoding="UTF-8" isErrorPage="true" %>
+<%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>BRMO Service: Fout</title>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <link rel="stylesheet" type="text/css" href="/brmo-service/styles/main.css">
+    <link rel="stylesheet" type="text/css" href="/brmo-service/extjs/resources/css/crisp/ext-theme-crisp-all.css">
+</head>
+<body class="x-body">
+
+<div class="header">
+    <h1>B3Partners BRMO</h1>
+    <ul>
+        <li><a href="${pageContext.request.contextPath}/index.jsp">&#155; Home</a></li>
+    </ul>
+</div>
+
+<div class="content">
+    <h1>Fout</h1>
+    <p>Er is een fout opgetreden. Neem contact op met de beheerder als deze zich voor blijft doen.</p>
+    <p>Fout code: <c:out value="${requestScope['javax.servlet.error.status_code']}"/></p>
+    <p><i><c:out value="${requestScope['javax.servlet.error.message']}"/></i></p>
+</div>
+
+<div class="footer"></div>
+</body>
+</html>

--- a/brmo-service/src/main/webapp/WEB-INF/web.xml
+++ b/brmo-service/src/main/webapp/WEB-INF/web.xml
@@ -203,4 +203,29 @@
     <welcome-file-list>
         <welcome-file>index.jsp</welcome-file>
     </welcome-file-list>
+
+    <error-page>
+        <error-code>400</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>403</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>404</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>415</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>500</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>503</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
 </web-app>

--- a/brmo-service/src/test/java/nl/b3p/web/ErrorPageIntegrationTest.java
+++ b/brmo-service/src/test/java/nl/b3p/web/ErrorPageIntegrationTest.java
@@ -1,0 +1,45 @@
+package nl.b3p.web;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ErrorPageIntegrationTest extends WebTestUtil {
+    /**
+     * onze test response.
+     */
+    private HttpResponse response;
+
+    @Test
+    public void testBestaatNiet() throws IOException {
+        response = client.execute(new HttpGet(BASE_TEST_URL + "/bestaat/niet"));
+        // server side redirect naar login pagina
+        final String body = EntityUtils.toString(response.getEntity());
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode(), "Response status is niet OK.");
+        assertNotNull(body, "Response body mag niet null zijn.");
+        assertTrue(body.contains("Inloggen"), "body bevat geen inlog formulier.");
+    }
+
+    @Test
+    public void test404Style() throws IOException {
+        response = client.execute(new HttpGet(BASE_TEST_URL + "/styles/"));
+
+        final String body = EntityUtils.toString(response.getEntity());
+        assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusLine().getStatusCode(), "Response status is niet 404.");
+        assertNotNull(body, "Response body mag niet null zijn.");
+        // generieke error pagina bevat Tomcat + versienummer; dat willen we niet zien
+        assertFalse(body.contains("Tomcat"));
+    }
+
+    @Override
+    public void setUp() throws Exception {/* void implementatie */}
+}

--- a/brmo-soap/src/main/webapp/WEB-INF/jsp/error.jsp
+++ b/brmo-soap/src/main/webapp/WEB-INF/jsp/error.jsp
@@ -1,0 +1,26 @@
+<%@page contentType="text/html" pageEncoding="UTF-8" isErrorPage="true" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>BRMO SOAP Services: Fout</title>
+    <meta charset="utf-8">
+</head>
+<body class="x-body">
+
+<div class="header">
+    <h1>B3Partners BRMO</h1>
+    <ul>
+        <li><a href="${pageContext.request.contextPath}/index.html">Home</a></li>
+    </ul>
+</div>
+
+<div class="content">
+    <h1>Fout</h1>
+    <p>Er is een fout opgetreden. Neem contact op met de beheerder als deze zich voor blijft doen.</p>
+    <p>Fout code: ${requestScope['javax.servlet.error.status_code']}</p>
+    <p><i>${requestScope['javax.servlet.error.message']}</i></p>
+</div>
+
+<div class="footer"></div>
+</body>
+</html>

--- a/brmo-soap/src/main/webapp/WEB-INF/web.xml
+++ b/brmo-soap/src/main/webapp/WEB-INF/web.xml
@@ -54,11 +54,33 @@
         <url-pattern>/EigendomMutatieService</url-pattern>
     </servlet-mapping>
     <session-config>
-        <session-timeout>
-            30
-        </session-timeout>
+        <session-timeout>30</session-timeout>
     </session-config>
     <welcome-file-list>
         <welcome-file>index.html</welcome-file>
     </welcome-file-list>
+    <error-page>
+        <error-code>400</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>403</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>404</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>415</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>500</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>503</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
 </web-app>

--- a/brmo-stufbg204/src/main/webapp/WEB-INF/jsp/error.jsp
+++ b/brmo-stufbg204/src/main/webapp/WEB-INF/jsp/error.jsp
@@ -1,0 +1,26 @@
+<%@page contentType="text/html" pageEncoding="UTF-8" isErrorPage="true" %>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>BRMO StUF BG 2.04 Services: Fout</title>
+    <meta charset="utf-8">
+</head>
+<body class="x-body">
+
+<div class="header">
+    <h1>B3Partners BRMO</h1>
+    <ul>
+        <li><a href="${pageContext.request.contextPath}/index.html">Home</a></li>
+    </ul>
+</div>
+
+<div class="content">
+    <h1>Fout</h1>
+    <p>Er is een fout opgetreden. Neem contact op met de beheerder als deze zich voor blijft doen.</p>
+    <p>Fout code: ${requestScope['javax.servlet.error.status_code']}</p>
+    <p><i>${requestScope['javax.servlet.error.message']}</i></p>
+</div>
+
+<div class="footer"></div>
+</body>
+</html>

--- a/brmo-stufbg204/src/main/webapp/WEB-INF/web.xml
+++ b/brmo-stufbg204/src/main/webapp/WEB-INF/web.xml
@@ -63,4 +63,30 @@
     <welcome-file-list>
         <welcome-file>index.html</welcome-file>
     </welcome-file-list>
+
+
+    <error-page>
+        <error-code>400</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>403</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>404</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>415</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>500</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
+    <error-page>
+        <error-code>503</error-code>
+        <location>/WEB-INF/jsp/error.jsp</location>
+    </error-page>
 </web-app>

--- a/brmo-stufbg204/src/test/java/nl/b3p/brmo/stufbg204/ErrorPageIntegrationTest.java
+++ b/brmo-stufbg204/src/test/java/nl/b3p/brmo/stufbg204/ErrorPageIntegrationTest.java
@@ -1,0 +1,36 @@
+package nl.b3p.brmo.stufbg204;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ErrorPageIntegrationTest extends WebTestStub {
+
+    /**
+     * onze test response.
+     */
+    private HttpResponse response;
+
+    @Test
+    public void test404() throws IOException {
+        response = client.execute(new HttpGet(BASE_TEST_URL + "/styles/"));
+
+        final String body = EntityUtils.toString(response.getEntity());
+        assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusLine().getStatusCode(), "Response status is niet 404.");
+        assertNotNull(body, "Response body mag niet null zijn.");
+        // generieke error pagina bevat Tomcat + versienummer; dat willen we niet zien
+        assertFalse(body.contains("Tomcat"));
+    }
+
+    @Override
+    public void setUp() throws Exception {/* void implementatie */}
+}


### PR DESCRIPTION
gebruik generieke foutpagina's die geen zaken verklappen over de internals of de runtime omgeving.

NB. de internals van de applicatie zijn natuurlijk altijd beschikbaar omdat dit een open source product is en error pages kunnen bijv. ook door een (Apache httpd) proxy worden afgeleverd.

Custom error page voor de meest voorkomende fout codes voor:
- [x] brmo-soap
- [x] brmo-service
- [x] brmo-stufbg204
- [x] brmo-proxyservice

close [BRMO-74]

[BRMO-74]: https://b3partners.atlassian.net/browse/BRMO-74