### PR TITLE
Use GeoTools gml-geometry-streaming module in DataComfortXMLReader

### DIFF
--- a/brmo-loader/pom.xml
+++ b/brmo-loader/pom.xml
@@ -79,9 +79,6 @@
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-gml-geometry-streaming</artifactId>
-            <!-- NOTE: we use a SNAPSHOT version, as this module is not yet released! -->
-            <version>26-SNAPSHOT</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.geotools.jdbc</groupId>

--- a/brmo-loader/pom.xml
+++ b/brmo-loader/pom.xml
@@ -77,6 +77,13 @@
             <artifactId>gt-xsd-gml3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-gml-geometry-streaming</artifactId>
+            <!-- NOTE: we use a SNAPSHOT version, as this module is not yet released! -->
+            <version>26-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.geotools.jdbc</groupId>
             <artifactId>gt-jdbc-oracle</artifactId>
         </dependency>

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/util/DataComfortXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/util/DataComfortXMLReader.java
@@ -175,6 +175,10 @@ public class DataComfortXMLReader {
 
                         // Detecteer XML elementen of text
                         xer.next();
+			// Skip whitespace before a possible element
+                        while(xer.isWhiteSpace()) {
+                            xer.next();
+                        }
                         if (xer.isStartElement()) {
                             Split split2 = SimonManager.getStopwatch("b3p.util.datacomfortxmlreader.parsegml").start();
 

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/util/DataComfortXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/util/DataComfortXMLReader.java
@@ -4,6 +4,8 @@ import org.geotools.gml.stream.XmlStreamGeometryReader;
 import org.javasimon.SimonManager;
 import org.javasimon.Split;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Polygon;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
@@ -163,6 +165,10 @@ public class DataComfortXMLReader {
                             Split split2 = SimonManager.getStopwatch("b3p.util.datacomfortxmlreader.parsegml").start();
 
                             Geometry geom = geometryReader.readGeometry();
+                            // TODO/HACK force polygon to multi-polygon
+                            if (geom instanceof Polygon) {
+                                geom = new MultiPolygon(new Polygon[]{(Polygon) geom}, geom.getFactory());
+                            }
 
                             // Note: this linearizes curves, we could use a WKTWriter2 instead!
                             row.getValues().add(geom.toString());

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/util/DataComfortXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/util/DataComfortXMLReader.java
@@ -8,7 +8,6 @@ import org.locationtech.jts.geom.Geometry;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.transform.Source;
-import javax.xml.transform.TransformerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,8 +22,6 @@ public class DataComfortXMLReader {
     private static final int LEVEL_COMFORT = 2;
     private static final int LEVEL_TABLE = 3;
     private static final int LEVEL_DELETE = 4;
-
-    private final TransformerFactory tf = TransformerFactory.newInstance();
     private final XMLInputFactory xif = XMLInputFactory.newInstance();
 
     public DataComfortXMLReader() {
@@ -39,7 +36,7 @@ public class DataComfortXMLReader {
         XmlStreamGeometryReader geometryReader = new XmlStreamGeometryReader(xer);
 
         int level = LEVEL_ROOT;
-        List<TableData> list = new ArrayList();
+        List<TableData> list = new ArrayList<>();
         TableData data = null;
         TableRow row = null;
         boolean inComfortData = false;
@@ -170,8 +167,12 @@ public class DataComfortXMLReader {
                             // Note: this linearizes curves, we could use a WKTWriter2 instead!
                             row.getValues().add(geom.toString());
 
-                            //System.out.println("Sub elements " + tag + ": " + sw.toString());
                             split2.stop();
+
+                            // After parsing geometry, move to end of enclosing tag
+                            while(!(tag.equals(xer.getLocalName()) && xer.isEndElement())) {
+                                xer.nextTag();
+                            }
                         } else if (xer.isCharacters()) {
                             StringBuilder t = new StringBuilder();
                             do {

--- a/brmo-loader/src/test/java/nl/b3p/brmo/loader/entity/BagBerichtIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/brmo/loader/entity/BagBerichtIntegrationTest.java
@@ -42,8 +42,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Draaien met:
- * {@code mvn -Dit.test=BagBerichtIntegrationTest -Dtest.onlyITs=true verify -pl brmo-loader -Ppostgresql >
- * /tmp/postgresql.log}
+ * {@code mvn -Dit.test=BagBerichtIntegrationTest -Dtest.onlyITs=true verify -pl brmo-loader -Ppostgresql > /tmp/postgresql.log}
  * voor bijvoorbeeld PostgreSQL.
  *
  * @author mprins

--- a/brmo-loader/src/test/java/nl/b3p/brmo/loader/util/DataComfortXMLReaderTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/brmo/loader/util/DataComfortXMLReaderTest.java
@@ -52,7 +52,7 @@ public class DataComfortXMLReaderTest {
         StreamSource source= new StreamSource(stream);
         List<TableData> data = reader.readDataXML(source);
         try{
-            assertEquals(6, data.size());
+            assertEquals(22, data.size());
         }catch (Exception e){
             fail(e.getLocalizedMessage());
         }
@@ -63,7 +63,7 @@ public class DataComfortXMLReaderTest {
         StreamSource source= new StreamSource(stream);
         List<TableData> data = reader.readDataXML(source);
         try{
-            assertEquals(6, data.size());
+            assertEquals(15, data.size());
         }catch (Exception e){
             fail(e.getLocalizedMessage());
         }
@@ -74,7 +74,7 @@ public class DataComfortXMLReaderTest {
         StreamSource source = new StreamSource(stream);
         List<TableData> data = reader.readDataXML(source);
         try {
-            assertEquals(3, data.size(), "Er zijn drie table data elementen");
+            assertEquals(9, data.size(), "Er zijn drie table data elementen");
             TableData d = data.get(0);
             assertTrue(d.isComfortData(), "eerste table data is comfort data.");
             assertEquals(4, d.getRows().size(), "Er zijn vier table rows");
@@ -83,10 +83,27 @@ public class DataComfortXMLReaderTest {
 
             d = data.get(2);
             row = d.getRows().get(0);
-            assertEquals("214606.115 581137.695 214593.637 581184.181 214586.404 581200.432 214582.757 581198.853 214579.699 581197.328 214595.919 581135.491 214597.599 581135.854 214606.115 581137.695",
-                    row.getColumnValue("posList"));
+            assertEquals("MULTIPOLYGON (((214606.115 581137.695, 214593.637 581184.181, 214586.404 581200.432, 214582.757 581198.853, 214579.699 581197.328, 214595.919 581135.491, 214597.599 581135.854, 214606.115 581137.695)))",
+                    row.getColumnValue("begrenzing_perceel"));
 
 
+        } catch (Exception e) {
+            fail(e.getLocalizedMessage());
+        }
+    }
+
+    @Test
+    public void testGml32() throws Exception {
+        InputStream stream = DataComfortXMLReaderTest.class.getResourceAsStream("comfortdata32.xml");
+        StreamSource source = new StreamSource(stream);
+        List<TableData> data = reader.readDataXML(source);
+        try {
+            assertEquals(9, data.size(), "Er zijn drie table data elementen");
+            TableData d = data.get(6);
+            assertEquals(1, d.getRows().size(), "Er is één table row");
+            TableRow row = d.getRows().get(0);
+            assertEquals("perceel", row.getTable());
+            assertEquals("MULTIPOLYGON (((19452.172 366623.187, 19476.238 366616.882, 19477.741 366622.664, 19453.125 366629.117, 19452.172 366623.187)))", row.getValues().get(2));
         } catch (Exception e) {
             fail(e.getLocalizedMessage());
         }

--- a/brmo-loader/src/test/resources/nl/b3p/brmo/loader/util/comfortdata32.xml
+++ b/brmo-loader/src/test/resources/nl/b3p/brmo/loader/util/comfortdata32.xml
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root xmlns:gml="http://www.opengis.net/gml/3.2">
+    <!--objectRef: NL.IMKAD.KadastraalObject:50247970000, datum: 2021-06-10 00:00:00.0, volgordeNummer: -1, soort: brk2-->
+    <data>
+        <adres ignore-duplicates="yes">
+            <identificatie>NL.IMKAD.AdresLocatie.KPR.6384596</identificatie>
+            <huisnummer/>
+            <huisletter/>
+            <huisnummertoevoeging/>
+            <postbusnummer>269</postbusnummer>
+            <postcode>4530AG</postcode>
+            <openbareruimtenaam/>
+            <woonplaatsnaam>TERNEUZEN</woonplaatsnaam>
+            <openbareruimte/>
+            <verblijfsobject/>
+            <adresseerbaarobject/>
+            <nummeraanduiding/>
+            <standplaats/>
+            <ligplaats/>
+            <nevenadres/>
+            <hoofdadres/>
+            <koppelingswijze/>
+            <buitenlandadres/>
+            <buitenlandwoonplaats/>
+            <buitenlandregio/>
+            <land/>
+            <onroerendezaak/>
+        </adres>
+        <adres ignore-duplicates="yes">
+            <identificatie>NL.IMKAD.AdresLocatie.KPR.10893769</identificatie>
+            <huisnummer>2</huisnummer>
+            <huisletter/>
+            <huisnummertoevoeging/>
+            <postbusnummer/>
+            <postcode>4538BV</postcode>
+            <openbareruimtenaam>Communicatielaan</openbareruimtenaam>
+            <woonplaatsnaam>TERNEUZEN</woonplaatsnaam>
+            <openbareruimte/>
+            <verblijfsobject/>
+            <adresseerbaarobject/>
+            <nummeraanduiding/>
+            <standplaats/>
+            <ligplaats/>
+            <nevenadres/>
+            <hoofdadres/>
+            <koppelingswijze/>
+            <buitenlandadres/>
+            <buitenlandwoonplaats/>
+            <buitenlandregio/>
+            <land/>
+            <onroerendezaak/>
+        </adres>
+        <comfort search-table="nietnatuurlijkpersoon" search-column="identificatie"
+                 search-value="NL.IMKAD.Persoon.133914028" snapshot-date="2021-06-10">
+            <persoon>
+                <identificatie>NL.IMKAD.Persoon.133914028</identificatie>
+                <beschikkingsbevoegdheid/>
+                <indicatieniettoonbarediakriet>false</indicatieniettoonbarediakriet>
+                <postlocatie/>
+                <woonlocatie>NL.IMKAD.AdresLocatie.KPR.10893769</woonlocatie>
+                <soort>nietnatuurlijkpersoon</soort>
+            </persoon>
+            <nietnatuurlijkpersoon>
+                <identificatie>NL.IMKAD.Persoon.133914028</identificatie>
+                <statutairenaam>Stichting Woongoed Zeeuws-Vlaanderen</statutairenaam>
+                <rechtsvorm>Stichting</rechtsvorm>
+                <statutairezetel>TERNEUZEN</statutairezetel>
+                <betreft/>
+                <rsin>002595849</rsin>
+                <kvknummer>21013149</kvknummer>
+            </nietnatuurlijkpersoon>
+        </comfort>
+        <stuk>
+            <identificatie>NL.IMKAD.TIAStuk.20170208000090</identificatie>
+            <toelichtingbewaarder/>
+            <portefeuillenummer/>
+            <deel>70045</deel>
+            <nummer>63</nummer>
+            <reeks/>
+            <registercode>Hyp4</registercode>
+            <soortregister>Onroerende Zaken</soortregister>
+            <tijdstipaanbieding>2017-02-08T09:00:00</tijdstipaanbieding>
+            <tijdstipondertekening/>
+            <tekeningingeschreven>false</tekeningingeschreven>
+        </stuk>
+        <stukdeel>
+            <identificatie>NL.IMKAD.Stukdeel.AKR1.100000011467529</identificatie>
+            <aard>Akte van Koop en Verkoop</aard>
+            <bedragtransactiesomlevering>180000</bedragtransactiesomlevering>
+            <datumkenbaarheidpb/>
+            <deelvan>NL.IMKAD.TIAStuk.20170208000090</deelvan>
+        </stukdeel>
+        <onroerendezaak column-dat-beg-geldh="begingeldigheid" column-datum-einde-geldh="eindegeldigheid">
+            <begingeldigheid>2021-06-10</begingeldigheid>
+            <eindegeldigheid/>
+            <identificatie>NL.IMKAD.KadastraalObject.50247970000</identificatie>
+            <akrkadastralegemeentecode>6</akrkadastralegemeentecode>
+            <akrkadastralegemeente>ADB00</akrkadastralegemeente>
+            <kadastralegemeentecode>6</kadastralegemeentecode>
+            <kadastralegemeente>Aardenburg</kadastralegemeente>
+            <sectie>E</sectie>
+            <perceelnummer>2479</perceelnummer>
+            <appartementsrechtvolgnummer/>
+            <landinrichtingsrente_bedrag/>
+            <landinrichtingsrente_jaar/>
+            <aard_cultuur_onbebouwd/>
+            <aard_cultuur_bebouwd>Wonen</aard_cultuur_bebouwd>
+            <koopsom_bedrag>180000</koopsom_bedrag>
+            <koopsom_koopjaar>2017</koopsom_koopjaar>
+            <koopsom_indicatiemeerobjecten>false</koopsom_indicatiemeerobjecten>
+            <toelichtingbewaarder/>
+            <tijdstipontstaanobject/>
+            <oudstdigitaalbekend>1984-12-11</oudstdigitaalbekend>
+            <ontstaanuit/>
+        </onroerendezaak>
+        <perceel>
+            <begingeldigheid alleen-archief="true">2021-06-10</begingeldigheid>
+            <identificatie>NL.IMKAD.KadastraalObject.50247970000</identificatie>
+            <begrenzing_perceel>
+                <gml:Surface srsName="urn:ogc:def:crs:EPSG::28992">
+                    <gml:patches>
+                        <gml:PolygonPatch>
+                            <gml:exterior>
+                                <gml:LinearRing>
+                                    <gml:posList count="5" srsDimension="2">19452.172 366623.187 19476.238 366616.882 19477.741 366622.664 19453.125 366629.117 19452.172 366623.187</gml:posList>
+                                </gml:LinearRing>
+                            </gml:exterior>
+                        </gml:PolygonPatch>
+                    </gml:patches>
+                </gml:Surface>
+            </begrenzing_perceel>
+            <kadastralegrootte>152</kadastralegrootte>
+            <soortgrootte>Vastgesteld</soortgrootte>
+            <perceelnummerrotatie>14.5</perceelnummerrotatie>
+            <perceelnummer_deltax/>
+            <perceelnummer_deltay/>
+            <plaatscoordinaten>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992">
+                    <gml:pos>19461.513 366623.67</gml:pos>
+                </gml:Point>
+            </plaatscoordinaten>
+            <meettariefverschuldigd>false</meettariefverschuldigd>
+        </perceel>
+        <recht column-dat-beg-geldh="begingeldigheid" column-datum-einde-geldh="einddatumrecht">
+            <identificatie>NL.IMKAD.ZakelijkRecht.120259679</identificatie>
+            <aard/>
+            <toelichtingbewaarder/>
+            <isbelastmet/>
+            <isgebaseerdop/>
+            <rustop>NL.IMKAD.KadastraalObject.50247970000</rustop>
+            <isontstaanuit/>
+            <isbetrokkenbij/>
+            <isbestemdtot/>
+            <isbeperkttot/>
+            <soort/>
+            <jaarlijksbedrag/>
+            <jaarlijksbedragbetreftmeerdere_oz/>
+            <einddatumafkoop/>
+            <indicatieoudeonroerendezaakbetrokken/>
+            <heefthoofdzaak/>
+            <heeftverenigingvaneigenaren/>
+            <aandeel_teller/>
+            <aandeel_noemer/>
+            <burgerlijkestaattentijdevanverkrijging/>
+            <verkregennamenssamenwerkingsverband/>
+            <betrokkenpartner/>
+            <geldtvoor/>
+            <betrokkensamenwerkingsverband/>
+            <betrokkengorzenenaanwassen/>
+            <tennamevan/>
+            <omschrijving/>
+            <einddatumrecht alleen-archief="true"/>
+            <einddatum/>
+            <betreftgedeeltevanperceel/>
+            <aantekeningrecht/>
+            <aantekeningkadastraalobject/>
+            <betrokkenpersoon/>
+            <begingeldigheid>2021-06-10</begingeldigheid>
+        </recht>
+        <recht column-dat-beg-geldh="begingeldigheid" column-datum-einde-geldh="einddatumrecht">
+            <identificatie>NL.IMKAD.Tenaamstelling.120045870</identificatie>
+            <aard/>
+            <toelichtingbewaarder/>
+            <isbelastmet/>
+            <isgebaseerdop>NL.IMKAD.Stukdeel.AKR1.100000011467529</isgebaseerdop>
+            <rustop/>
+            <isontstaanuit/>
+            <isbetrokkenbij/>
+            <isbestemdtot/>
+            <isbeperkttot/>
+            <soort/>
+            <jaarlijksbedrag/>
+            <jaarlijksbedragbetreftmeerdere_oz/>
+            <einddatumafkoop/>
+            <indicatieoudeonroerendezaakbetrokken/>
+            <heefthoofdzaak/>
+            <heeftverenigingvaneigenaren/>
+            <aandeel_teller>1</aandeel_teller>
+            <aandeel_noemer>1</aandeel_noemer>
+            <burgerlijkestaattentijdevanverkrijging/>
+            <verkregennamenssamenwerkingsverband/>
+            <betrokkenpartner/>
+            <geldtvoor/>
+            <betrokkensamenwerkingsverband/>
+            <betrokkengorzenenaanwassen/>
+            <tennamevan>NL.IMKAD.Persoon.133914028</tennamevan>
+            <omschrijving/>
+            <einddatumrecht alleen-archief="true"/>
+            <einddatum/>
+            <betreftgedeeltevanperceel/>
+            <aantekeningrecht/>
+            <aantekeningkadastraalobject/>
+            <betrokkenpersoon/>
+            <begingeldigheid>2021-06-10</begingeldigheid>
+        </recht>
+    </data>
+</root>


### PR DESCRIPTION
Dit is een veel snellere GML parser dan die uit de GeoTools XSD module, bovendien kunnen GML 3 en GML 3.2 tegelijkertijd geparsed worden

TODO:
- ~~The `gt-gml-geometry-streaming` module currently does not support `gml:Surface` and `gml:patches`/`gml:PolygonPatch`~~
- ~~The `gt-gml-geometry-streaming` module is currently not yet released~~

Note: based on #1118 so the testcase actually parses the GML

zie ook https://osgeo-org.atlassian.net/browse/GEOT-6841