### PR TITLE
[SUPPORT-12817] Voeg een workaround toe voor BRK berichten met verkeerde inhoud in `aanduidingNaamgebruik`

### DIFF
--- a/brmo-loader/src/main/resources/xsl/brk-snapshot-to-rsgb-xml.xsl
+++ b/brmo-loader/src/main/resources/xsl/brk-snapshot-to-rsgb-xml.xsl
@@ -661,6 +661,7 @@
             <!--
             <adres_buitenland>149 char</adres_buitenland>
             <vb_adres_buitenland_1>35 char</vb_adres_buitenland_1>
+            <vb_adres_buitenland_1>35 char</vb_adres_buitenland_1>
             <vb_adres_buitenland_2>35 char</vb_adres_buitenland_2>
             <vb_adres_buitenland_3>35 char</vb_adres_buitenland_3>
             -->
@@ -741,7 +742,13 @@
             <xsl:value-of select="$persoon/gba:geslacht/gba:geslachtsaanduiding/typ:code"/>
         </geslachtsaand>
         <aand_naamgebruik>
-            <xsl:value-of select="$persoon/gba:aanduidingNaamgebruik/typ:code"/>
+            <!--
+            https://b3partners.atlassian.net/browse/SUPPORT-12817 ondervang "waarde" in "code" veld
+            door overslaan als niet geldig
+            -->
+            <xsl:if test="string-length($persoon/gba:aanduidingNaamgebruik/typ:code) = 1">
+                <xsl:value-of select="$persoon/gba:aanduidingNaamgebruik/typ:code"/>
+            </xsl:if>
         </aand_naamgebruik>
     </xsl:template>
 

--- a/brmo-loader/src/test/resources/SUPPORT-12817_DATAFOUT_aanduiding_naamgebruik/BRK_XML.anon.xml
+++ b/brmo-loader/src/test/resources/SUPPORT-12817_DATAFOUT_aanduiding_naamgebruik/BRK_XML.anon.xml
@@ -1,0 +1,832 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Geanonimiseerd door B3Partners BV op 2021-10-11+02:00, zie commentaar in bericht.-->
+
+<Mutatie:Mutatie xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:Mutatie="http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901" xmlns:Snapshot="http://www.kadaster.nl/schemas/brk-levering/snapshot/v20120901" xmlns:GbaPersoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon/v20120901" xmlns:Adres="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-adres/v20120201" xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201" xmlns:Persoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon/v20120201" xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201" xmlns:BagAdres="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-bag-adres/v20120201" xmlns:KadastraalObject="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject/v20120701" xmlns:InOnderzoek="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-inonderzoek/v20120201" xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml" xmlns:NhrRechtspersoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-nhr-rechtspersoon/v20120201" xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201" xmlns:GbaPersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon-ref/v20120201" xmlns:PersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon-ref/v20120201" xmlns:NhrRechtspersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-nhr-rechtspersoon-ref/v20120201" xmlns:RechtRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht-ref/v20120201" xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201" xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201" xsi:schemaLocation="http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901 http://www.kadaster.nl/schemas/brk-levering/product-mutatie/v20120901/BRKLeveringMutatie_v1_1_4.xsd http://www.opengis.net/gml http://www.kadaster.nl/schemas/gml/3.1.1/base/gml.xsd http://www.w3.org/1999/xlink http://www.kadaster.nl/schemas/xlink/1.0.0/xlinks.xsd">
+   <Mutatie:BRKDatum>2021-09-02</Mutatie:BRKDatum>
+   <Mutatie:volgnummerKadastraalObjectDatum>1</Mutatie:volgnummerKadastraalObjectDatum>
+   <Mutatie:kadastraalObject>
+      <Mutatie:AanduidingKadastraalObject>
+         <Mutatie:indicatieDeelperceel>false</Mutatie:indicatieDeelperceel>
+         <Mutatie:kadastraleAanduiding>
+            <KadastraalObject:AKRKadastraleGemeenteCode>
+               <Typen:code>1299</Typen:code>
+               <Typen:waarde>ZLE00</Typen:waarde>
+            </KadastraalObject:AKRKadastraleGemeenteCode>
+            <KadastraalObject:naamKadastraleGemeente>
+               <Typen:code>1189</Typen:code>
+               <Typen:waarde>Zwolle</Typen:waarde>
+            </KadastraalObject:naamKadastraleGemeente>
+            <KadastraalObject:sectie>F</KadastraalObject:sectie>
+            <KadastraalObject:perceelnummer>8549</KadastraalObject:perceelnummer>
+            <KadastraalObject:appartementsrechtVolgnummer>36</KadastraalObject:appartementsrechtVolgnummer>
+         </Mutatie:kadastraleAanduiding>
+         <Mutatie:kadastraalObject>
+            <KadastraalObjectRef:PerceelRef xlink:href="NL.KAD.OnroerendeZaak.69550854910036" />
+         </Mutatie:kadastraalObject>
+      </Mutatie:AanduidingKadastraalObject>
+   </Mutatie:kadastraalObject>
+   <Mutatie:wordt>
+
+
+<Snapshot:KadastraalObjectSnapshot xmlns:Snapshot="http://www.kadaster.nl/schemas/brk-levering/snapshot/v20120901">
+   <Snapshot:referentie>3F4192003054-7877639A</Snapshot:referentie>
+   <Snapshot:toestandsdatum>2021-09-02</Snapshot:toestandsdatum>
+   <KadastraalObject:Appartementsrecht xmlns:KadastraalObject="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject/v20120701"
+                                       id="ID.9008394363">
+      <KadastraalObject:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.OnroerendeZaak</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">69550854910036</NEN3610:lokaalId>
+      </KadastraalObject:identificatie>
+      <KadastraalObject:kadastraleAanduiding>
+         <KadastraalObject:AKRKadastraleGemeenteCode>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">1299</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">ZLE00</Typen:waarde>
+         </KadastraalObject:AKRKadastraleGemeenteCode>
+         <KadastraalObject:naamKadastraleGemeente>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">1189</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Zwolle</Typen:waarde>
+         </KadastraalObject:naamKadastraleGemeente>
+         <KadastraalObject:sectie>F</KadastraalObject:sectie>
+         <KadastraalObject:perceelnummer>8549</KadastraalObject:perceelnummer>
+         <KadastraalObject:appartementsrechtVolgnummer>36</KadastraalObject:appartementsrechtVolgnummer>
+      </KadastraalObject:kadastraleAanduiding>
+      <KadastraalObject:aardCultuurOnbebouwd>
+         <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">34</Typen:code>
+         <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Parkeren</Typen:waarde>
+      </KadastraalObject:aardCultuurOnbebouwd>
+   </KadastraalObject:Appartementsrecht>
+   <Recht:ZakelijkRecht xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201"
+                        id="ID.9008394360">
+      <Recht:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.ZakelijkRecht</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">AKR1.100000009198981</NEN3610:lokaalId>
+      </Recht:identificatie>
+      <Recht:aard>
+         <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+         <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Eigendom (recht van)</Typen:waarde>
+      </Recht:aard>
+      <Recht:rustOp>
+         <KadastraalObjectRef:AppartementsrechtRef xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201"
+                                                   xmlns:xlink="http://www.w3.org/1999/xlink"
+                                                   xlink:href="#ID.9008394363"/>
+      </Recht:rustOp>
+      <Recht:ontstaanUit>
+         <Recht:HoofdSplitsing>
+            <Recht:verenigingVanEigenaren>
+               <PersoonRef:KADNietNatuurlijkPersoonRef xmlns:PersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon-ref/v20120201"
+                                                       xmlns:xlink="http://www.w3.org/1999/xlink"
+                                                       xlink:href="#ID.9008394313"/>
+            </Recht:verenigingVanEigenaren>
+            <Recht:isGebaseerdOp>
+               <StukRef:StukdeelRef xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201"
+                                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                                    xlink:href="#ID.9008394314"/>
+            </Recht:isGebaseerdOp>
+         </Recht:HoofdSplitsing>
+      </Recht:ontstaanUit>
+   </Recht:ZakelijkRecht>
+   <Recht:Tenaamstelling xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201"
+                         id="ID.9008394274">
+      <Recht:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Tenaamstelling</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">AKR1.100000010882283</NEN3610:lokaalId>
+      </Recht:identificatie>
+      <Recht:isGebaseerdOp>
+         <StukRef:StukdeelRef xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201"
+                              xmlns:xlink="http://www.w3.org/1999/xlink"
+                              xlink:href="#ID.9008394273"/>
+      </Recht:isGebaseerdOp>
+      <Recht:vanPersoon>
+         <GbaPersoonRef:IngezeteneRef xmlns:GbaPersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon-ref/v20120201"
+                                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                                      xlink:href="#ID.9008394277"/>
+      </Recht:vanPersoon>
+      <Recht:aandeel>
+         <Recht:teller>1</Recht:teller>
+         <Recht:noemer>2</Recht:noemer>
+      </Recht:aandeel>
+      <Recht:burgerlijkeStaatTenTijdeVanVerkrijging>
+         <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">1</Typen:code>
+         <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Gehuwd</Typen:waarde>
+      </Recht:burgerlijkeStaatTenTijdeVanVerkrijging>
+      <Recht:betrokkenBijVerkrijging>
+         <GbaPersoonRef:IngezeteneRef xmlns:GbaPersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon-ref/v20120201"
+                                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                                      xlink:href="#ID.9008394275"/>
+      </Recht:betrokkenBijVerkrijging>
+      <Recht:van>
+         <RechtRef:ZakelijkRechtRef xmlns:RechtRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht-ref/v20120201"
+                                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                                    xlink:href="#ID.9008394360"/>
+      </Recht:van>
+   </Recht:Tenaamstelling>
+   <Recht:Tenaamstelling xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201"
+                         id="ID.9008394280">
+      <Recht:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Tenaamstelling</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">AKR1.100000010882314</NEN3610:lokaalId>
+      </Recht:identificatie>
+      <Recht:isGebaseerdOp>
+         <StukRef:StukdeelRef xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201"
+                              xmlns:xlink="http://www.w3.org/1999/xlink"
+                              xlink:href="#ID.9008394273"/>
+      </Recht:isGebaseerdOp>
+      <Recht:vanPersoon>
+         <GbaPersoonRef:IngezeteneRef xmlns:GbaPersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon-ref/v20120201"
+                                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                                      xlink:href="#ID.9008394275"/>
+      </Recht:vanPersoon>
+      <Recht:aandeel>
+         <Recht:teller>1</Recht:teller>
+         <Recht:noemer>2</Recht:noemer>
+      </Recht:aandeel>
+      <Recht:burgerlijkeStaatTenTijdeVanVerkrijging>
+         <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">1</Typen:code>
+         <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Gehuwd</Typen:waarde>
+      </Recht:burgerlijkeStaatTenTijdeVanVerkrijging>
+      <Recht:betrokkenBijVerkrijging>
+         <GbaPersoonRef:IngezeteneRef xmlns:GbaPersoonRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon-ref/v20120201"
+                                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                                      xlink:href="#ID.9008394277"/>
+      </Recht:betrokkenBijVerkrijging>
+      <Recht:van>
+         <RechtRef:ZakelijkRechtRef xmlns:RechtRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht-ref/v20120201"
+                                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                                    xlink:href="#ID.9008394360"/>
+      </Recht:van>
+   </Recht:Tenaamstelling>
+   <Recht:Aantekening xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201"
+                      id="ID.9008394265">
+      <Recht:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Aantekening</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">AKR1.100000009094133</NEN3610:lokaalId>
+      </Recht:identificatie>
+      <Recht:aard>
+         <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">125</Typen:code>
+         <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Besluit op grond van artikel 110 I Wet geluidhinder gedeeltelijk</Typen:waarde>
+      </Recht:aard>
+      <Recht:betreftAantekeningKadastraalObject>
+         <Recht:AantekeningKadastraalObject>
+            <Recht:heeftBetrekkingOp>
+               <KadastraalObjectRef:AppartementsrechtRef xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201"
+                                                         xmlns:xlink="http://www.w3.org/1999/xlink"
+                                                         xlink:href="#ID.9008394363"/>
+            </Recht:heeftBetrekkingOp>
+         </Recht:AantekeningKadastraalObject>
+      </Recht:betreftAantekeningKadastraalObject>
+      <Recht:isGebaseerdOp>
+         <StukRef:StukdeelRef xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201"
+                              xmlns:xlink="http://www.w3.org/1999/xlink"
+                              xlink:href="#ID.9008394266"/>
+      </Recht:isGebaseerdOp>
+   </Recht:Aantekening>
+   <Recht:Aantekening xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201"
+                      id="ID.9008394269">
+      <Recht:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Aantekening</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">AKR1.100000009094194</NEN3610:lokaalId>
+      </Recht:identificatie>
+      <Recht:aard>
+         <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">124</Typen:code>
+         <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Besluit op grond van artikel 110 I Wet geluidhinder</Typen:waarde>
+      </Recht:aard>
+      <Recht:betreftAantekeningKadastraalObject>
+         <Recht:AantekeningKadastraalObject>
+            <Recht:heeftBetrekkingOp>
+               <KadastraalObjectRef:AppartementsrechtRef xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201"
+                                                         xmlns:xlink="http://www.w3.org/1999/xlink"
+                                                         xlink:href="#ID.9008394363"/>
+            </Recht:heeftBetrekkingOp>
+         </Recht:AantekeningKadastraalObject>
+      </Recht:betreftAantekeningKadastraalObject>
+      <Recht:isGebaseerdOp>
+         <StukRef:StukdeelRef xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201"
+                              xmlns:xlink="http://www.w3.org/1999/xlink"
+                              xlink:href="#ID.9008394268"/>
+      </Recht:isGebaseerdOp>
+   </Recht:Aantekening>
+   <Recht:Aantekening xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201"
+                      id="ID.9008394270">
+      <Recht:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Aantekening</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">AKR1.100000009754802</NEN3610:lokaalId>
+      </Recht:identificatie>
+      <Recht:aard>
+         <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">67</Typen:code>
+         <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Kwalitatieve verplichting</Typen:waarde>
+      </Recht:aard>
+      <Recht:betreftAantekeningKadastraalObject>
+         <Recht:AantekeningKadastraalObject>
+            <Recht:heeftBetrekkingOp>
+               <KadastraalObjectRef:AppartementsrechtRef xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201"
+                                                         xmlns:xlink="http://www.w3.org/1999/xlink"
+                                                         xlink:href="#ID.9008394363"/>
+            </Recht:heeftBetrekkingOp>
+         </Recht:AantekeningKadastraalObject>
+      </Recht:betreftAantekeningKadastraalObject>
+      <Recht:isGebaseerdOp>
+         <StukRef:StukdeelRef xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201"
+                              xmlns:xlink="http://www.w3.org/1999/xlink"
+                              xlink:href="#ID.9008394271"/>
+      </Recht:isGebaseerdOp>
+   </Recht:Aantekening>
+   <Recht:Aantekening xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201"
+                      id="ID.9008394302">
+      <Recht:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Aantekening</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">KRS6.340770174719613</NEN3610:lokaalId>
+      </Recht:identificatie>
+      <Recht:aard>
+         <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">164</Typen:code>
+         <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Kennisgeving, vordering, bevel of beschikking, Wet Bodembescherming</Typen:waarde>
+      </Recht:aard>
+      <Recht:betreftAantekeningKadastraalObject>
+         <Recht:AantekeningKadastraalObject>
+            <Recht:heeftBetrekkingOp>
+               <KadastraalObjectRef:AppartementsrechtRef xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201"
+                                                         xmlns:xlink="http://www.w3.org/1999/xlink"
+                                                         xlink:href="#ID.9008394363"/>
+            </Recht:heeftBetrekkingOp>
+         </Recht:AantekeningKadastraalObject>
+      </Recht:betreftAantekeningKadastraalObject>
+      <Recht:isGebaseerdOp>
+         <StukRef:StukdeelRef xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201"
+                              xmlns:xlink="http://www.w3.org/1999/xlink"
+                              xlink:href="#ID.9008394303"/>
+      </Recht:isGebaseerdOp>
+   </Recht:Aantekening>
+   <Recht:Aantekening xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201"
+                      id="ID.9008394288">
+      <Recht:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Aantekening</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">KRS6.663228892562897</NEN3610:lokaalId>
+      </Recht:identificatie>
+      <Recht:aard>
+         <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">164</Typen:code>
+         <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Kennisgeving, vordering, bevel of beschikking, Wet Bodembescherming</Typen:waarde>
+      </Recht:aard>
+      <Recht:betreftAantekeningKadastraalObject>
+         <Recht:AantekeningKadastraalObject>
+            <Recht:heeftBetrekkingOp>
+               <KadastraalObjectRef:AppartementsrechtRef xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201"
+                                                         xmlns:xlink="http://www.w3.org/1999/xlink"
+                                                         xlink:href="#ID.9008394363"/>
+            </Recht:heeftBetrekkingOp>
+         </Recht:AantekeningKadastraalObject>
+      </Recht:betreftAantekeningKadastraalObject>
+      <Recht:isGebaseerdOp>
+         <StukRef:StukdeelRef xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201"
+                              xmlns:xlink="http://www.w3.org/1999/xlink"
+                              xlink:href="#ID.9008394290"/>
+      </Recht:isGebaseerdOp>
+   </Recht:Aantekening>
+   <Recht:Aantekening xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201"
+                      id="ID.9008394305">
+      <Recht:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Aantekening</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">KRS6.734789464832806</NEN3610:lokaalId>
+      </Recht:identificatie>
+      <Recht:aard>
+         <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">164</Typen:code>
+         <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Kennisgeving, vordering, bevel of beschikking, Wet Bodembescherming</Typen:waarde>
+      </Recht:aard>
+      <Recht:betreftAantekeningKadastraalObject>
+         <Recht:AantekeningKadastraalObject>
+            <Recht:heeftBetrekkingOp>
+               <KadastraalObjectRef:AppartementsrechtRef xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201"
+                                                         xmlns:xlink="http://www.w3.org/1999/xlink"
+                                                         xlink:href="#ID.9008394363"/>
+            </Recht:heeftBetrekkingOp>
+         </Recht:AantekeningKadastraalObject>
+      </Recht:betreftAantekeningKadastraalObject>
+      <Recht:isGebaseerdOp>
+         <StukRef:StukdeelRef xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201"
+                              xmlns:xlink="http://www.w3.org/1999/xlink"
+                              xlink:href="#ID.9008394306"/>
+      </Recht:isGebaseerdOp>
+   </Recht:Aantekening>
+   <Recht:Aantekening xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201"
+                      id="ID.9008394309">
+      <Recht:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Aantekening</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">KRS6.741982112592198</NEN3610:lokaalId>
+      </Recht:identificatie>
+      <Recht:aard>
+         <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">164</Typen:code>
+         <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Kennisgeving, vordering, bevel of beschikking, Wet Bodembescherming</Typen:waarde>
+      </Recht:aard>
+      <Recht:betreftAantekeningKadastraalObject>
+         <Recht:AantekeningKadastraalObject>
+            <Recht:heeftBetrekkingOp>
+               <KadastraalObjectRef:AppartementsrechtRef xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201"
+                                                         xmlns:xlink="http://www.w3.org/1999/xlink"
+                                                         xlink:href="#ID.9008394363"/>
+            </Recht:heeftBetrekkingOp>
+         </Recht:AantekeningKadastraalObject>
+      </Recht:betreftAantekeningKadastraalObject>
+      <Recht:isGebaseerdOp>
+         <StukRef:StukdeelRef xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201"
+                              xmlns:xlink="http://www.w3.org/1999/xlink"
+                              xlink:href="#ID.9008394310"/>
+      </Recht:isGebaseerdOp>
+   </Recht:Aantekening>
+   <Recht:Aantekening xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201"
+                      id="ID.9008394283">
+      <Recht:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Aantekening</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">KRS6.747911860146554</NEN3610:lokaalId>
+      </Recht:identificatie>
+      <Recht:aard>
+         <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">164</Typen:code>
+         <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Kennisgeving, vordering, bevel of beschikking, Wet Bodembescherming</Typen:waarde>
+      </Recht:aard>
+      <Recht:betreftAantekeningKadastraalObject>
+         <Recht:AantekeningKadastraalObject>
+            <Recht:heeftBetrekkingOp>
+               <KadastraalObjectRef:AppartementsrechtRef xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201"
+                                                         xmlns:xlink="http://www.w3.org/1999/xlink"
+                                                         xlink:href="#ID.9008394363"/>
+            </Recht:heeftBetrekkingOp>
+         </Recht:AantekeningKadastraalObject>
+      </Recht:betreftAantekeningKadastraalObject>
+      <Recht:isGebaseerdOp>
+         <StukRef:StukdeelRef xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201"
+                              xmlns:xlink="http://www.w3.org/1999/xlink"
+                              xlink:href="#ID.9008394285"/>
+      </Recht:isGebaseerdOp>
+   </Recht:Aantekening>
+   <Recht:Aantekening xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201"
+                      id="ID.9008394293">
+      <Recht:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Aantekening</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">KRS6.777130407108579</NEN3610:lokaalId>
+      </Recht:identificatie>
+      <Recht:aard>
+         <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">164</Typen:code>
+         <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Kennisgeving, vordering, bevel of beschikking, Wet Bodembescherming</Typen:waarde>
+      </Recht:aard>
+      <Recht:betreftAantekeningKadastraalObject>
+         <Recht:AantekeningKadastraalObject>
+            <Recht:heeftBetrekkingOp>
+               <KadastraalObjectRef:AppartementsrechtRef xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201"
+                                                         xmlns:xlink="http://www.w3.org/1999/xlink"
+                                                         xlink:href="#ID.9008394363"/>
+            </Recht:heeftBetrekkingOp>
+         </Recht:AantekeningKadastraalObject>
+      </Recht:betreftAantekeningKadastraalObject>
+      <Recht:isGebaseerdOp>
+         <StukRef:StukdeelRef xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201"
+                              xmlns:xlink="http://www.w3.org/1999/xlink"
+                              xlink:href="#ID.9008394294"/>
+      </Recht:isGebaseerdOp>
+   </Recht:Aantekening>
+   <Recht:Aantekening xmlns:Recht="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-recht/v20120201"
+                      id="ID.9008394297">
+      <Recht:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Aantekening</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">KRS6.999999199486969</NEN3610:lokaalId>
+      </Recht:identificatie>
+      <Recht:aard>
+         <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">391</Typen:code>
+         <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Wet bodembescherming: Beschikking geval ernstige verontreiniging en noodzaak spoedige sanering</Typen:waarde>
+      </Recht:aard>
+      <Recht:betreftAantekeningKadastraalObject>
+         <Recht:AantekeningKadastraalObject>
+            <Recht:heeftBetrekkingOp>
+               <KadastraalObjectRef:AppartementsrechtRef xmlns:KadastraalObjectRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-kadastraalobject-ref/v20120201"
+                                                         xmlns:xlink="http://www.w3.org/1999/xlink"
+                                                         xlink:href="#ID.9008394363"/>
+            </Recht:heeftBetrekkingOp>
+         </Recht:AantekeningKadastraalObject>
+      </Recht:betreftAantekeningKadastraalObject>
+      <Recht:isGebaseerdOp>
+         <StukRef:StukdeelRef xmlns:StukRef="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk-ref/v20120201"
+                              xmlns:xlink="http://www.w3.org/1999/xlink"
+                              xlink:href="#ID.9008394298"/>
+      </Recht:isGebaseerdOp>
+   </Recht:Aantekening>
+   <GbaPersoon:Ingezetene xmlns:GbaPersoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon/v20120901"
+                          id="ID.9008394277">
+      <Persoon:identificatie xmlns:Persoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon/v20120201">
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Persoon</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">23786864</NEN3610:lokaalId>
+      </Persoon:identificatie>
+      <Persoon:woonlocatie xmlns:Persoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon/v20120201">
+         <Adres:KADBinnenlandsAdres xmlns:Adres="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-adres/v20120201">
+            <Adres:openbareRuimteNaam>Thorbeckewal</Adres:openbareRuimteNaam>
+            <Adres:huisNummer>46</Adres:huisNummer>
+            <Adres:postcode>8011WD</Adres:postcode>
+            <Adres:woonplaatsNaam>ZWOLLE</Adres:woonplaatsNaam>
+         </Adres:KADBinnenlandsAdres>
+      </Persoon:woonlocatie>
+      <GbaPersoon:BSN>637518354</GbaPersoon:BSN>
+      <!--Anonimisatie 'GbaPersoon:BSN': getal is met behoud van vorm vervangen door een hash van van het oorspronkelijke getal.--><GbaPersoon:naam>
+         <GbaPersoon:geslachtsnaam>5e164</GbaPersoon:geslachtsnaam>
+         <!--Anonimisatie 'GbaPersoon:geslachtsnaam': waarde is vervangen door een hash van de oorspronkelijke waarde met de zelfde lengte.--><GbaPersoon:voornamen>2d bc69d7 b630d</GbaPersoon:voornamen>
+         <!--Anonimisatie 'GbaPersoon:voornamen': waarde is vervangen door een hash van de oorspronkelijke waarde met de zelfde lengte.--></GbaPersoon:naam>
+      <GbaPersoon:geslacht>
+         <GbaPersoon:geslachtsaanduiding>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">M</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Man</Typen:waarde>
+         </GbaPersoon:geslachtsaanduiding>
+      </GbaPersoon:geslacht>
+      <GbaPersoon:aanduidingNaamgebruik>
+         <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Eigen naam</Typen:code>
+         <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Eigen naam</Typen:waarde>
+      </GbaPersoon:aanduidingNaamgebruik>
+      <GbaPersoon:geboorte>
+         <GbaPersoon:geboortedatum>1971-11-08</GbaPersoon:geboortedatum>
+         <!--Anonimisatie 'GbaPersoon:geboortedatum': datum is met behoud van vorm vervangen door een hash van de oorspronkelijke datum.--><GbaPersoon:geboorteplaats>430f43fcf</GbaPersoon:geboorteplaats>
+         <!--Anonimisatie 'GbaPersoon:geboorteplaats': waarde is vervangen door een hash van de oorspronkelijke waarde met de zelfde lengte.--></GbaPersoon:geboorte>
+   </GbaPersoon:Ingezetene>
+   <GbaPersoon:Ingezetene xmlns:GbaPersoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-gba-persoon/v20120901"
+                          id="ID.9008394275">
+      <Persoon:identificatie xmlns:Persoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon/v20120201">
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Persoon</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">23786880</NEN3610:lokaalId>
+      </Persoon:identificatie>
+      <Persoon:woonlocatie xmlns:Persoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon/v20120201">
+         <Adres:KADBinnenlandsAdres xmlns:Adres="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-adres/v20120201">
+            <Adres:openbareRuimteNaam>Thorbeckewal</Adres:openbareRuimteNaam>
+            <Adres:huisNummer>46</Adres:huisNummer>
+            <Adres:postcode>8011WD</Adres:postcode>
+            <Adres:woonplaatsNaam>ZWOLLE</Adres:woonplaatsNaam>
+         </Adres:KADBinnenlandsAdres>
+      </Persoon:woonlocatie>
+      <GbaPersoon:BSN>808070289</GbaPersoon:BSN>
+      <!--Anonimisatie 'GbaPersoon:BSN': getal is met behoud van vorm vervangen door een hash van van het oorspronkelijke getal.--><GbaPersoon:naam>
+         <GbaPersoon:geslachtsnaam>c6be</GbaPersoon:geslachtsnaam>
+         <!--Anonimisatie 'GbaPersoon:geslachtsnaam': waarde is vervangen door een hash van de oorspronkelijke waarde met de zelfde lengte.--><GbaPersoon:voornamen>f64889b eb3a2</GbaPersoon:voornamen>
+         <!--Anonimisatie 'GbaPersoon:voornamen': waarde is vervangen door een hash van de oorspronkelijke waarde met de zelfde lengte.--><GbaPersoon:voorvoegselsgeslachtsnaam>e44</GbaPersoon:voorvoegselsgeslachtsnaam>
+         <!--Anonimisatie 'GbaPersoon:voorvoegselsgeslachtsnaam': waarde is vervangen door een hash van de oorspronkelijke waarde met de zelfde lengte.--></GbaPersoon:naam>
+      <GbaPersoon:geslacht>
+         <GbaPersoon:geslachtsaanduiding>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">V</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Vrouw</Typen:waarde>
+         </GbaPersoon:geslachtsaanduiding>
+      </GbaPersoon:geslacht>
+      <GbaPersoon:aanduidingNaamgebruik>
+         <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Eigen naam</Typen:code>
+         <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Eigen naam</Typen:waarde>
+      </GbaPersoon:aanduidingNaamgebruik>
+      <GbaPersoon:geboorte>
+         <GbaPersoon:geboortedatum>1957-03-08</GbaPersoon:geboortedatum>
+         <!--Anonimisatie 'GbaPersoon:geboortedatum': datum is met behoud van vorm vervangen door een hash van de oorspronkelijke datum.--><GbaPersoon:geboorteplaats>56352bb8a1</GbaPersoon:geboorteplaats>
+         <!--Anonimisatie 'GbaPersoon:geboorteplaats': waarde is vervangen door een hash van de oorspronkelijke waarde met de zelfde lengte.--></GbaPersoon:geboorte>
+   </GbaPersoon:Ingezetene>
+   <Persoon:KADNietNatuurlijkPersoon xmlns:Persoon="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-persoon/v20120201"
+                                     id="ID.9008394313">
+      <Persoon:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Persoon</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">460421800</NEN3610:lokaalId>
+      </Persoon:identificatie>
+      <Persoon:naam>Vereniging van eigenaars stallingsgarage fase 1 Kraanbolwerk gelegen nabij de Friesewal te Zwolle te Zwolle</Persoon:naam>
+      <Persoon:rechtsvorm>
+         <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">21</Typen:code>
+         <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Vereniging van eigenaars</Typen:waarde>
+      </Persoon:rechtsvorm>
+      <Persoon:statutaireZetel>ZWOLLE</Persoon:statutaireZetel>
+   </Persoon:KADNietNatuurlijkPersoon>
+   <Stuk:TerInschrijvingAangebodenStuk xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201"
+                                       id="ID.9008394267">
+      <Stuk:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.TIAStuk</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">20141017000601</NEN3610:lokaalId>
+      </Stuk:identificatie>
+      <Stuk:omvat>
+         <Stuk:Stukdeel id="ID.9008394268">
+            <Stuk:identificatie>
+               <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Stukdeel</NEN3610:namespace>
+               <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">AKR1.100000007745170</NEN3610:lokaalId>
+            </Stuk:identificatie>
+            <Stuk:aardStukdeel>
+               <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">187</Typen:code>
+               <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Gedoogverplichting als bedoeld in art. 164 van de Wet geluidhinder ten behoeve van geluidmetingen</Typen:waarde>
+            </Stuk:aardStukdeel>
+         </Stuk:Stukdeel>
+         <Stuk:Stukdeel id="ID.9008394266">
+            <Stuk:identificatie>
+               <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Stukdeel</NEN3610:namespace>
+               <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">AKR1.100000007745171</NEN3610:lokaalId>
+            </Stuk:identificatie>
+            <Stuk:aardStukdeel>
+               <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">187</Typen:code>
+               <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Gedoogverplichting als bedoeld in art. 164 van de Wet geluidhinder ten behoeve van geluidmetingen</Typen:waarde>
+            </Stuk:aardStukdeel>
+         </Stuk:Stukdeel>
+      </Stuk:omvat>
+      <Stuk:tijdstipAanbieding>2014-10-17T09:00:00</Stuk:tijdstipAanbieding>
+      <Stuk:deelEnNummer>
+         <Stuk:deel>64521</Stuk:deel>
+         <Stuk:nummer>142</Stuk:nummer>
+         <Stuk:registercode>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Hyp4</Typen:waarde>
+         </Stuk:registercode>
+         <Stuk:soortRegister>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Onroerende Zaken</Typen:waarde>
+         </Stuk:soortRegister>
+      </Stuk:deelEnNummer>
+   </Stuk:TerInschrijvingAangebodenStuk>
+   <Stuk:TerInschrijvingAangebodenStuk xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201"
+                                       id="ID.9008394315">
+      <Stuk:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.TIAStuk</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">20141202000948</NEN3610:lokaalId>
+      </Stuk:identificatie>
+      <Stuk:omvat>
+         <Stuk:Stukdeel id="ID.9008394314">
+            <Stuk:identificatie>
+               <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Stukdeel</NEN3610:namespace>
+               <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">AKR1.100000007928375</NEN3610:lokaalId>
+            </Stuk:identificatie>
+            <Stuk:aardStukdeel>
+               <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">025</Typen:code>
+               <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Akte van Splitsing in Appartementsrechten</Typen:waarde>
+            </Stuk:aardStukdeel>
+         </Stuk:Stukdeel>
+      </Stuk:omvat>
+      <Stuk:tijdstipAanbieding>2014-12-02T09:00:00</Stuk:tijdstipAanbieding>
+      <Stuk:deelEnNummer>
+         <Stuk:deel>65274</Stuk:deel>
+         <Stuk:nummer>109</Stuk:nummer>
+         <Stuk:registercode>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Hyp4</Typen:waarde>
+         </Stuk:registercode>
+         <Stuk:soortRegister>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Onroerende Zaken</Typen:waarde>
+         </Stuk:soortRegister>
+      </Stuk:deelEnNummer>
+   </Stuk:TerInschrijvingAangebodenStuk>
+   <Stuk:TerInschrijvingAangebodenStuk xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201"
+                                       id="ID.9008394272">
+      <Stuk:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.TIAStuk</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">20160107000761</NEN3610:lokaalId>
+      </Stuk:identificatie>
+      <Stuk:omvat>
+         <Stuk:Stukdeel id="ID.9008394271">
+            <Stuk:identificatie>
+               <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Stukdeel</NEN3610:namespace>
+               <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">AKR1.100000009582525</NEN3610:lokaalId>
+            </Stuk:identificatie>
+            <Stuk:aardStukdeel>
+               <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">183</Typen:code>
+               <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Stuk betreffende bedingen inzake een kwalitatieve verbintenis (iets dulden of iets niet doen)</Typen:waarde>
+            </Stuk:aardStukdeel>
+         </Stuk:Stukdeel>
+         <Stuk:Stukdeel id="ID.9008394273">
+            <Stuk:identificatie>
+               <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Stukdeel</NEN3610:namespace>
+               <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">AKR1.100000009582613</NEN3610:lokaalId>
+            </Stuk:identificatie>
+            <Stuk:aardStukdeel>
+               <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">001</Typen:code>
+               <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Akte van Koop en Verkoop</Typen:waarde>
+            </Stuk:aardStukdeel>
+         </Stuk:Stukdeel>
+      </Stuk:omvat>
+      <Stuk:tijdstipAanbieding>2016-01-07T10:59:00</Stuk:tijdstipAanbieding>
+      <Stuk:deelEnNummer>
+         <Stuk:deel>67559</Stuk:deel>
+         <Stuk:nummer>21</Stuk:nummer>
+         <Stuk:registercode>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Hyp4</Typen:waarde>
+         </Stuk:registercode>
+         <Stuk:soortRegister>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Onroerende Zaken</Typen:waarde>
+         </Stuk:soortRegister>
+      </Stuk:deelEnNummer>
+   </Stuk:TerInschrijvingAangebodenStuk>
+   <Stuk:TerInschrijvingAangebodenStuk xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201"
+                                       id="ID.9008394292">
+      <Stuk:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.TIAStuk</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">20201215002460</NEN3610:lokaalId>
+      </Stuk:identificatie>
+      <Stuk:omvat>
+         <Stuk:Stukdeel id="ID.9008394290">
+            <Stuk:identificatie>
+               <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Stukdeel</NEN3610:namespace>
+               <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">33105007</NEN3610:lokaalId>
+            </Stuk:identificatie>
+            <Stuk:aardStukdeel>
+               <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">208</Typen:code>
+               <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Aanbrengen/doorhalen aantekening bij perceel t.b.v. WKPB</Typen:waarde>
+            </Stuk:aardStukdeel>
+         </Stuk:Stukdeel>
+      </Stuk:omvat>
+      <Stuk:tijdstipAanbieding>2020-12-15T09:38:00</Stuk:tijdstipAanbieding>
+      <Stuk:deelEnNummer>
+         <Stuk:deel>79963</Stuk:deel>
+         <Stuk:nummer>51</Stuk:nummer>
+         <Stuk:registercode>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Hyp4</Typen:waarde>
+         </Stuk:registercode>
+         <Stuk:soortRegister>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Onroerende zaken</Typen:waarde>
+         </Stuk:soortRegister>
+      </Stuk:deelEnNummer>
+   </Stuk:TerInschrijvingAangebodenStuk>
+   <Stuk:TerInschrijvingAangebodenStuk xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201"
+                                       id="ID.9008394287">
+      <Stuk:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.TIAStuk</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">20201215002468</NEN3610:lokaalId>
+      </Stuk:identificatie>
+      <Stuk:omvat>
+         <Stuk:Stukdeel id="ID.9008394285">
+            <Stuk:identificatie>
+               <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Stukdeel</NEN3610:namespace>
+               <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">33105012</NEN3610:lokaalId>
+            </Stuk:identificatie>
+            <Stuk:aardStukdeel>
+               <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">208</Typen:code>
+               <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Aanbrengen/doorhalen aantekening bij perceel t.b.v. WKPB</Typen:waarde>
+            </Stuk:aardStukdeel>
+         </Stuk:Stukdeel>
+      </Stuk:omvat>
+      <Stuk:tijdstipAanbieding>2020-12-15T09:38:00</Stuk:tijdstipAanbieding>
+      <Stuk:deelEnNummer>
+         <Stuk:deel>79963</Stuk:deel>
+         <Stuk:nummer>53</Stuk:nummer>
+         <Stuk:registercode>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Hyp4</Typen:waarde>
+         </Stuk:registercode>
+         <Stuk:soortRegister>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Onroerende zaken</Typen:waarde>
+         </Stuk:soortRegister>
+      </Stuk:deelEnNummer>
+   </Stuk:TerInschrijvingAangebodenStuk>
+   <Stuk:TerInschrijvingAangebodenStuk xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201"
+                                       id="ID.9008394307">
+      <Stuk:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.TIAStuk</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">20201215002488</NEN3610:lokaalId>
+      </Stuk:identificatie>
+      <Stuk:omvat>
+         <Stuk:Stukdeel id="ID.9008394306">
+            <Stuk:identificatie>
+               <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Stukdeel</NEN3610:namespace>
+               <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">33105035</NEN3610:lokaalId>
+            </Stuk:identificatie>
+            <Stuk:aardStukdeel>
+               <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">208</Typen:code>
+               <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Aanbrengen/doorhalen aantekening bij perceel t.b.v. WKPB</Typen:waarde>
+            </Stuk:aardStukdeel>
+         </Stuk:Stukdeel>
+      </Stuk:omvat>
+      <Stuk:tijdstipAanbieding>2020-12-15T09:38:00</Stuk:tijdstipAanbieding>
+      <Stuk:deelEnNummer>
+         <Stuk:deel>79963</Stuk:deel>
+         <Stuk:nummer>65</Stuk:nummer>
+         <Stuk:registercode>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Hyp4</Typen:waarde>
+         </Stuk:registercode>
+         <Stuk:soortRegister>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Onroerende zaken</Typen:waarde>
+         </Stuk:soortRegister>
+      </Stuk:deelEnNummer>
+   </Stuk:TerInschrijvingAangebodenStuk>
+   <Stuk:TerInschrijvingAangebodenStuk xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201"
+                                       id="ID.9008394296">
+      <Stuk:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.TIAStuk</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">20201215002505</NEN3610:lokaalId>
+      </Stuk:identificatie>
+      <Stuk:omvat>
+         <Stuk:Stukdeel id="ID.9008394294">
+            <Stuk:identificatie>
+               <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Stukdeel</NEN3610:namespace>
+               <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">33105047</NEN3610:lokaalId>
+            </Stuk:identificatie>
+            <Stuk:aardStukdeel>
+               <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">208</Typen:code>
+               <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Aanbrengen/doorhalen aantekening bij perceel t.b.v. WKPB</Typen:waarde>
+            </Stuk:aardStukdeel>
+         </Stuk:Stukdeel>
+      </Stuk:omvat>
+      <Stuk:tijdstipAanbieding>2020-12-15T09:38:00</Stuk:tijdstipAanbieding>
+      <Stuk:deelEnNummer>
+         <Stuk:deel>79963</Stuk:deel>
+         <Stuk:nummer>73</Stuk:nummer>
+         <Stuk:registercode>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Hyp4</Typen:waarde>
+         </Stuk:registercode>
+         <Stuk:soortRegister>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Onroerende zaken</Typen:waarde>
+         </Stuk:soortRegister>
+      </Stuk:deelEnNummer>
+   </Stuk:TerInschrijvingAangebodenStuk>
+   <Stuk:TerInschrijvingAangebodenStuk xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201"
+                                       id="ID.9008394304">
+      <Stuk:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.TIAStuk</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">20201215002524</NEN3610:lokaalId>
+      </Stuk:identificatie>
+      <Stuk:omvat>
+         <Stuk:Stukdeel id="ID.9008394303">
+            <Stuk:identificatie>
+               <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Stukdeel</NEN3610:namespace>
+               <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">33105056</NEN3610:lokaalId>
+            </Stuk:identificatie>
+            <Stuk:aardStukdeel>
+               <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">208</Typen:code>
+               <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Aanbrengen/doorhalen aantekening bij perceel t.b.v. WKPB</Typen:waarde>
+            </Stuk:aardStukdeel>
+         </Stuk:Stukdeel>
+      </Stuk:omvat>
+      <Stuk:tijdstipAanbieding>2020-12-15T09:38:00</Stuk:tijdstipAanbieding>
+      <Stuk:deelEnNummer>
+         <Stuk:deel>79963</Stuk:deel>
+         <Stuk:nummer>78</Stuk:nummer>
+         <Stuk:registercode>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Hyp4</Typen:waarde>
+         </Stuk:registercode>
+         <Stuk:soortRegister>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Onroerende zaken</Typen:waarde>
+         </Stuk:soortRegister>
+      </Stuk:deelEnNummer>
+   </Stuk:TerInschrijvingAangebodenStuk>
+   <Stuk:TerInschrijvingAangebodenStuk xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201"
+                                       id="ID.9008394311">
+      <Stuk:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.TIAStuk</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">20201215002545</NEN3610:lokaalId>
+      </Stuk:identificatie>
+      <Stuk:omvat>
+         <Stuk:Stukdeel id="ID.9008394310">
+            <Stuk:identificatie>
+               <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Stukdeel</NEN3610:namespace>
+               <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">33105077</NEN3610:lokaalId>
+            </Stuk:identificatie>
+            <Stuk:aardStukdeel>
+               <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">208</Typen:code>
+               <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Aanbrengen/doorhalen aantekening bij perceel t.b.v. WKPB</Typen:waarde>
+            </Stuk:aardStukdeel>
+         </Stuk:Stukdeel>
+      </Stuk:omvat>
+      <Stuk:tijdstipAanbieding>2020-12-15T09:38:00</Stuk:tijdstipAanbieding>
+      <Stuk:deelEnNummer>
+         <Stuk:deel>79963</Stuk:deel>
+         <Stuk:nummer>98</Stuk:nummer>
+         <Stuk:registercode>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Hyp4</Typen:waarde>
+         </Stuk:registercode>
+         <Stuk:soortRegister>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Onroerende zaken</Typen:waarde>
+         </Stuk:soortRegister>
+      </Stuk:deelEnNummer>
+   </Stuk:TerInschrijvingAangebodenStuk>
+   <Stuk:TerInschrijvingAangebodenStuk xmlns:Stuk="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-stuk/v20120201"
+                                       id="ID.9008394300">
+      <Stuk:identificatie>
+         <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.TIAStuk</NEN3610:namespace>
+         <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">20210902003844</NEN3610:lokaalId>
+      </Stuk:identificatie>
+      <Stuk:omvat>
+         <Stuk:Stukdeel id="ID.9008394298">
+            <Stuk:identificatie>
+               <NEN3610:namespace xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">NL.KAD.Stukdeel</NEN3610:namespace>
+               <NEN3610:lokaalId xmlns:NEN3610="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-NEN3610-2011/v20120201">33505839</NEN3610:lokaalId>
+            </Stuk:identificatie>
+            <Stuk:aardStukdeel>
+               <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">208</Typen:code>
+               <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Aanbrengen/doorhalen aantekening bij perceel t.b.v. WKPB</Typen:waarde>
+            </Stuk:aardStukdeel>
+         </Stuk:Stukdeel>
+      </Stuk:omvat>
+      <Stuk:tijdstipAanbieding>2021-09-02T10:07:00</Stuk:tijdstipAanbieding>
+      <Stuk:deelEnNummer>
+         <Stuk:deel>82000</Stuk:deel>
+         <Stuk:nummer>187</Stuk:nummer>
+         <Stuk:registercode>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Hyp4</Typen:waarde>
+         </Stuk:registercode>
+         <Stuk:soortRegister>
+            <Typen:code xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">2</Typen:code>
+            <Typen:waarde xmlns:Typen="http://www.kadaster.nl/schemas/brk-levering/snapshot/imkad-typen/v20120201">Onroerende zaken</Typen:waarde>
+         </Stuk:soortRegister>
+      </Stuk:deelEnNummer>
+   </Stuk:TerInschrijvingAangebodenStuk>
+</Snapshot:KadastraalObjectSnapshot>
+   </Mutatie:wordt>
+</Mutatie:Mutatie>


### PR DESCRIPTION
Als Kadaster een bericht stuurt waarin niet de code in het code veld staat, maar de waarde dan kunnen we dat op deze manier toch laden. We zorgen ervoor dat er een comment van wordt gemaakt.

resolves SUPPORT-12817