### PR TITLE
Bump  itextpdf.version from 7.1.16 to 7.1.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <geotools.version>26.0</geotools.version>
         <jdbc-util.version>10.0</jdbc-util.version>
         <jts.version>1.18.2</jts.version>
-        <itextpdf.version>7.1.16</itextpdf.version>
+        <itextpdf.version>7.1.17</itextpdf.version>
         <postgresql.jdbc.version>42.3.0</postgresql.jdbc.version>
         <postgresql.postgis-jdbc.version>2.5.1</postgresql.postgis-jdbc.version>
         <oracle.jdbc.version>21.3.0.0</oracle.jdbc.version>


### PR DESCRIPTION
Bumps `itextpdf.version` from 7.1.16 to 7.1.17.

- Updates `kernel` from 7.1.16 to 7.1.17
- Updates `itext7-core` from 7.1.16 to 7.1.17
- Updates `layout` from 7.1.16 to 7.1.17

see: https://github.com/itext/itext7/releases/tag/7.1.17 (**NB** brmo is niet kwetsbaar voor de Ghostscript issue in iText omdat er geen Ghostscript gebruikt wordt)