### PR TITLE
Oracle XE docker image update

### DIFF
--- a/.build/ci/oracle-start-docker.sh
+++ b/.build/ci/oracle-start-docker.sh
@@ -2,11 +2,11 @@
 docker version
 
 # this docker image has the following users/credentials (user/password = system/oracle)
-docker pull gvenzl/oracle-xe:full
+docker pull gvenzl/oracle-xe:18.4.0-full
 
 # start the dockerized oracle-xe instance (the container will be destroyed/removed on stopping)
 # this container can be stopped using: docker stop oracle_brmo
-docker run --rm -p 1521:1521 --name oracle_brmo -h oracle_brmo -e ORACLE_PASSWORD=oracle -d gvenzl/oracle-xe:full
+docker run --rm -p 1521:1521 --name oracle_brmo -h oracle_brmo -e ORACLE_PASSWORD=oracle -d gvenzl/oracle-xe:18.4.0-full
 
 printf "\n\nStarting Oracle XE container, this could take a few minutes..."
 printf "\nWaiting for Oracle XE database to start up.... "

--- a/.build/ci/oracle-start-docker.sh
+++ b/.build/ci/oracle-start-docker.sh
@@ -2,20 +2,20 @@
 docker version
 
 # this docker image has the following users/credentials (user/password = system/oracle)
-docker pull gvenzl/oracle-xe:18.4.0-full
+docker pull gvenzl/oracle-xe:$1
 
 # start the dockerized oracle-xe instance (the container will be destroyed/removed on stopping)
 # this container can be stopped using: docker stop oracle_brmo
-docker run --rm -p 1521:1521 --name oracle_brmo -h oracle_brmo -e ORACLE_PASSWORD=oracle -d gvenzl/oracle-xe:18.4.0-full
+docker run --rm -p 1521:1521 --name oracle_brmo -h oracle_brmo -e ORACLE_PASSWORD=oracle -d gvenzl/oracle-xe:$1
 
-printf "\n\nStarting Oracle XE container, this could take a few minutes..."
-printf "\nWaiting for Oracle XE database to start up.... "
+printf "\n\nStarting Oracle $1 XE container, this could take a few minutes..."
+printf "\nWaiting for Oracle $1 XE database to start up.... "
 _WAIT=0;
 while :
 do
     printf " $_WAIT"
     if $(docker logs oracle_brmo | grep -q 'DATABASE IS READY TO USE!'); then
-        printf "\nOracle XE Database started\n\n"
+        printf "\nOracle $1 XE Database started\n\n"
         break
     fi
     sleep 10

--- a/.build/ci/oracle/github.connections.brmo-persistence.properties
+++ b/.build/ci/oracle/github.connections.brmo-persistence.properties
@@ -1,2 +1,4 @@
 # brmo-persistence/src/test/resources/local.connections.properties
-oracle.url=jdbc:oracle:thin:@127.0.0.1:1521:XE
+# bug in Docker that prevents Oracle Out-of-Band (in 19c+) to work, so we need to disable that for 21.x
+# see https://github.com/gvenzl/oci-oracle-xe/issues/43
+oracle.url=jdbc:oracle:thin:@127.0.0.1:1521:XE?oracle.net.disableOob=true

--- a/.build/ci/oracle/github.oracle.brmo-commandline.properties
+++ b/.build/ci/oracle/github.oracle.brmo-commandline.properties
@@ -1,10 +1,12 @@
 # brmo-commandline/src/test/resources/oracle.properties
 dbtype=oracle
 # rsgb database gegevens
-rsgb.url=jdbc:oracle:thin:@localhost:1521:XE
+# bug in Docker that prevents Oracle Out-of-Band (in 19c+) to work, so we need to disable that for 21.x
+# see https://github.com/gvenzl/oci-oracle-xe/issues/43
+rsgb.url=jdbc:oracle:thin:@localhost:1521:?oracle.net.disableOob=true
 rsgb.user=jenkins_rsgb
 rsgb.password=jenkins_rsgb
 # staging database gegevens
-staging.url=jdbc:oracle:thin:@localhost:1521:XE
+staging.url=jdbc:oracle:thin:@localhost:1521:XE?oracle.net.disableOob=true
 staging.user=jenkins_staging
 staging.password=jenkins_staging

--- a/.build/ci/oracle/github.oracle.brmo-loader.properties
+++ b/.build/ci/oracle/github.oracle.brmo-loader.properties
@@ -1,7 +1,9 @@
 # ./brmo-loader/src/test/resources/local.oracle.properties
 rsgb.host=127.0.0.1
 rsgb.port=1521
-rsgb.jdbc.url=jdbc:oracle:thin:@127.0.0.1:1521:XE
-staging.jdbc.url=jdbc:oracle:thin:@127.0.0.1:1521:XE
-rsgbbgt.jdbc.url=jdbc:oracle:thin:@127.0.0.1:1521:XE
-topnl.jdbc.url=jdbc:oracle:thin:@127.0.0.1:1521:XE
+# bug in Docker that prevents Oracle Out-of-Band (in 19c+) to work, so we need to disable that for 21.x
+# see https://github.com/gvenzl/oci-oracle-xe/issues/43
+rsgb.jdbc.url=jdbc:oracle:thin:@127.0.0.1:1521:XE?oracle.net.disableOob=true
+staging.jdbc.url=jdbc:oracle:thin:@127.0.0.1:1521:XE?oracle.net.disableOob=true
+rsgbbgt.jdbc.url=jdbc:oracle:thin:@127.0.0.1:1521:XE?oracle.net.disableOob=true
+topnl.jdbc.url=jdbc:oracle:thin:@127.0.0.1:1521:XE?oracle.net.disableOob=true

--- a/.build/ci/oracle/github.oracle.brmo-service.properties
+++ b/.build/ci/oracle/github.oracle.brmo-service.properties
@@ -1,5 +1,7 @@
 # brmo-service/src/test/resources/local.oracle.properties
-rsgb.url=jdbc:oracle:thin:@127.0.0.1:1521:XE
-staging.url=jdbc:oracle:thin:@127.0.0.1:1521:XE
-rsgbbgt.jdbc.url=jdbc:oracle:thin:@127.0.0.1:1521:XE
-topnl.jdbc.url=jdbc:oracle:thin:@127.0.0.1:1521:XE
+# bug in Docker that prevents Oracle Out-of-Band (in 19c+) to work, so we need to disable that for 21.x
+# see https://github.com/gvenzl/oci-oracle-xe/issues/43
+rsgb.url=jdbc:oracle:thin:@127.0.0.1:1521:XE?oracle.net.disableOob=true
+staging.url=jdbc:oracle:thin:@127.0.0.1:1521:XE?oracle.net.disableOob=true
+rsgbbgt.jdbc.url=jdbc:oracle:thin:@127.0.0.1:1521:XE?oracle.net.disableOob=true
+topnl.jdbc.url=jdbc:oracle:thin:@127.0.0.1:1521:XE?oracle.net.disableOob=true

--- a/.build/ci/oracle/github.oracle.brmo-soap.properties
+++ b/.build/ci/oracle/github.oracle.brmo-soap.properties
@@ -1,3 +1,5 @@
 # brmo-soap/src/test/resources/local.oracle.properties
-rsgb.url=jdbc:oracle:thin:@127.0.0.1:1521:XE
-staging.url=jdbc:oracle:thin:@127.0.0.1:1521:XE
+# bug in Docker that prevents Oracle Out-of-Band (in 19c+) to work, so we need to disable that for 21.x
+# see https://github.com/gvenzl/oci-oracle-xe/issues/43
+rsgb.url=jdbc:oracle:thin:@127.0.0.1:1521:XE?oracle.net.disableOob=true
+staging.url=jdbc:oracle:thin:@127.0.0.1:1521:XE?oracle.net.disableOob=true

--- a/.build/ci/oracle/github.oracle.brmo-stufbg204.properties
+++ b/.build/ci/oracle/github.oracle.brmo-stufbg204.properties
@@ -1,3 +1,5 @@
 # brmo-stufbg204/src/test/resources/local.oracle.properties
-rsgb.url=jdbc:oracle:thin:@127.0.0.1:1521:XE
-staging.url=jdbc:oracle:thin:@127.0.0.1:1521:XE
+# bug in Docker that prevents Oracle Out-of-Band (in 19c+) to work, so we need to disable that for 21.x
+# see https://github.com/gvenzl/oci-oracle-xe/issues/43
+rsgb.url=jdbc:oracle:thin:@127.0.0.1:1521:XE?oracle.net.disableOob=true
+staging.url=jdbc:oracle:thin:@127.0.0.1:1521:XE?oracle.net.disableOob=true

--- a/.build/ci/oracle/github.oracle.datamodel.properties
+++ b/.build/ci/oracle/github.oracle.datamodel.properties
@@ -1,5 +1,7 @@
 # ./datamodel/src/test/resources/local.oracle.properties
-rsgb.url=jdbc:oracle:thin:@localhost:1521:XE
-staging.url=jdbc:oracle:thin:@localhost:1521:XE
-rsgbbgt.url=jdbc:oracle:thin:@localhost:1521:XE
-topnl.url=jdbc:oracle:thin:@localhost:1521:XE
+# bug in Docker that prevents Oracle Out-of-Band (in 19c+) to work, so we need to disable that for 21.x
+# see https://github.com/gvenzl/oci-oracle-xe/issues/43
+rsgb.url=jdbc:oracle:thin:@localhost:1521:XE?oracle.net.disableOob=true
+staging.url=jdbc:oracle:thin:@localhost:1521:XE?oracle.net.disableOob=true
+rsgbbgt.url=jdbc:oracle:thin:@localhost:1521:XE?oracle.net.disableOob=true
+topnl.url=jdbc:oracle:thin:@localhost:1521:XE?oracle.net.disableOob=true

--- a/.github/workflows/linux-mssql.yml
+++ b/.github/workflows/linux-mssql.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
       - name: Install extra software

--- a/.github/workflows/linux-oracle.yml
+++ b/.github/workflows/linux-oracle.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11]
-        java-dist: [ 'adopt' ]
+        java-dist: [ 'temurin' ]
         oracle: ['18.4.0-full', '21.3.0-full']
 
     steps:

--- a/.github/workflows/linux-oracle.yml
+++ b/.github/workflows/linux-oracle.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         java: [ 11]
         java-dist: [ 'adopt' ]
+        oracle: ['18.4.0-full', '21.3.0-full']
 
     steps:
       - uses: actions/checkout@v2
@@ -55,7 +56,7 @@ jobs:
 
       - name: Setup Oracle XE
         run: |
-          ./.build/ci/oracle-start-docker.sh
+          ./.build/ci/oracle-start-docker.sh ${{ matrix.oracle }}
           ./.build/ci/oracle-setup.sh
 
       - name: Test

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        java-dist: [ 'adopt' ]
+        java-dist: [ 'temurin' ]
         # docker image tags from https://hub.docker.com/r/postgis/postgis/tags?page=1&ordering=last_updated
         # zie ook https://www.postgresql.org/support/versioning/
         postgis: [

--- a/.github/workflows/upgrade-oracle.yml
+++ b/.github/workflows/upgrade-oracle.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: datamodel Priming build

--- a/.github/workflows/upgrade-oracle.yml
+++ b/.github/workflows/upgrade-oracle.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Setup Oracle XE
         run: |
-          ./.build/ci/oracle-start-docker.sh
+          ./.build/ci/oracle-start-docker.sh 18.4.0-full
           ./.build/ci/oracle-setup-previous.sh
 
       - name: Upgrade databases

--- a/.github/workflows/upgrade-pgsql.yml
+++ b/.github/workflows/upgrade-pgsql.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: datamodel Priming build

--- a/bgt-loader/README.md
+++ b/bgt-loader/README.md
@@ -141,7 +141,7 @@ je de gebruiksvoorwaarden van Oracle accepteert):
 Onderstaand commando gebruikt ter illustratie een onofficieel image (deze is wel 18 GB groot).
 
 ```shell
-docker run --detach --publish 1521:1521 --name oracle-xe -d pvargacl/oracle-xe-18.4.0:latest
+docker run --detach --publish 1521:1521 --name oracle-xe -d gvenzl/oracle-xe:18.4.0-full
 ```
 Wacht totdat Oracle is gestart en voer het volgende uit om een schema en gebruiker aan te maken (met bash syntax):
 ```shell

--- a/bgt-loader/pom.xml
+++ b/bgt-loader/pom.xml
@@ -342,7 +342,9 @@ SPDX-License-Identifier: MIT
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables>
-                                <db.connectionString>jdbc:oracle:thin:@localhost:1521:XE</db.connectionString>
+                                <!-- disable Out-of-Band for 19.x and higher when running Dockerized Oracle
+                                    see https://github.com/gvenzl/oci-oracle-xe/issues/43 -->
+                                <db.connectionString>jdbc:oracle:thin:@localhost:1521:XE?oracle.net.disableOob=true</db.connectionString>
                                 <db.user>jenkins_rsgbbgt</db.user>
                                 <db.password>jenkins_rsgbbgt</db.password>
                             </systemPropertyVariables>


### PR DESCRIPTION
- gebruik gvenzl/oracle-xe:18.4.0-full ipv oracle-xe:full want de :full image is upgraded naar 21c geupgraded
- gebruik temurin voor de java runtimes
- test tegen Oracle XE 21.3

zie ook #1203