### PR TITLE
[BRMO-124] [BRMO-125]  Improve loading of BAG2 extracts

### DIFF
--- a/bag2-loader/src/main/java/nl/b3p/brmo/bag2/loader/BAG2LoaderUtils.java
+++ b/bag2-loader/src/main/java/nl/b3p/brmo/bag2/loader/BAG2LoaderUtils.java
@@ -7,7 +7,14 @@
 
 package nl.b3p.brmo.bag2.loader;
 
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Path;
 import java.text.MessageFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
 import java.util.ResourceBundle;
 
 public class BAG2LoaderUtils {
@@ -46,5 +53,132 @@ public class BAG2LoaderUtils {
 
     public static String getBrmoVersion() {
         return getBundleString("brmo.version");
+    }
+
+    public static class BAG2FileName {
+        private String name;
+        private boolean isStand;
+        private boolean isGemeente;
+        private boolean isMaandmutaties;
+        private String gemeenteCode;
+        private LocalDate mutatiesFrom;
+        private LocalDate mutatiesTo;
+
+
+        public BAG2FileName(String name, boolean isStand, boolean isGemeente, boolean isMaandmutaties) {
+            this(name, isStand, isGemeente, isMaandmutaties, null, null, null);
+        }
+
+        public BAG2FileName(String name, boolean isStand, boolean isGemeente, boolean isMaandmutaties, String gemeenteCode) {
+            this(name, isStand, isGemeente, isMaandmutaties, gemeenteCode, null, null);
+        }
+
+        public BAG2FileName(String name, boolean isStand, boolean isGemeente, boolean isMaandmutaties, String gemeenteCode, LocalDate mutatiesFrom, LocalDate mutatiesTo) {
+            this.name = name;
+            this.isStand = isStand;
+            this.isGemeente = isGemeente;
+            this.isMaandmutaties = isMaandmutaties;
+            this.gemeenteCode = gemeenteCode;
+            this.mutatiesFrom = mutatiesFrom;
+            this.mutatiesTo = mutatiesTo;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public boolean isStand() {
+            return isStand;
+        }
+
+        public boolean isGemeente() {
+            return isGemeente;
+        }
+
+        public boolean isMaandmutaties() {
+            return isMaandmutaties;
+        }
+
+        public String getGemeenteCode() {
+            return gemeenteCode;
+        }
+
+        public LocalDate getMutatiesFrom() {
+            return mutatiesFrom;
+        }
+
+        public LocalDate getMutatiesTo() {
+            return mutatiesTo;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            BAG2FileName that = (BAG2FileName) o;
+            return isStand == that.isStand && isGemeente == that.isGemeente && isMaandmutaties == that.isMaandmutaties && name.equals(that.name) && Objects.equals(gemeenteCode, that.gemeenteCode) && Objects.equals(mutatiesFrom, that.mutatiesFrom) && Objects.equals(mutatiesTo, that.mutatiesTo);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, isStand, isGemeente, isMaandmutaties, gemeenteCode, mutatiesFrom, mutatiesTo);
+        }
+
+        @Override
+        public String toString() {
+            return "BAG2FileName{" +
+                    "name='" + name + '\'' +
+                    ", isStand=" + isStand +
+                    ", isGemeente=" + isGemeente +
+                    ", isMaandmutaties=" + isMaandmutaties +
+                    ", gemeenteCode='" + gemeenteCode + '\'' +
+                    ", mutatiesFrom=" + mutatiesFrom +
+                    ", mutatiesTo=" + mutatiesTo +
+                    '}';
+        }
+    }
+
+    /**
+     *
+     * @param name BAG2 filename to analyze, can be URL or full path.
+     * @throws IllegalArgumentException If the filename is not a BAG2 filename (outer zip only)
+     */
+    public static BAG2FileName analyzeBAG2FileName(String name) throws IllegalArgumentException {
+        if (name.startsWith("http://") || name.startsWith("https://")) {
+            URI uri = URI.create(name);
+            String[] parts = uri.getPath().split("/");
+            name = parts[parts.length-1];
+        }
+        if (name.contains(File.separator)) {
+            Path p = Path.of(name);
+            name = p.getFileName().toString();
+        }
+
+        if (name.equals("lvbag-extract-nl.zip") || name.matches("BAGNLDL-\\d{8}\\.zip")) {
+            return new BAG2FileName(name, true, false, false);
+        }
+
+        if (name.matches("BAGGEM\\d{4}L-\\d{8}\\.zip")) {
+            return new BAG2FileName(name, true, true, false, name.substring(6, 10));
+        }
+
+        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("ddMMyyyy");
+
+        if (name.matches("BAGGEM\\d{4}M-\\d{8}-\\d{8}\\.zip")) {
+            // Gemeente can only have monthly updates
+            LocalDate mutatiesFrom = LocalDate.parse(name.substring(12, 20), dtf);
+            LocalDate mutatiesTo = LocalDate.parse(name.substring(21, 29), dtf);
+            return new BAG2FileName(name, false, true, true, name.substring(6, 10), mutatiesFrom, mutatiesTo);
+        }
+
+        if (name.matches("BAGNLDM-\\d{8}-\\d{8}\\.zip")) {
+            // Parse dates to determine whether updates are daily or monthly
+            LocalDate mutatiesFrom = LocalDate.parse(name.substring(8, 16), dtf);
+            LocalDate mutatiesTo = LocalDate.parse(name.substring(17, 25), dtf);
+            long days = ChronoUnit.DAYS.between(mutatiesFrom, mutatiesTo);
+            return new BAG2FileName(name, false, false, days > 1, null, mutatiesFrom, mutatiesTo);
+        }
+
+        throw new IllegalArgumentException("Ongeldige BAG2 bestandsnaam: " + name);
     }
 }

--- a/bag2-loader/src/test/java/nl/b3p/brmo/bag2/loader/BAG2LoaderUtilsTest.java
+++ b/bag2-loader/src/test/java/nl/b3p/brmo/bag2/loader/BAG2LoaderUtilsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2021 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+
+package nl.b3p.brmo.bag2.loader;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.locationtech.jts.io.ParseException;
+
+import java.io.File;
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BAG2LoaderUtilsTest {
+
+    @ParameterizedTest(name="[{index}] {0}")
+    @MethodSource
+    void analyzeBAG2FileName(String name, BAG2LoaderUtils.BAG2FileName expected) {
+        assertEquals(expected, BAG2LoaderUtils.analyzeBAG2FileName(name));
+    }
+
+    @Test
+    void analyzeBAG2FileNameError() {
+        assertThrows(IllegalArgumentException.class, () -> BAG2LoaderUtils.analyzeBAG2FileName("bla.zip"));
+    }
+
+    private static Stream<Arguments> analyzeBAG2FileName() {
+        BAG2LoaderUtils.BAG2FileName nlStand = new BAG2LoaderUtils.BAG2FileName("lvbag-extract-nl.zip", true, false, false);
+        return Stream.of(
+                Arguments.of("lvbag-extract-nl.zip", nlStand),
+                Arguments.of("https://some.host/path/lvbag-extract-nl.zip", nlStand),
+                Arguments.of("http://other.host/path/subpath/lvbag-extract-nl.zip", nlStand),
+                Arguments.of("https://extracten.bag.kadaster.nl/lvbag/extracten/Nederland%20LVC/BAGNLDL-08112021.zip", new BAG2LoaderUtils.BAG2FileName("BAGNLDL-08112021.zip", true, false, false)),
+                Arguments.of("some" + File.separator + "local" + File.separator + "path" + File.separator + "lvbag-extract-nl.zip", nlStand),
+                Arguments.of("BAGGEM0344L-08112021.zip", new BAG2LoaderUtils.BAG2FileName("BAGGEM0344L-08112021.zip", true, true, false, "0344")),
+                Arguments.of("BAGGEM0344M-08112021-08122021.zip", new BAG2LoaderUtils.BAG2FileName("BAGGEM0344M-08112021-08122021.zip", false, true, true, "0344", LocalDate.of(2021, 11, 8), LocalDate.of(2021, 12, 8))),
+                Arguments.of("BAGNLDM-08112021-08122021.zip", new BAG2LoaderUtils.BAG2FileName("BAGNLDM-08112021-08122021.zip", false, false, true, null, LocalDate.of(2021, 11, 8), LocalDate.of(2021, 12, 8))),
+                Arguments.of("BAGNLDM-08112021-09112021.zip", new BAG2LoaderUtils.BAG2FileName("BAGNLDM-08112021-09112021.zip", false, false, false, null, LocalDate.of(2021, 11, 8), LocalDate.of(2021, 11, 9))),
+                Arguments.of("BAGNLDM-31102021-01112021.zip", new BAG2LoaderUtils.BAG2FileName("BAGNLDM-31102021-01112021.zip", false, false, false, null, LocalDate.of(2021, 10, 31), LocalDate.of(2021, 11, 1)))
+        );
+    }
+}

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/BAG2LoadActionBean.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/BAG2LoadActionBean.java
@@ -258,7 +258,7 @@ public class BAG2LoadActionBean implements ActionBean {
             BAG2LoaderMain.configureLogging(false);
             BAG2LoaderMain main = new BAG2LoaderMain();
             BAG2LoadOptions loadOptions = new BAG2LoadOptions();
-            main.loadFiles(bag2Database, databaseOptions, loadOptions, new BAG2ProgressReporter(), Arrays.stream(files.split("\n")).map(String::trim).toArray(String[]::new));
+            main.loadFiles(bag2Database, databaseOptions, loadOptions, new BAG2ProgressReporter(), Arrays.stream(files.split("\n")).map(String::trim).toArray(String[]::new), null);
             this.loadResult = true;
         } catch(Exception e) {
             this.loadResult = false;


### PR DESCRIPTION
Fixes that only a single dagmutatie file could be loaded at a time, along with the following improvements:

Separate stand and mutatie loading into separate methods and verify mutaties apply to current technische datum before applying and add more checks before loading files so only applicable files will be loaded. Validate files to load based on analyzing the BAG file name scheme.

Prepare for loading from URLs requiring a session cookie.

resolves: 
- BRMO-124
- BRMO-125