### PR TITLE
Remove BAG2 upload form

### DIFF
--- a/brmo-service/src/main/webapp/WEB-INF/jsp/bestand/bag2.jsp
+++ b/brmo-service/src/main/webapp/WEB-INF/jsp/bestand/bag2.jsp
@@ -110,9 +110,6 @@
             <stripes:textarea name="files" cols="120" rows="6"/>
             <c:set var="loadDisabled" value="${!actionBean.connectionOk or (actionBean.databaseDialect == 'oracle' and !oracleConnectionOk)}"/>
             <stripes:submit name="load" value="Inladen" disabled="${loadDisabled}" />
-            <h2>Dag- of maandmutaties uploaden via de browser (max 10 MB)</h2>
-            <p><stripes:file name="bestand"/></p>
-            <stripes:submit name="upload" value="Verzenden" disabled="${loadDisabled}"/>
         </stripes:form>
     </stripes:layout-component>
 </stripes:layout-render>


### PR DESCRIPTION
Manually uploading files should be discouraged anyway, load stand manually from URL or local file(s) and load updates automatically. Backend code was not yet written. 