### PR TITLE
[BRMO-130] Nieuwe BAG2 RSGB views en bugfix BAG views

### DIFF
--- a/.build/ci/oracle-db-grant-bag-to-rsgb.sql
+++ b/.build/ci/oracle-db-grant-bag-to-rsgb.sql
@@ -1,15 +1,15 @@
-BEGIN
-    FOR t IN (SELECT * FROM USER_TABLES)
-    LOOP
-        EXECUTE IMMEDIATE 'GRANT SELECT ON ' || t.table_name || ' TO JENKINS_RSGB';
-    END LOOP;
-END;
-/
+-- BEGIN
+--     FOR t IN (SELECT * FROM USER_TABLES)
+--     LOOP
+--         EXECUTE IMMEDIATE 'GRANT SELECT ON ' || t.table_name || ' TO JENKINS_RSGB';
+--     END LOOP;
+-- END;
+-- /
 
 BEGIN
-    FOR t IN (SELECT * FROM USER_SEQUENCES)
+    FOR t IN (SELECT * FROM USER_VIEWS)
     LOOP
-        EXECUTE IMMEDIATE 'GRANT SELECT ON ' || t.sequence_name || ' TO JENKINS_RSGB';
+        EXECUTE IMMEDIATE 'GRANT SELECT ON ' || t.view_name || ' TO JENKINS_RSGB';
     END LOOP;
 END;
 /

--- a/.build/ci/oracle-setup-bag2_views.sh
+++ b/.build/ci/oracle-setup-bag2_views.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+export SQLPATH=./.build/ci
+printf "\nset up BAG views...\n"
+docker exec -i oracle_brmo sqlplus -l jenkins_bag/jenkins_bag@//localhost:1521/XE < ./datamodel/extra_scripts/oracle/208_bag2_views.sql
+printf "\nSetup BAG grants...\n"
+docker exec -i oracle_brmo sqlplus -l jenkins_bag/jenkins_bag@//localhost:1521/XE < ./.build/ci/oracle-db-grant-bag-to-rsgb.sql
+printf "\nset up RSGB BAG views...\n"
+docker exec -i oracle_brmo sqlplus -l jenkins_rsgb/jenkins_rsgb@//localhost:1521/XE < ./datamodel/extra_scripts/oracle/209_bag2_rsgb_views.sql

--- a/.build/ci/pgsql-drop-bag2_schema.sh
+++ b/.build/ci/pgsql-drop-bag2_schema.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+psql -U postgres -h localhost -d rsgb -c 'DROP SCHEMA bag CASCADE;'

--- a/.build/ci/pgsql-setup-bag2_views.sh
+++ b/.build/ci/pgsql-setup-bag2_views.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+printf "\nset up BAG views...\n"
+psql -U postgres -h localhost -w -d rsgb -f ./datamodel/extra_scripts/postgresql/208_bag2_views.sql
+printf "\nset up RSGB BAG views...\n"
+psql -U postgres -h localhost -w -d rsgb -f ./datamodel/extra_scripts/postgresql/209_bag2_rsgb_views.sql

--- a/.build/ci/pgsql-setup.sh
+++ b/.build/ci/pgsql-setup.sh
@@ -1,8 +1,23 @@
-#!/bin/bash -e
-# set up staging db
-psql -U postgres -h localhost -d staging -f ./brmo-persistence/db/create-brmo-persistence-postgresql.sql
-# set up rsgb
-psql -U postgres -h localhost -w -q -d rsgb -f ./datamodel/generated_scripts/datamodel_postgresql.sql
-# set up topnl
-psql -U postgres -h localhost -w -q -d topnl -f ./brmo-topnl-loader/src/main/resources/nl/b3p/topnl/database/postgres.sql
-
+#!/usr/bin/env bash
+set -e
+printf "\nset up staging DB...\n"
+psql -v ON_ERROR_STOP=1 -U postgres -h localhost -d staging -f ./brmo-persistence/db/create-brmo-persistence-postgresql.sql
+if [ $? -eq 0 ]; then
+    echo Success
+else
+    echo Failed setting up staging DB
+fi
+printf "\nset up rsgb DB...\n"
+psql -v ON_ERROR_STOP=1 -U postgres -h localhost -w -q -d rsgb -f ./datamodel/generated_scripts/datamodel_postgresql.sql
+if [ $? -eq 0 ]; then
+    echo Success
+else
+    echo Failed setting up rsgb DB
+fi
+printf "\nset up topnl DB...\n"
+psql -v ON_ERROR_STOP=1 -U postgres -h localhost -w -q -d topnl -f ./brmo-topnl-loader/src/main/resources/nl/b3p/topnl/database/postgres.sql
+if [ $? -eq 0 ]; then
+    echo Success
+else
+    echo Failed setting up topnl DB
+fi

--- a/.github/workflows/linux-oracle.yml
+++ b/.github/workflows/linux-oracle.yml
@@ -62,6 +62,11 @@ jobs:
       - name: Test
         run: |
           mvn -e test -B -Poracle -pl '!brmo-dist' -Dtest.onlyITs=false
+
+      - name: Verify bag2-loader
+        run: |
+          mvn -e verify -B -Poracle -T1 -Dtest.onlyITs=true -pl 'bag2-loader'
+          .build/ci/oracle-setup-bag2_views.sh
           mvn resources:testResources compiler:testCompile surefire:test -Poracle -pl datamodel -Dtest='!*UpgradeTest,!P8*'
 
       - name: Verify bgt-loader

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -90,7 +90,14 @@ jobs:
       - name: Test
         run: |
           mvn -e test -B -Ppostgresql -pl '!brmo-dist' -Dtest.onlyITs=false
+
+      - name: Verify bag2-loader
+        # bag schema gedropped vanwege dbunit beperking "ambiguous table LIGPLAATS" en we hebben geen zin alle brmo-loader test code te herschrijven
+        run: |
+          mvn -e verify -B -Ppostgresql -T1 -Dtest.onlyITs=true -pl 'bag2-loader'
+          .build/ci/pgsql-setup-bag2_views.sh
           mvn resources:testResources compiler:testCompile surefire:test -Ppostgresql -pl datamodel -Dtest='!*UpgradeTest,!P8*'
+          .build/ci/pgsql-drop-bag2_schema.sh
 
       - name: Verify bgt-loader
         run: mvn -e verify -B -Ppostgresql -T1 -Dtest.onlyITs=true -pl 'bgt-loader'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ timestamps {
                         }
 
                         stage("datamodel tests"){
-                            sh "mvn -e -B -Poracle -pl 'datamodel' resources:testResources compiler:testCompile surefire:test -Dtest='!*UpgradeTest,!P8*'"
+                            sh "mvn -e -B -Poracle -pl 'datamodel' resources:testResources compiler:testCompile surefire:test -Dtest='!*UpgradeTest,!P8*',!*ViewsTest"
                         }
 
                         stage("bgt-loader Integration Test") {

--- a/bag2-loader/pom.xml
+++ b/bag2-loader/pom.xml
@@ -66,6 +66,18 @@ SPDX-License-Identifier: MIT
             <artifactId>commons-dbutils</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>nl.b3p</groupId>
+            <artifactId>bgt-loader</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.postgis</groupId>
             <artifactId>postgis-jdbc</artifactId>
         </dependency>
@@ -76,7 +88,7 @@ SPDX-License-Identifier: MIT
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
@@ -88,16 +100,14 @@ SPDX-License-Identifier: MIT
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
+            <groupId>org.dbunit</groupId>
+            <artifactId>dbunit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>nl.b3p</groupId>
-            <artifactId>bgt-loader</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -268,6 +278,53 @@ SPDX-License-Identifier: MIT
                         <configuration>
                             <verbose>false</verbose>
                             <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>postgresql</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/*IntegrationTest.java</include>
+                            </includes>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <argLine>${failsafeArgLine}</argLine>
+                            <trimStackTrace>false</trimStackTrace>
+                            <systemPropertyVariables>
+                                <dbuser>rsgb</dbuser>
+                                <dbpasword>rsgb</dbpasword>
+                                <!-- volledig zoekpad opnemen voor DBunit; dus incl. bag schema -->
+                                <dburl>jdbc:postgresql:rsgb?currentSchema=bag,public&amp;sslmode=disable&amp;reWriteBatchedInserts=true</dburl>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>oracle</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/*IntegrationTest.java</include>
+                            </includes>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <argLine>${failsafeArgLine}</argLine>
+                            <trimStackTrace>false</trimStackTrace>
+                            <systemPropertyVariables>
+                                <dbuser>JENKINS_BAG</dbuser>
+                                <dbpassword>jenkins_bag</dbpassword>
+                                <dburl>jdbc:oracle:thin:@127.0.0.1:1521:XE?oracle.net.disableOob=true</dburl>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/bag2-loader/src/main/java/nl/b3p/brmo/bag2/loader/BAG2GMLMutatieGroepStream.java
+++ b/bag2-loader/src/main/java/nl/b3p/brmo/bag2/loader/BAG2GMLMutatieGroepStream.java
@@ -10,7 +10,7 @@ package nl.b3p.brmo.bag2.loader;
 import nl.b3p.brmo.bag2.schema.BAG2Object;
 import nl.b3p.brmo.bag2.schema.BAG2ObjectType;
 import nl.b3p.brmo.bag2.schema.BAG2Schema;
-import nl.b3p.brmo.util.Force2DCoordinateSequenceFactory;
+import nl.b3p.brmo.bag2.util.Force2DCoordinateSequenceFactory;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.codehaus.staxmate.SMInputFactory;

--- a/bag2-loader/src/main/java/nl/b3p/brmo/bag2/util/Force2DCoordinateSequenceFactory.java
+++ b/bag2-loader/src/main/java/nl/b3p/brmo/bag2/util/Force2DCoordinateSequenceFactory.java
@@ -5,7 +5,7 @@
  *
  */
 
-package nl.b3p.brmo.util;
+package nl.b3p.brmo.bag2.util;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateSequence;

--- a/bag2-loader/src/test/java/nl/b3p/brmo/bag2/loader/BAGLoaderDatabaseIntegrationTest.java
+++ b/bag2-loader/src/test/java/nl/b3p/brmo/bag2/loader/BAGLoaderDatabaseIntegrationTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2021 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+package nl.b3p.brmo.bag2.loader;
+
+import nl.b3p.brmo.bag2.loader.cli.BAG2DatabaseOptions;
+import nl.b3p.brmo.bag2.loader.cli.BAG2LoadOptions;
+import nl.b3p.brmo.bag2.loader.cli.BAG2LoaderMain;
+import org.apache.commons.lang3.StringUtils;
+import org.dbunit.database.DatabaseConfig;
+import org.dbunit.database.DatabaseConnection;
+import org.dbunit.database.IDatabaseConnection;
+import org.dbunit.ext.oracle.Oracle10DataTypeFactory;
+import org.dbunit.ext.postgresql.PostgresqlDataTypeFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+/**
+ * Laadt een BAG stand in de database. Test of tabellen en actueel views bestaan en gevuld zijn.
+ * <i>NB</i> De anader BAG (materalized) views worden in de datamodel module getest; deze test
+ * laat dus een gevulde BAG database achter.
+ *
+ * @author mprins
+ */
+public class BAGLoaderDatabaseIntegrationTest {
+    private static final String[] BAGTABLES = new String[]{"ligplaats", "ligplaats_nevenadres", "nummeraanduiding", "openbareruimte", "pand", "standplaats", "standplaats_nevenadres", "verblijfsobject", "verblijfsobject_gebruiksdoel", "verblijfsobject_maaktdeeluitvan", "verblijfsobject_nevenadres", "woonplaats"};
+    private static final String[] BAGACTUEELVIEWS = new String[]{"v_ligplaats_actueel", "v_nummeraanduiding_actueel", "v_openbareruimte_actueel", "v_pand_actueel", "v_standplaats_actueel", "v_verblijfsobject_actueel", "v_woonplaats_actueel"};
+    private static String dbUrl = System.getProperty("dburl");
+    private static String dbUser = System.getProperty("dbuser", "rsgb");
+    private static String dbPass = System.getProperty("dbpassword", "rsgb");
+
+    private BAG2Database bag2Database;
+    private BAG2DatabaseOptions databaseOptions;
+    private BAG2LoadOptions bag2LoadOptions;
+    private IDatabaseConnection bag;
+    private String testFileName;
+    private String tableQualifierPrefix = "";
+
+    @BeforeAll
+    static void beforeAll() {
+        BAG2LoaderMain.configureLogging(false);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        assumeFalse(StringUtils.isEmpty(dbUrl), "skipping integration test: missing database url");
+        URL u = BAGLoaderDatabaseIntegrationTest.class.getResource("/BAGGEM1904L-15102021.zip");
+        assumeFalse(null == u, "skipping integration test: missing testdata");
+        testFileName = u.getFile();
+        bag = new DatabaseConnection(DriverManager.getConnection(dbUrl, dbUser, dbPass));
+
+        if (dbUrl.contains("postgresql")) {
+            bag.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new PostgresqlDataTypeFactory());
+            bag.getConfig().setProperty(DatabaseConfig.FEATURE_QUALIFIED_TABLE_NAMES, true);
+            tableQualifierPrefix = "bag.";
+        }
+        if (dbUrl.contains("oracle")) {
+            bag.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new Oracle10DataTypeFactory());
+            bag.getConfig().setProperty(DatabaseConfig.FEATURE_SKIP_ORACLE_RECYCLEBIN_TABLES, true);
+        }
+
+        bag2LoadOptions = new BAG2LoadOptions();
+        // dit ruim alle BAG tabelle op met een cascade; dat is niet wat je wilt omdat daar tabellen
+        // een views van het RSGB schema bij zitten
+        // bag2LoadOptions.setDropIfExists(true);
+
+        databaseOptions = new BAG2DatabaseOptions();
+        databaseOptions.setConnectionString(dbUrl);
+        databaseOptions.setUser(dbUser);
+        databaseOptions.setPassword(dbPass);
+        bag2Database = new BAG2Database(databaseOptions);
+    }
+
+    @AfterEach
+    void cleanup() throws SQLException {
+        // geladen data wordt niet opgeruimd
+        if (null != bag) bag.close();
+    }
+
+    @Test
+    void testStand() throws SQLException {
+        BAG2LoaderMain loader = new BAG2LoaderMain();
+
+        try {
+            loader.loadFiles(bag2Database, databaseOptions, bag2LoadOptions, new BAG2ProgressReporter(), new String[]{testFileName}, null);
+        } catch (Exception e) {
+            fail("Laden BAG data is mislukt. " + e.getLocalizedMessage(), e);
+        }
+        // check tables
+        for (String t : BAGTABLES) {
+            // omdat sommige BAG tabellen ook in RSGB schema zitten bag qualifier gebruiken
+            t = tableQualifierPrefix + t;
+            assertTrue(bag.getRowCount(t) > 0, "Onverwacht lege tabel: " + t);
+        }
+        // check views
+        for (String t : BAGACTUEELVIEWS) {
+            assertTrue(bag.getRowCount(t) > 0, "Onverwacht lege view: " + t);
+        }
+    }
+}

--- a/bag2-loader/src/test/resources/BAGGEM1904L-15102021.zip
+++ b/bag2-loader/src/test/resources/BAGGEM1904L-15102021.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3c3e6bf532d1199d041869359667644d75091ce5db5ddcecfe0eec669bd6f85
+size 2345064

--- a/bag2-loader/src/test/resources/log4j.xml
+++ b/bag2-loader/src/test/resources/log4j.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration PUBLIC "-//APACHE//DTD LOG4J 1.2//EN" "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+    <appender name="consoleAppender" class="org.apache.log4j.ConsoleAppender">
+        <param name="Threshold" value="all"/>
+        <layout class="org.apache.log4j.EnhancedPatternLayout">
+            <param name="ConversionPattern" value="BAG2-LOADER-TEST: %5p %d{HH:mm:ss} (%C{1.}#%M:%L) - %m%n"/>
+        </layout>
+    </appender>
+    <logger name="org.dbunit.database">
+        <level value="info"/>
+    </logger>
+    <logger name="org.dbunit.operation">
+        <level value="info"/>
+    </logger>
+    <logger name="org.dbunit.util">
+        <level value="info"/>
+    </logger>
+    <logger name="org.dbunit.dataset">
+        <level value="info"/>
+    </logger>
+    <logger name="org.dbunit.ext">
+        <level value="info"/>
+    </logger>
+    <logger name="nl.b3p">
+        <level value="info"/>
+    </logger>
+    <logger name="nl.b3p.brmo">
+        <level value="info"/>
+    </logger>
+    <logger name="nl.b3p.brmo.bag2">
+        <level value="info"/>
+    </logger>
+    <logger name="nl.b3p.brmo.util">
+        <level value="info"/>
+    </logger>
+    <root>
+        <level value="info"/>
+        <appender-ref ref="consoleAppender"/>
+    </root>
+</log4j:configuration>

--- a/datamodel/extra_scripts/oracle/208_bag2_views.sql
+++ b/datamodel/extra_scripts/oracle/208_bag2_views.sql
@@ -28,45 +28,56 @@ comment on table vb_adres is 'volledig actueel adres zonder locatie';
 
 -- Vervangt vb_ligplaats_adres. Gemeentevelden zijn nog niet beschikbaar.
 create or replace view vb_ligplaats_adres as
-select lp.objectid,
-       'true'                                 as ishoofdadres,
-       lp.status,
-       lp.identificatie,
-       a.identificatienummeraanduiding,
-       a.status                               as nummeraanduidingstatus,
-       a.gemeente,
-       a.woonplaats,
-       a.straatnaam,
-       a.huisnummer,
-       a.huisletter,
-       a.huisnummertoevoeging,
-       a.postcode,
-       sdo_geom.sdo_centroid(lp.geometrie, 2) as geometrie_centroide,
-       lp.geometrie
-from v_ligplaats_actueel lp
-         join vb_adres a on lp.heeftalshoofdadres = a.identificatienummeraanduiding
-union all
-select lpa.objectid,
-       'false'                                 as ishoofdadres,
-       lpa.status,
-       lpa.identificatie,
-       a.identificatienummeraanduiding,
-       a.status                                as nummeraanduidingstatus,
-       a.gemeente,
-       a.woonplaats,
-       a.straatnaam,
-       a.huisnummer,
-       a.huisletter,
-       a.huisnummertoevoeging,
-       a.postcode,
-       sdo_geom.sdo_centroid(lpa.geometrie, 2) as geometrie_centroide,
-       lpa.geometrie
-from v_ligplaats_actueel lpa
-         join ligplaats_nevenadres lpna on
-    (lpna.identificatie = lpa.identificatie
-        and lpna.voorkomenidentificatie = lpa.voorkomenidentificatie)
-         join vb_adres a on
-    lpa.heeftalshoofdadres = a.identificatienummeraanduiding;
+select cast(ROWNUM as INTEGER) as objectid,
+       qry.ishoofdadres,
+       qry.status,
+       qry.identificatie,
+       qry.identificatienummeraanduiding,
+       qry.nummeraanduidingstatus,
+       qry.gemeente,
+       qry.woonplaats,
+       qry.straatnaam,
+       qry.huisnummer,
+       qry.huisletter,
+       qry.huisnummertoevoeging,
+       qry.postcode,
+       qry.geometrie_centroide,
+       qry.geometrie
+from (select 'true'                                 as ishoofdadres,
+             lp.status,
+             lp.identificatie,
+             a.identificatienummeraanduiding,
+             a.status                               as nummeraanduidingstatus,
+             a.gemeente,
+             a.woonplaats,
+             a.straatnaam,
+             a.huisnummer,
+             a.huisletter,
+             a.huisnummertoevoeging,
+             a.postcode,
+             sdo_geom.sdo_centroid(lp.geometrie, 2) as geometrie_centroide,
+             lp.geometrie
+      from v_ligplaats_actueel lp
+               join vb_adres a on lp.heeftalshoofdadres = a.identificatienummeraanduiding
+      union all
+      select 'false'                                 as ishoofdadres,
+             lpa.status,
+             lpa.identificatie,
+             a.identificatienummeraanduiding,
+             a.status                                as nummeraanduidingstatus,
+             a.gemeente,
+             a.woonplaats,
+             a.straatnaam,
+             a.huisnummer,
+             a.huisletter,
+             a.huisnummertoevoeging,
+             a.postcode,
+             sdo_geom.sdo_centroid(lpa.geometrie, 2) as geometrie_centroide,
+             lpa.geometrie
+      from v_ligplaats_actueel lpa
+               join ligplaats_nevenadres lpna on (lpna.identificatie = lpa.identificatie and
+                                                  lpna.voorkomenidentificatie = lpa.voorkomenidentificatie)
+               join vb_adres a on lpa.heeftalshoofdadres = a.identificatienummeraanduiding) qry;
 
 comment on table vb_ligplaats_adres is 'ligplaats met adres en puntlocatie';
 delete from user_sdo_geom_metadata where table_name = 'VB_LIGPLAATS_ADRES';
@@ -78,47 +89,59 @@ insert into user_sdo_geom_metadata
 values ('VB_LIGPLAATS_ADRES', 'GEOMETRIE', mdsys.sdo_dim_array(mdsys.sdo_dim_element('X', 12000, 280000, .1),
                                                                mdsys.sdo_dim_element('Y', 304000, 620000, .1)), 28992);
 
+
 -- Vervangt vb_standplaats_adres. Gemeentevelden zijn nog niet beschikbaar.
 create or replace view vb_standplaats_adres as
-select sp.objectid,
-       'true'                                 as ishoofdadres,
-       sp.status,
-       sp.identificatie,
-       a.identificatienummeraanduiding,
-       a.status                               as nummeraanduidingstatus,
-       a.gemeente,
-       a.woonplaats,
-       a.straatnaam,
-       a.huisnummer,
-       a.huisletter,
-       a.huisnummertoevoeging,
-       a.postcode,
-       sdo_geom.sdo_centroid(sp.geometrie, 2) as geometrie_centroide,
-       sp.geometrie
-from v_standplaats_actueel sp
-         join vb_adres a on sp.heeftalshoofdadres = a.identificatienummeraanduiding
-union all
-select spa.objectid,
-       'false'                                 as ishoofdadres,
-       spa.status,
-       spa.identificatie,
-       a.identificatienummeraanduiding,
-       a.status                                as nummeraanduidingstatus,
-       a.gemeente,
-       a.woonplaats,
-       a.straatnaam,
-       a.huisnummer,
-       a.huisletter,
-       a.huisnummertoevoeging,
-       a.postcode,
-       sdo_geom.sdo_centroid(spa.geometrie, 2) as geometrie_centroide,
-       spa.geometrie
-from v_standplaats_actueel spa
-         join standplaats_nevenadres spna on
-    (spna.identificatie = spa.identificatie
-        and spna.voorkomenidentificatie = spa.voorkomenidentificatie)
-         join vb_adres a on
-    spa.heeftalshoofdadres = a.identificatienummeraanduiding;
+select cast(ROWNUM as INTEGER) as objectid,
+       qry.ishoofdadres,
+       qry.status,
+       qry.identificatie,
+       qry.identificatienummeraanduiding,
+       qry.nummeraanduidingstatus,
+       qry.gemeente,
+       qry.woonplaats,
+       qry.straatnaam,
+       qry.huisnummer,
+       qry.huisletter,
+       qry.huisnummertoevoeging,
+       qry.postcode,
+       qry.geometrie_centroide,
+       qry.geometrie
+from (select 'true'                                 as ishoofdadres,
+             sp.status,
+             sp.identificatie,
+             a.identificatienummeraanduiding,
+             a.status                               as nummeraanduidingstatus,
+             a.gemeente,
+             a.woonplaats,
+             a.straatnaam,
+             a.huisnummer,
+             a.huisletter,
+             a.huisnummertoevoeging,
+             a.postcode,
+             sdo_geom.sdo_centroid(sp.geometrie, 2) as geometrie_centroide,
+             sp.geometrie
+      from v_standplaats_actueel sp
+               join vb_adres a on sp.heeftalshoofdadres = a.identificatienummeraanduiding
+      union all
+      select 'false'                                 as ishoofdadres,
+             spa.status,
+             spa.identificatie,
+             a.identificatienummeraanduiding,
+             a.status                                as nummeraanduidingstatus,
+             a.gemeente,
+             a.woonplaats,
+             a.straatnaam,
+             a.huisnummer,
+             a.huisletter,
+             a.huisnummertoevoeging,
+             a.postcode,
+             sdo_geom.sdo_centroid(spa.geometrie, 2) as geometrie_centroide,
+             spa.geometrie
+      from v_standplaats_actueel spa
+               join standplaats_nevenadres spna on (spna.identificatie = spa.identificatie and
+                                                    spna.voorkomenidentificatie = spa.voorkomenidentificatie)
+               join vb_adres a on spa.heeftalshoofdadres = a.identificatienummeraanduiding) qry;
 
 comment on table vb_standplaats_adres is 'standplaats met adres en puntlocatie';
 delete from user_sdo_geom_metadata where table_name = 'VB_STANDPLAATS_ADRES';
@@ -134,61 +157,76 @@ values ('VB_STANDPLAATS_ADRES', 'GEOMETRIE', mdsys.sdo_dim_array(mdsys.sdo_dim_e
 
 -- Vervangt vb_vbo_adres. Gemeentevelden zijn nog niet beschikbaar.
 create or replace view vb_verblijfsobject_adres as
-select vo.objectid,
-       'true'                                                                      as ishoofdadres,
-       vo.status,
-       vo.identificatie,
-       a.identificatienummeraanduiding,
-       a.status                                                                    as nummeraanduidingstatus,
-       a.gemeente,
-       a.woonplaats,
-       a.straatnaam,
-       a.huisnummer,
-       a.huisletter,
-       a.huisnummertoevoeging,
-       a.postcode,
-       vbod.maaktdeeluitvan,
-       (select LISTAGG(vg.gebruiksdoel, ', ')
-        from verblijfsobject_gebruiksdoel vg
-        where (vg.identificatie = vo.identificatie and vg.voorkomenidentificatie =
-                                                       vo.voorkomenidentificatie)) as gebruiksdoelen,
-       vo.oppervlakte,
-       sdo_geom.sdo_centroid(vo.geometrie, 2)                                      as geometrie_centroide,
-       vo.geometrie
-from v_verblijfsobject_actueel vo
-         join vb_adres a on vo.heeftalshoofdadres = a.identificatienummeraanduiding
-         join verblijfsobject_maaktdeeluitvan vbod
-              on vo.identificatie = vbod.identificatie and vo.voorkomenidentificatie = vbod.voorkomenidentificatie
-union all
-select voa.objectid,
-       'false'                                                                       as ishoofdadres,
-       voa.status,
-       voa.identificatie,
-       a.identificatienummeraanduiding,
-       a.status                                                                      as nummeraanduidingstatus,
-       a.gemeente,
-       a.woonplaats,
-       a.straatnaam,
-       a.huisnummer,
-       a.huisletter,
-       a.huisnummertoevoeging,
-       a.postcode,
-       vbod.maaktdeeluitvan,
-       (select LISTAGG(vg.gebruiksdoel, ', ')
-        from verblijfsobject_gebruiksdoel vg
-        where (vg.identificatie = voa.identificatie and vg.voorkomenidentificatie =
-                                                        voa.voorkomenidentificatie)) as gebruiksdoelen,
-       voa.oppervlakte,
-       sdo_geom.sdo_centroid(voa.geometrie, 2)                                       as geometrie_centroide,
-       voa.geometrie
-from v_verblijfsobject_actueel voa
-         join verblijfsobject_nevenadres vona on
-    (vona.identificatie = voa.identificatie
-        and vona.voorkomenidentificatie = voa.voorkomenidentificatie)
-         join vb_adres a on
-    voa.heeftalshoofdadres = a.identificatienummeraanduiding
-         join verblijfsobject_maaktdeeluitvan vbod
-              on voa.identificatie = vbod.identificatie and voa.voorkomenidentificatie = vbod.voorkomenidentificatie;
+select cast(ROWNUM as INTEGER) as objectid,
+       qry.ishoofdadres,
+       qry.status,
+       qry.identificatie,
+       qry.identificatienummeraanduiding,
+       qry.nummeraanduidingstatus,
+       qry.gemeente,
+       qry.woonplaats,
+       qry.straatnaam,
+       qry.huisnummer,
+       qry.huisletter,
+       qry.huisnummertoevoeging,
+       qry.postcode,
+       qry.maaktdeeluitvan,
+       qry.gebruiksdoelen,
+       qry.oppervlakte,
+       qry.geometrie_centroide,
+       qry.geometrie
+from (select 'true'                                                                                                  as ishoofdadres,
+             vo.status,
+             vo.identificatie,
+             a.identificatienummeraanduiding,
+             a.status                                                                                                as nummeraanduidingstatus,
+             a.gemeente,
+             a.woonplaats,
+             a.straatnaam,
+             a.huisnummer,
+             a.huisletter,
+             a.huisnummertoevoeging,
+             a.postcode,
+             vbod.maaktdeeluitvan,
+             (select listagg(vg.gebruiksdoel, ', ')
+              from verblijfsobject_gebruiksdoel vg
+              where (vg.identificatie = vo.identificatie and vg.voorkomenidentificatie =
+                                                             vo.voorkomenidentificatie))                             as gebruiksdoelen,
+             vo.oppervlakte,
+             sdo_geom.sdo_centroid(vo.geometrie, 2)                                                                  as geometrie_centroide,
+             vo.geometrie
+      from v_verblijfsobject_actueel vo
+               join vb_adres a on vo.heeftalshoofdadres = a.identificatienummeraanduiding
+               join verblijfsobject_maaktdeeluitvan vbod
+                    on vo.identificatie = vbod.identificatie and vo.voorkomenidentificatie = vbod.voorkomenidentificatie
+      union all
+      select 'false'                                                          as ishoofdadres,
+             voa.status,
+             voa.identificatie,
+             a.identificatienummeraanduiding,
+             a.status                                                         as nummeraanduidingstatus,
+             a.gemeente,
+             a.woonplaats,
+             a.straatnaam,
+             a.huisnummer,
+             a.huisletter,
+             a.huisnummertoevoeging,
+             a.postcode,
+             vbod.maaktdeeluitvan,
+             (select listagg(vg.gebruiksdoel, ', ')
+              from verblijfsobject_gebruiksdoel vg
+              where (vg.identificatie = voa.identificatie and
+                     vg.voorkomenidentificatie = voa.voorkomenidentificatie)) as gebruiksdoelen,
+             voa.oppervlakte,
+             sdo_geom.sdo_centroid(voa.geometrie, 2)                          as geometrie_centroide,
+             voa.geometrie
+      from v_verblijfsobject_actueel voa
+               join verblijfsobject_nevenadres vona on (vona.identificatie = voa.identificatie and
+                                                        vona.voorkomenidentificatie = voa.voorkomenidentificatie)
+               join vb_adres a on voa.heeftalshoofdadres = a.identificatienummeraanduiding
+               join verblijfsobject_maaktdeeluitvan vbod on voa.identificatie = vbod.identificatie and
+                                                            voa.voorkomenidentificatie =
+                                                            vbod.voorkomenidentificatie) qry;
 
 comment on table vb_verblijfsobject_adres is 'verblijfsobject met adres, pandverwijzing, gebruiksdoel en puntlocatie';
 delete from user_sdo_geom_metadata where table_name = 'VB_VERBLIJFSOBJECT_ADRES';
@@ -204,68 +242,84 @@ values ('VB_VERBLIJFSOBJECT_ADRES', 'GEOMETRIE', mdsys.sdo_dim_array(mdsys.sdo_d
 
 -- vervangt vb_benoemd_obj_adres alle objecten met een (neven)adres
 create or replace view vb_adresseerbaar_object_geometrie as
-select CAST(ROWNUM AS INTEGER) as objectid,
-       vla.ishoofdadres,
-       vla.status,
-       vla.identificatie,
-       vla.identificatienummeraanduiding,
-       vla.nummeraanduidingstatus,
-       vla.gemeente,
-       vla.woonplaats,
-       vla.straatnaam,
-       vla.huisnummer,
-       vla.huisletter,
-       vla.huisnummertoevoeging,
-       vla.postcode,
-       'ligplaats'             as soort,
-       null                    as maaktdeeluitvan,
-       null                    as gebruiksdoelen,
-       null                    as oppervlakte,
-       vla.geometrie_centroide,
-       vla.geometrie
-from vb_ligplaats_adres vla
-union all
-select CAST(ROWNUM AS INTEGER) as objectid,
-       vsa.ishoofdadres,
-       vsa.status,
-       vsa.identificatie,
-       vsa.identificatienummeraanduiding,
-       vsa.nummeraanduidingstatus,
-       vsa.gemeente,
-       vsa.woonplaats,
-       vsa.straatnaam,
-       vsa.huisnummer,
-       vsa.huisletter,
-       vsa.huisnummertoevoeging,
-       vsa.postcode,
-       'standplaats'           as soort,
-       null                    as maaktdeeluitvan,
-       null                    as gebruiksdoelen,
-       null                    as oppervlakte,
-       vsa.geometrie_centroide,
-       vsa.geometrie
-from vb_standplaats_adres vsa
-union all
-select CAST(ROWNUM AS INTEGER) as objectid,
-       vva.ishoofdadres,
-       vva.status,
-       vva.identificatie,
-       vva.identificatienummeraanduiding,
-       vva.nummeraanduidingstatus,
-       vva.gemeente,
-       vva.woonplaats,
-       vva.straatnaam,
-       vva.huisnummer,
-       vva.huisletter,
-       vva.huisnummertoevoeging,
-       vva.postcode,
-       'verblijfsobject'       as soort,
-       vva.maaktdeeluitvan,
-       vva.gebruiksdoelen,
-       vva.oppervlakte,
-       vva.geometrie_centroide,
-       vva.geometrie
-from vb_verblijfsobject_adres vva;
+select cast(ROWNUM as INTEGER) as objectid,
+       qry.ishoofdadres,
+       qry.status,
+       qry.identificatie,
+       qry.identificatienummeraanduiding,
+       qry.nummeraanduidingstatus,
+       qry.gemeente,
+       qry.woonplaats,
+       qry.straatnaam,
+       qry.huisnummer,
+       qry.huisletter,
+       qry.huisnummertoevoeging,
+       qry.postcode,
+       qry.soort,
+       qry.maaktdeeluitvan,
+       qry.gebruiksdoelen,
+       qry.oppervlakte,
+       qry.geometrie_centroide,
+       qry.geometrie
+from (select vla.ishoofdadres,
+             vla.status,
+             vla.identificatie,
+             vla.identificatienummeraanduiding,
+             vla.nummeraanduidingstatus,
+             vla.gemeente,
+             vla.woonplaats,
+             vla.straatnaam,
+             vla.huisnummer,
+             vla.huisletter,
+             vla.huisnummertoevoeging,
+             vla.postcode,
+             'ligplaats' as soort,
+             null        as maaktdeeluitvan,
+             null        as gebruiksdoelen,
+             null        as oppervlakte,
+             vla.geometrie_centroide,
+             vla.geometrie
+      from vb_ligplaats_adres vla
+      union all
+      select vsa.ishoofdadres,
+             vsa.status,
+             vsa.identificatie,
+             vsa.identificatienummeraanduiding,
+             vsa.nummeraanduidingstatus,
+             vsa.gemeente,
+             vsa.woonplaats,
+             vsa.straatnaam,
+             vsa.huisnummer,
+             vsa.huisletter,
+             vsa.huisnummertoevoeging,
+             vsa.postcode,
+             'standplaats' as soort,
+             null          as maaktdeeluitvan,
+             null          as gebruiksdoelen,
+             null          as oppervlakte,
+             vsa.geometrie_centroide,
+             vsa.geometrie
+      from vb_standplaats_adres vsa
+      union all
+      select vva.ishoofdadres,
+             vva.status,
+             vva.identificatie,
+             vva.identificatienummeraanduiding,
+             vva.nummeraanduidingstatus,
+             vva.gemeente,
+             vva.woonplaats,
+             vva.straatnaam,
+             vva.huisnummer,
+             vva.huisletter,
+             vva.huisnummertoevoeging,
+             vva.postcode,
+             'verblijfsobject' as soort,
+             vva.maaktdeeluitvan,
+             vva.gebruiksdoelen,
+             vva.oppervlakte,
+             vva.geometrie_centroide,
+             vva.geometrie
+      from vb_verblijfsobject_adres vva) qry;
 
 comment on table vb_adresseerbaar_object_geometrie is 'alle adresseerbare objecten (ligplaatst, standplaats, verblijfsobject) met adres, gebruiksdoel, pand en (afgeleide) geometrie.';
 delete from user_sdo_geom_metadata where table_name = 'VB_ADRESSEERBAAR_OBJECT_GEOMETRIE';

--- a/datamodel/extra_scripts/oracle/208_bag2_views.sql
+++ b/datamodel/extra_scripts/oracle/208_bag2_views.sql
@@ -152,6 +152,7 @@ select vo.objectid,
         from verblijfsobject_gebruiksdoel vg
         where (vg.identificatie = vo.identificatie and vg.voorkomenidentificatie =
                                                        vo.voorkomenidentificatie)) as gebruiksdoelen,
+       vo.oppervlakte,
        sdo_geom.sdo_centroid(vo.geometrie, 2)                                      as geometrie_centroide,
        vo.geometrie
 from v_verblijfsobject_actueel vo
@@ -177,6 +178,7 @@ select voa.objectid,
         from verblijfsobject_gebruiksdoel vg
         where (vg.identificatie = voa.identificatie and vg.voorkomenidentificatie =
                                                         voa.voorkomenidentificatie)) as gebruiksdoelen,
+       voa.oppervlakte,
        sdo_geom.sdo_centroid(voa.geometrie, 2)                                       as geometrie_centroide,
        voa.geometrie
 from v_verblijfsobject_actueel voa
@@ -218,6 +220,7 @@ select CAST(ROWNUM AS INTEGER) as objectid,
        'ligplaats'             as soort,
        null                    as maaktdeeluitvan,
        null                    as gebruiksdoelen,
+       null                    as oppervlakte,
        vla.geometrie_centroide,
        vla.geometrie
 from vb_ligplaats_adres vla
@@ -238,6 +241,7 @@ select CAST(ROWNUM AS INTEGER) as objectid,
        'standplaats'           as soort,
        null                    as maaktdeeluitvan,
        null                    as gebruiksdoelen,
+       null                    as oppervlakte,
        vsa.geometrie_centroide,
        vsa.geometrie
 from vb_standplaats_adres vsa
@@ -258,6 +262,7 @@ select CAST(ROWNUM AS INTEGER) as objectid,
        'verblijfsobject'       as soort,
        vva.maaktdeeluitvan,
        vva.gebruiksdoelen,
+       vva.oppervlakte,
        vva.geometrie_centroide,
        vva.geometrie
 from vb_verblijfsobject_adres vva;

--- a/datamodel/extra_scripts/oracle/209_bag2_rsgb_views.sql
+++ b/datamodel/extra_scripts/oracle/209_bag2_rsgb_views.sql
@@ -1,7 +1,7 @@
 -- Via de BRMO GUI kunnen deze materialized views vervolgens automatisch ververst worden.
 
--- LET OP: de aanname is dat het BAG schema de naam "BAG" heeft, indien dat niet het geval is moet dat hieronder
--- aangepast worden op die plaatsen waar verwezen wordt naar het BAG schema, zoek naar "bag." om dat te vervangen
+-- LET OP: de aanname is dat het BAG schema de naam "JENKINS_BAG" heeft, indien dat niet het geval is moet dat hieronder
+-- aangepast worden op die plaatsen waar verwezen wordt naar het BAG schema, zoek naar "jenkins_bag." om dat te vervangen
 -- in de definities van mb_adres_bag en mb_adresseerbaar_object_geometrie_bag
 
 -- Aangezien het in een Oracle database niet mogelijk is om op schema nivo permissies uit te delen dient dat per view
@@ -15,12 +15,12 @@
 --      vb_ligplaats_adres
 --      vb_standplaats_adres
 --      vb_verblijfsobject_adres
-BEGIN
-    FOR t IN (SELECT * FROM USER_VIEWS)
-    LOOP
-        EXECUTE IMMEDIATE 'GRANT SELECT ON ' || t.view_name || ' TO JENKINS_RSGB';
-    END LOOP;
-END;
+-- BEGIN
+--     FOR t IN (SELECT * FROM USER_VIEWS)
+--     LOOP
+--         EXECUTE IMMEDIATE 'GRANT SELECT ON ' || t.view_name || ' TO JENKINS_RSGB';
+--     END LOOP;
+-- END;
 
 -- Vervangt mb_adres. Gemeentevelden zijn nog niet beschikbaar.
 -- Gemeente-woonplaats relatie nog niet beschikbaar (BRMO-104)
@@ -39,9 +39,9 @@ select na.objectid,
        opr.identificatie          as identificatieopenbareruimte,
        wp.identificatie           as identificatiewoonplaats,
        cast(null as NUMBER(4, 0)) as gemeentecode
-from bag.v_nummeraanduiding_actueel na
-         left join bag.v_openbareruimte_actueel opr on (opr.identificatie = na.ligtaan)
-         left join bag.v_woonplaats_actueel wp on (wp.identificatie = opr.ligtin);
+from jenkins_bag.v_nummeraanduiding_actueel na
+         left join jenkins_bag.v_openbareruimte_actueel opr on (opr.identificatie = na.ligtaan)
+         left join jenkins_bag.v_woonplaats_actueel wp on (wp.identificatie = opr.ligtin);
 
 create unique index mb_adres_bag_identificatie on mb_adres_bag (identificatienummeraanduiding asc);
 create unique index mb_adres_bag_objectid on mb_adres_bag (objectid asc);
@@ -87,7 +87,7 @@ from (select vla.ishoofdadres,
              cast(null as NUMBER(10, 0))  as oppervlakte,
              vla.geometrie_centroide,
              vla.geometrie
-      from bag.vb_ligplaats_adres vla
+      from jenkins_bag.vb_ligplaats_adres vla
       union all
       select vsa.ishoofdadres,
              vsa.status,
@@ -107,7 +107,7 @@ from (select vla.ishoofdadres,
              cast(null as NUMBER(10, 0))  as oppervlakte,
              vsa.geometrie_centroide,
              vsa.geometrie
-      from bag.vb_standplaats_adres vsa
+      from jenkins_bag.vb_standplaats_adres vsa
       union all
       select vva.ishoofdadres,
              vva.status,
@@ -127,7 +127,7 @@ from (select vla.ishoofdadres,
              vva.oppervlakte,
              vva.geometrie_centroide,
              vva.geometrie
-      from bag.vb_verblijfsobject_adres vva) qry;
+      from jenkins_bag.vb_verblijfsobject_adres vva) qry;
 
 comment on materialized view mb_adresseerbaar_object_geometrie_bag is 'alle adresseerbare objecten (ligplaatst, standplaats, verblijfsobject) met adres, gebruiksdoel, pand en (afgeleide) geometrie.';
 delete
@@ -259,9 +259,9 @@ from (select p.sc_kad_identif                                                   
 comment on materialized view mb_kad_onrrnd_zk_adres_bag is 'alle kadastrale onroerende zaken (perceel en appartementsrecht) met opgezochte verkoop datum, objectid voor geoserver/arcgis en BAG adres';
 delete
 from user_sdo_geom_metadata
-where table_name = 'MB_ADRESSEERBAAR_OBJECT_GEOMETRIE_BAG';
+where table_name = 'MB_KAD_ONRRND_ZK_ADRES_BAG';
 insert into user_sdo_geom_metadata
-values ('MB_ADRESSEERBAAR_OBJECT_GEOMETRIE_BAG', 'BEGRENZING_PERCEEL',
+values ('MB_KAD_ONRRND_ZK_ADRES_BAG', 'BEGRENZING_PERCEEL',
         mdsys.sdo_dim_array(mdsys.sdo_dim_element('X', 12000, 280000, .1),
                             mdsys.sdo_dim_element('Y', 304000, 620000, .1)), 28992);
 

--- a/datamodel/extra_scripts/oracle/209_bag2_rsgb_views.sql
+++ b/datamodel/extra_scripts/oracle/209_bag2_rsgb_views.sql
@@ -1,0 +1,425 @@
+-- Via de BRMO GUI kunnen deze materialized views vervolgens automatisch ververst worden.
+
+-- LET OP: de aanname is dat het BAG schema de naam "BAG" heeft, indien dat niet het geval is moet dat hieronder
+-- aangepast worden op die plaatsen waar verwezen wordt naar het BAG schema, zoek naar "bag." om dat te vervangen
+-- in de definities van mb_adres_bag en mb_adresseerbaar_object_geometrie_bag
+
+-- Aangezien het in een Oracle database niet mogelijk is om op schema nivo permissies uit te delen dient dat per view
+-- gedaan te worden in het BAG schema/door de BAG user. Dat kan met onderstaande procedure
+-- waarbij de RSGB user nog moet aangepast (in onderstaande 'JENKINS_RSGB'):
+--
+-- Vooralsnog gaat het om de views:
+--      v_nummeraanduiding_actueel
+--      v_openbareruimte_actueel
+--      v_woonplaats_actueel
+--      vb_ligplaats_adres
+--      vb_standplaats_adres
+--      vb_verblijfsobject_adres
+BEGIN
+    FOR t IN (SELECT * FROM USER_VIEWS)
+    LOOP
+        EXECUTE IMMEDIATE 'GRANT SELECT ON ' || t.view_name || ' TO JENKINS_RSGB';
+    END LOOP;
+END;
+
+-- Vervangt mb_adres. Gemeentevelden zijn nog niet beschikbaar.
+-- Gemeente-woonplaats relatie nog niet beschikbaar (BRMO-104)
+create materialized view mb_adres_bag build deferred refresh on demand as
+select na.objectid,
+       na.identificatie           as identificatienummeraanduiding,
+       na.status,
+       na.begingeldigheid,
+       cast(null as varchar2(40)) as gemeente,
+       wp.naam                    as woonplaats,
+       opr.naam                   as straatnaam,
+       na.huisnummer,
+       na.huisletter,
+       na.huisnummertoevoeging,
+       na.postcode,
+       opr.identificatie          as identificatieopenbareruimte,
+       wp.identificatie           as identificatiewoonplaats,
+       cast(null as NUMBER(4, 0)) as gemeentecode
+from bag.v_nummeraanduiding_actueel na
+         left join bag.v_openbareruimte_actueel opr on (opr.identificatie = na.ligtaan)
+         left join bag.v_woonplaats_actueel wp on (wp.identificatie = opr.ligtin);
+
+create unique index mb_adres_bag_identificatie on mb_adres_bag (identificatienummeraanduiding asc);
+create unique index mb_adres_bag_objectid on mb_adres_bag (objectid asc);
+comment on materialized view mb_adres_bag is 'volledig actueel adres zonder locatie';
+
+
+-- maakt een materialized view van vb_adresseerbaar_object_geometrie tbv performance bij zeer grote datasets.
+create materialized view mb_adresseerbaar_object_geometrie_bag build deferred refresh on demand as
+select cast(ROWNUM as INTEGER) as objectid,
+       qry.ishoofdadres,
+       qry.status,
+       qry.identificatie,
+       qry.identificatienummeraanduiding,
+       qry.nummeraanduidingstatus,
+       qry.gemeente,
+       qry.woonplaats,
+       qry.straatnaam,
+       qry.huisnummer,
+       qry.huisletter,
+       qry.huisnummertoevoeging,
+       qry.postcode,
+       qry.soort,
+       qry.maaktdeeluitvan,
+       qry.gebruiksdoelen,
+       qry.oppervlakte,
+       qry.geometrie_centroide,
+       qry.geometrie
+from (select vla.ishoofdadres,
+             vla.status,
+             vla.identificatie,
+             vla.identificatienummeraanduiding,
+             vla.nummeraanduidingstatus,
+             cast(null as varchar2(40))   as gemeente,
+             vla.woonplaats,
+             vla.straatnaam,
+             vla.huisnummer,
+             vla.huisletter,
+             vla.huisnummertoevoeging,
+             vla.postcode,
+             'ligplaats'                  as soort,
+             cast(null as char(16))       as maaktdeeluitvan,
+             cast(null as varchar2(4000)) as gebruiksdoelen,
+             cast(null as NUMBER(10, 0))  as oppervlakte,
+             vla.geometrie_centroide,
+             vla.geometrie
+      from bag.vb_ligplaats_adres vla
+      union all
+      select vsa.ishoofdadres,
+             vsa.status,
+             vsa.identificatie,
+             vsa.identificatienummeraanduiding,
+             vsa.nummeraanduidingstatus,
+             cast(null as varchar2(40))   as gemeente,
+             vsa.woonplaats,
+             vsa.straatnaam,
+             vsa.huisnummer,
+             vsa.huisletter,
+             vsa.huisnummertoevoeging,
+             vsa.postcode,
+             'standplaats'                as soort,
+             cast(null as char(16))       as maaktdeeluitvan,
+             cast(null as varchar2(4000)) as gebruiksdoelen,
+             cast(null as NUMBER(10, 0))  as oppervlakte,
+             vsa.geometrie_centroide,
+             vsa.geometrie
+      from bag.vb_standplaats_adres vsa
+      union all
+      select vva.ishoofdadres,
+             vva.status,
+             vva.identificatie,
+             vva.identificatienummeraanduiding,
+             vva.nummeraanduidingstatus,
+             cast(null as varchar2(40)) as gemeente,
+             vva.woonplaats,
+             vva.straatnaam,
+             vva.huisnummer,
+             vva.huisletter,
+             vva.huisnummertoevoeging,
+             vva.postcode,
+             'verblijfsobject'          as soort,
+             vva.maaktdeeluitvan,
+             vva.gebruiksdoelen,
+             vva.oppervlakte,
+             vva.geometrie_centroide,
+             vva.geometrie
+      from bag.vb_verblijfsobject_adres vva) qry;
+
+comment on materialized view mb_adresseerbaar_object_geometrie_bag is 'alle adresseerbare objecten (ligplaatst, standplaats, verblijfsobject) met adres, gebruiksdoel, pand en (afgeleide) geometrie.';
+delete
+from user_sdo_geom_metadata
+where table_name = 'MB_ADRESSEERBAAR_OBJECT_GEOMETRIE_BAG';
+insert into user_sdo_geom_metadata
+values ('MB_ADRESSEERBAAR_OBJECT_GEOMETRIE_BAG', 'GEOMETRIE_CENTROIDE',
+        mdsys.sdo_dim_array(mdsys.sdo_dim_element('X', 12000, 280000, .1),
+                            mdsys.sdo_dim_element('Y', 304000, 620000, .1)), 28992);
+insert into user_sdo_geom_metadata
+values ('MB_ADRESSEERBAAR_OBJECT_GEOMETRIE_BAG', 'GEOMETRIE',
+        mdsys.sdo_dim_array(mdsys.sdo_dim_element('X', 12000, 280000, .1),
+                            mdsys.sdo_dim_element('Y', 304000, 620000, .1)), 28992);
+
+create index mb_adresseerbaar_object_geometrie_bag_geom on mb_adresseerbaar_object_geometrie_bag (geometrie) indextype is MDSYS.SPATIAL_INDEX;
+create index mb_adresseerbaar_object_geometrie_bag_centroid on mb_adresseerbaar_object_geometrie_bag (geometrie_centroide) indextype is MDSYS.SPATIAL_INDEX;
+create index mb_adresseerbaar_object_geometrie_bag_identificatie on mb_adresseerbaar_object_geometrie_bag (identificatienummeraanduiding);
+create unique index mb_adresseerbaar_object_geometrie_bag_objectid on mb_adresseerbaar_object_geometrie_bag (objectid);
+
+
+--Maakt dezelfde materialized view aan als mb_kad_onrrnd_zk_adres, maar de BAG gegevens worden uit mb_adresseerbaar_object_geometrie_bag gehaald.
+create materialized view mb_kad_onrrnd_zk_adres_bag build deferred refresh on demand as
+select cast(ROWNUM as INTEGER)                                                             as objectid,
+       qry.identif                                                                         as koz_identif,
+       koz.dat_beg_geldh                                                                   as begin_geldigheid,
+       to_date(koz.dat_beg_geldh, 'YYYY-MM-DD')                                            as begin_geldigheid_datum,
+       bok.fk_nn_lh_tgo_identif                                                            as benoemdobj_identif,
+       qry.type,
+       coalesce(qry.ka_sectie, '') || ' ' || coalesce(qry.ka_perceelnummer, '')            as aanduiding,
+       coalesce(qry.ka_kad_gemeentecode, '') || ' ' || coalesce(qry.ka_sectie, '') || ' ' ||
+       coalesce(qry.ka_perceelnummer, '') || ' ' || coalesce(qry.ka_appartementsindex, '') as aanduiding2,
+       qry.ka_sectie                                                                       as sectie,
+       qry.ka_perceelnummer                                                                as perceelnummer,
+       qry.ka_appartementsindex                                                            as appartementsindex,
+       qry.ka_kad_gemeentecode                                                             as gemeentecode,
+       qry.aand_soort_grootte,
+       qry.grootte_perceel,
+       qry.oppervlakte_geom,
+       qry.ka_deelperceelnummer                                                            as deelperceelnummer,
+       qry.omschr_deelperceel,
+       b.datum                                                                             as verkoop_datum,
+       koz.cu_aard_cultuur_onbebouwd                                                       as aard_cultuur_onbebouwd,
+       koz.ks_bedrag                                                                       as bedrag,
+       koz.ks_koopjaar                                                                     as koopjaar,
+       koz.ks_meer_onroerendgoed                                                           as meer_onroerendgoed,
+       koz.ks_valutasoort                                                                  as valutasoort,
+       koz.lo_loc__omschr                                                                  as loc_omschr,
+       aant.aantekeningen                                                                  as aantekeningen,
+       maogb.identificatienummeraanduiding,
+       maogb.nummeraanduidingstatus,
+       cast(null as varchar2(40))                                                          as gemeente,
+       maogb.woonplaats,
+       maogb.straatnaam,
+       maogb.huisnummer,
+       maogb.huisletter,
+       maogb.huisnummertoevoeging,
+       maogb.postcode,
+       maogb.gebruiksdoelen,
+       maogb.oppervlakte,
+       qry.lon,
+       qry.lat,
+       qry.begrenzing_perceel
+from (select p.sc_kad_identif                                                                    as identif,
+             'perceel'                                                                           as type,
+             p.ka_sectie,
+             p.ka_perceelnummer,
+             cast(null as CHARACTER VARYING(4))                                                  as ka_appartementsindex,
+             p.ka_kad_gemeentecode,
+             p.aand_soort_grootte,
+             p.grootte_perceel,
+             p.ka_deelperceelnummer,
+             p.omschr_deelperceel,
+             p.begrenzing_perceel                                                                as begrenzing_perceel,
+             case
+                 when p.begrenzing_perceel.get_gtype() is not null then sdo_geom.sdo_area(p.begrenzing_perceel, 0.1)
+                 else null end                                                                   as oppervlakte_geom,
+             case
+                 when p.begrenzing_perceel.get_gtype() is not null then sdo_cs.transform(
+                         sdo_geom.sdo_centroid(p.begrenzing_perceel, 0.1), 4326).sdo_point.x
+                 else null end                                                                   as lon,
+             case
+                 when p.begrenzing_perceel.get_gtype() is not null then sdo_cs.transform(
+                         sdo_geom.sdo_centroid(p.begrenzing_perceel, 0.1), 4326).sdo_point.y end as lat
+      from kad_perceel p
+      union all
+      select ar.sc_kad_identif                                                                    as identif,
+             'appartement'                                                                        as type,
+             ar.ka_sectie,
+             ar.ka_perceelnummer,
+             ar.ka_appartementsindex,
+             ar.ka_kad_gemeentecode,
+             cast(null as CHARACTER VARYING(2))                                                   as aand_soort_grootte,
+             cast(null as NUMERIC(8, 0))                                                          as grootte_perceel,
+             cast(null as CHARACTER VARYING(4))                                                   as ka_deelperceelnummer,
+             cast(null as CHARACTER VARYING(1120))                                                as omschr_deelperceel,
+             kp.begrenzing_perceel                                                                as begrenzing_perceel,
+             case
+                 when kp.begrenzing_perceel.get_gtype() is not null then sdo_geom.sdo_area(kp.begrenzing_perceel, 0.1)
+                 else null end                                                                    as oppervlakte_geom,
+             case
+                 when kp.begrenzing_perceel.get_gtype() is not null then sdo_cs.transform(
+                         sdo_geom.sdo_centroid(kp.begrenzing_perceel, 0.1), 4326).sdo_point.x
+                 else null end                                                                    as lon,
+             case
+                 when kp.begrenzing_perceel.get_gtype() is not null then sdo_cs.transform(
+                         sdo_geom.sdo_centroid(kp.begrenzing_perceel, 0.1), 4326).sdo_point.y end as lat
+      from mb_util_app_re_kad_perceel v
+               join kad_perceel kp on cast(v.perceel_identif as NUMERIC) = kp.sc_kad_identif
+               join app_re ar on cast(v.app_re_identif as NUMERIC) = ar.sc_kad_identif) qry
+         join kad_onrrnd_zk koz on (koz.kad_identif = qry.identif)
+         left join benoemd_obj_kad_onrrnd_zk bok on (bok.fk_nn_rh_koz_kad_identif = qry.identif)
+         left join mb_adresseerbaar_object_geometrie_bag maogb on (((bok.fk_nn_lh_tgo_identif) = maogb.identificatie))
+         left join (select bd.ref_id, max(bd.datum) as datum
+                    from brondocument bd
+                    where ((bd.omschrijving) = 'Akte van Koop en Verkoop')
+                    group by bd.ref_id) b on (koz.kad_identif = b.ref_id)
+         left join (select fk_4koz_kad_identif,
+                           listagg('id: ' || coalesce(koza.kadaster_identif_aantek, '') || ', ' || 'aard: ' ||
+                                   coalesce(koza.aard_aantek_kad_obj, '') || ', ' || 'begin: ' ||
+                                   coalesce(koza.begindatum_aantek_kad_obj, '') || ', ' || 'beschrijving: ' ||
+                                   coalesce(koza.beschrijving_aantek_kad_obj, '') || ', ' || 'eind: ' ||
+                                   coalesce(koza.eindd_aantek_kad_obj, '') || ', ' || 'koz-id: ' ||
+                                   coalesce(koza.fk_4koz_kad_identif, 0) || ', ' || 'subject-id: ' ||
+                                   coalesce(koza.fk_5pes_sc_identif, '') || '; ', ' & ' on OVERFLOW TRUNCATE with COUNT)
+                                   within group ( order by koza.fk_4koz_kad_identif ) as aantekeningen
+                    from kad_onrrnd_zk_aantek koza
+                    group by fk_4koz_kad_identif) aant on koz.kad_identif = aant.fk_4koz_kad_identif;
+
+comment on materialized view mb_kad_onrrnd_zk_adres_bag is 'alle kadastrale onroerende zaken (perceel en appartementsrecht) met opgezochte verkoop datum, objectid voor geoserver/arcgis en BAG adres';
+delete
+from user_sdo_geom_metadata
+where table_name = 'MB_ADRESSEERBAAR_OBJECT_GEOMETRIE_BAG';
+insert into user_sdo_geom_metadata
+values ('MB_ADRESSEERBAAR_OBJECT_GEOMETRIE_BAG', 'BEGRENZING_PERCEEL',
+        mdsys.sdo_dim_array(mdsys.sdo_dim_element('X', 12000, 280000, .1),
+                            mdsys.sdo_dim_element('Y', 304000, 620000, .1)), 28992);
+
+create index mb_kad_onrrnd_zk_adres_bag_begrenzing_perceel_idx on mb_kad_onrrnd_zk_adres_bag (begrenzing_perceel) indextype is MDSYS.SPATIAL_INDEX;
+create index mb_kad_onrrnd_zk_adres_bag_identif on mb_kad_onrrnd_zk_adres_bag (koz_identif);
+create unique index mb_kad_onrrnd_zk_adres_bag_objectid on mb_kad_onrrnd_zk_adres_bag (objectid);
+
+
+--Maakt dezelfde materialized view aan als mb_koz_rechth, maar de BAG gegevens worden uit mb_kad_onrrnd_zk_adres_bag gehaald.
+create materialized view mb_koz_rechth_bag build deferred refresh on demand as
+select cast(ROWNUM as INTEGER)                                            as objectid,
+       koz.koz_identif,
+       koz.begin_geldigheid,
+       to_date(koz.begin_geldigheid, 'YYYY-MM-DD')                        as begin_geldigheid_datum,
+       koz.type,
+       coalesce(koz.sectie, '') || ' ' || coalesce(koz.perceelnummer, '') as aanduiding,
+       coalesce(koz.gemeentecode, '') || ' ' || coalesce(koz.sectie, '') || ' ' || coalesce(koz.perceelnummer, '') ||
+       ' ' || coalesce(koz.appartementsindex, '')                         as aanduiding2,
+       koz.sectie,
+       koz.perceelnummer,
+       koz.appartementsindex,
+       koz.gemeentecode,
+       koz.aand_soort_grootte,
+       koz.grootte_perceel,
+       koz.oppervlakte_geom                                               as oppervlakte_geom,
+       koz.deelperceelnummer,
+       koz.omschr_deelperceel,
+       koz.verkoop_datum,
+       koz.aard_cultuur_onbebouwd,
+       koz.bedrag,
+       koz.koopjaar,
+       koz.meer_onroerendgoed,
+       koz.valutasoort,
+       koz.loc_omschr,
+       zrr.zr_identif,
+       zrr.ingangsdatum_recht,
+       zrr.subject_identif,
+       zrr.aandeel,
+       zrr.omschr_aard_verkregenr_recht,
+       zrr.indic_betrokken_in_splitsing,
+       zrr.soort,
+       zrr.geslachtsnaam,
+       zrr.voorvoegsel,
+       zrr.voornamen,
+       zrr.aand_naamgebruik,
+       zrr.geslachtsaand,
+       zrr.naam,
+       zrr.woonadres,
+       zrr.geboortedatum,
+       zrr.geboorteplaats,
+       zrr.overlijdensdatum,
+       zrr.bsn,
+       zrr.organisatie_naam,
+       zrr.rechtsvorm,
+       zrr.statutaire_zetel,
+       zrr.rsin,
+       zrr.kvk_nummer,
+       zrr.aantekeningen,
+       koz.gemeente,
+       koz.woonplaats,
+       koz.straatnaam,
+       koz.huisnummer,
+       koz.huisletter,
+       koz.huisnummertoevoeging,
+       koz.postcode,
+       koz.lon,
+       koz.lat,
+       koz.begrenzing_perceel
+from mb_zr_rechth zrr
+         right join mb_kad_onrrnd_zk_adres_bag koz on zrr.koz_identif = koz.koz_identif;
+
+comment on materialized view mb_kad_onrrnd_zk_adres_bag is 'kadastrale percelen een appartementsrechten met rechten en rechthebbenden en objectid voor geoserver/arcgis';
+delete
+from user_sdo_geom_metadata
+where table_name = 'MB_KOZ_RECHTH_BAG';
+insert into user_sdo_geom_metadata
+values ('MB_KOZ_RECHTH_BAG', 'BEGRENZING_PERCEEL',
+        mdsys.sdo_dim_array(mdsys.sdo_dim_element('X', 12000, 280000, .1),
+                            mdsys.sdo_dim_element('Y', 304000, 620000, .1)), 28992);
+
+create index mb_koz_rechth_bag_begrenzing_perceel_idx on mb_koz_rechth_bag (begrenzing_perceel) indextype is MDSYS.SPATIAL_INDEX;
+create index mb_koz_rechth_bag_identif on mb_koz_rechth_bag (koz_identif);
+create unique index mb_koz_rechth_bag_objectid on mb_koz_rechth_bag (objectid);
+
+
+--Maakt dezelfde materialized view aan als mb_avg_koz_rechth, maar de BAG gegevens worden uit mb_kad_onrrnd_zk_adres_bag gehaald.
+create materialized view mb_avg_koz_rechth_bag build deferred refresh on demand as
+select cast(ROWNUM as INTEGER)                                            as objectid,
+       koz.koz_identif                                                    as koz_identif,
+       koz.begin_geldigheid,
+       to_date(koz.begin_geldigheid, 'YYYY-MM-DD')                        as begin_geldigheid_datum,
+       koz.type,
+       coalesce(koz.sectie, '') || ' ' || coalesce(koz.perceelnummer, '') as aanduiding,
+       coalesce(koz.gemeentecode, '') || ' ' || coalesce(koz.sectie, '') || ' ' || coalesce(koz.perceelnummer, '') ||
+       ' ' || coalesce(koz.appartementsindex, '')                         as aanduiding2,
+       koz.sectie,
+       koz.perceelnummer,
+       koz.appartementsindex,
+       koz.gemeentecode,
+       koz.aand_soort_grootte,
+       koz.grootte_perceel,
+       koz.oppervlakte_geom,
+       koz.deelperceelnummer,
+       koz.omschr_deelperceel,
+       koz.verkoop_datum,
+       koz.aard_cultuur_onbebouwd,
+       koz.bedrag,
+       koz.koopjaar,
+       koz.meer_onroerendgoed,
+       koz.valutasoort,
+       koz.loc_omschr,
+       zrr.zr_identif,
+       zrr.ingangsdatum_recht,
+       zrr.subject_identif,
+       zrr.aandeel,
+       zrr.omschr_aard_verkregenr_recht,
+       zrr.indic_betrokken_in_splitsing,
+       zrr.soort,
+       zrr.geslachtsnaam,
+       zrr.voorvoegsel,
+       zrr.voornamen,
+       zrr.aand_naamgebruik,
+       zrr.geslachtsaand,
+       zrr.naam,
+       zrr.woonadres,
+       zrr.geboortedatum,
+       zrr.geboorteplaats,
+       zrr.overlijdensdatum,
+       zrr.bsn,
+       zrr.organisatie_naam,
+       zrr.rechtsvorm,
+       zrr.statutaire_zetel,
+       zrr.rsin,
+       zrr.kvk_nummer,
+       zrr.aantekeningen,
+       koz.gemeente,
+       koz.woonplaats,
+       koz.straatnaam,
+       koz.huisnummer,
+       koz.huisletter,
+       koz.huisnummertoevoeging,
+       koz.postcode,
+       koz.lon,
+       koz.lat,
+       koz.begrenzing_perceel
+from mb_avg_zr_rechth zrr
+         right join mb_kad_onrrnd_zk_adres_bag koz on zrr.koz_identif = koz.koz_identif;
+
+
+comment on materialized view mb_kad_onrrnd_zk_adres_bag is 'kadastrale percelen een appartementsrechten met rechten en rechthebbenden geschoond voor avg en objectid voor geoserver/arcgis';
+delete
+from user_sdo_geom_metadata
+where table_name = 'MB_AVG_KOZ_RECHTH_BAG';
+insert into user_sdo_geom_metadata
+values ('MB_AVG_KOZ_RECHTH_BAG', 'BEGRENZING_PERCEEL',
+        mdsys.sdo_dim_array(mdsys.sdo_dim_element('X', 12000, 280000, .1),
+                            mdsys.sdo_dim_element('Y', 304000, 620000, .1)), 28992);
+
+create index mb_avg_koz_rechth_bag_begrenzing_perceel_idx on mb_avg_koz_rechth_bag (begrenzing_perceel) indextype is MDSYS.SPATIAL_INDEX;
+create index mb_avg_koz_rechth_bag_identif on mb_avg_koz_rechth_bag (koz_identif);
+create unique index mb_avg_koz_rechth_bag_objectid on mb_avg_koz_rechth_bag (objectid);

--- a/datamodel/extra_scripts/postgresql/208_bag2_views.sql
+++ b/datamodel/extra_scripts/postgresql/208_bag2_views.sql
@@ -138,6 +138,7 @@ select vo.objectid,
                 from verblijfsobject_gebruiksdoel vg
                 where (vg.identificatie = vo.identificatie and vg.voorkomenidentificatie = vo.voorkomenidentificatie))
            , ', ')               as gebruiksdoelen,
+       vo.oppervlakte,
        st_centroid(vo.geometrie) as geometrie_centroide,
        vo.geometrie
 from v_verblijfsobject_actueel vo
@@ -164,6 +165,7 @@ select voa.objectid,
                 from verblijfsobject_gebruiksdoel vg
                 where (vg.identificatie = voa.identificatie and vg.voorkomenidentificatie = voa.voorkomenidentificatie))
            , ', ')                as gebruiksdoelen,
+       voa.oppervlakte,
        st_centroid(voa.geometrie) as geometrie_centroide,
        voa.geometrie
 from v_verblijfsobject_actueel voa
@@ -196,6 +198,7 @@ select (row_number() over ())::integer as objectid,
        'ligplaats'                     as soort,
        null                            as maaktdeeluitvan,
        null                            as gebruiksdoelen,
+       null                            as oppervlakte,
        vla.geometrie_centroide,
        vla.geometrie
 from vb_ligplaats_adres vla
@@ -216,6 +219,7 @@ select (row_number() over ())::integer as objectid,
        'standplaats'                   as soort,
        null                            as maaktdeeluitvan,
        null                            as gebruiksdoelen,
+       null                            as oppervlakte,
        vsa.geometrie_centroide,
        vsa.geometrie
 from vb_standplaats_adres vsa
@@ -236,6 +240,7 @@ select (row_number() over ())::integer as objectid,
        'verblijfsobject'               as soort,
        vva.maaktdeeluitvan,
        vva.gebruiksdoelen,
+       vva.oppervlakte,
        vva.geometrie_centroide,
        vva.geometrie
 from vb_verblijfsobject_adres vva;

--- a/datamodel/extra_scripts/postgresql/208_bag2_views.sql
+++ b/datamodel/extra_scripts/postgresql/208_bag2_views.sql
@@ -29,153 +29,199 @@ comment on view vb_adres is 'volledig actueel adres zonder locatie';
 
 -- Vervangt vb_ligplaats_adres. Gemeentevelden zijn nog niet beschikbaar.
 create or replace view vb_ligplaats_adres as
-select lp.objectid,
-       true                      as ishoofdadres,
-       lp.status,
-       lp.identificatie,
-       a.identificatienummeraanduiding,
-       a.status                  as nummeraanduidingstatus,
-       a.gemeente,
-       a.woonplaats,
-       a.straatnaam,
-       a.huisnummer,
-       a.huisletter,
-       a.huisnummertoevoeging,
-       a.postcode,
-       st_centroid(lp.geometrie) as geometrie_centroide,
-       lp.geometrie
-from v_ligplaats_actueel lp
-         join vb_adres a on lp.heeftalshoofdadres = a.identificatienummeraanduiding
-union all
-select lpa.objectid,
-       false                      as ishoofdadres,
-       lpa.status,
-       lpa.identificatie,
-       a.identificatienummeraanduiding,
-       a.status                   as nummeraanduidingstatus,
-       a.gemeente,
-       a.woonplaats,
-       a.straatnaam,
-       a.huisnummer,
-       a.huisletter,
-       a.huisnummertoevoeging,
-       a.postcode,
-       st_centroid(lpa.geometrie) as geometrie_centroide,
-       lpa.geometrie
-from v_ligplaats_actueel lpa
-         join ligplaats_nevenadres lpna on
-    (lpna.identificatie = lpa.identificatie
-        and lpna.voorkomenidentificatie = lpa.voorkomenidentificatie)
-         join vb_adres a on
-    lpa.heeftalshoofdadres = a.identificatienummeraanduiding;
+select (row_number() over ())::integer as objectid,
+       qry.ishoofdadres,
+       qry.status,
+       qry.identificatie,
+       qry.identificatienummeraanduiding,
+       qry.nummeraanduidingstatus,
+       qry.gemeente,
+       qry.woonplaats,
+       qry.straatnaam,
+       qry.huisnummer,
+       qry.huisletter,
+       qry.huisnummertoevoeging,
+       qry.postcode,
+       qry.geometrie_centroide,
+       qry.geometrie
+from (
+         select true                      as ishoofdadres,
+                lp.status,
+                lp.identificatie,
+                a.identificatienummeraanduiding,
+                a.status                  as nummeraanduidingstatus,
+                a.gemeente,
+                a.woonplaats,
+                a.straatnaam,
+                a.huisnummer,
+                a.huisletter,
+                a.huisnummertoevoeging,
+                a.postcode,
+                st_centroid(lp.geometrie) as geometrie_centroide,
+                lp.geometrie
+         from v_ligplaats_actueel lp
+                  join vb_adres a on lp.heeftalshoofdadres = a.identificatienummeraanduiding
+         union all
+         select false                      as ishoofdadres,
+                lpa.status,
+                lpa.identificatie,
+                a.identificatienummeraanduiding,
+                a.status                   as nummeraanduidingstatus,
+                a.gemeente,
+                a.woonplaats,
+                a.straatnaam,
+                a.huisnummer,
+                a.huisletter,
+                a.huisnummertoevoeging,
+                a.postcode,
+                st_centroid(lpa.geometrie) as geometrie_centroide,
+                lpa.geometrie
+         from v_ligplaats_actueel lpa
+                  join ligplaats_nevenadres lpna on
+             (lpna.identificatie = lpa.identificatie
+                 and lpna.voorkomenidentificatie = lpa.voorkomenidentificatie)
+                  join vb_adres a on
+             lpa.heeftalshoofdadres = a.identificatienummeraanduiding) qry;
 
 comment on view vb_ligplaats_adres is 'ligplaats met adres en puntlocatie';
 
 
 -- Vervangt vb_standplaats_adres. Gemeentevelden zijn nog niet beschikbaar.
 create or replace view vb_standplaats_adres as
-select sp.objectid,
-       true                      as ishoofdadres,
-       sp.status,
-       sp.identificatie,
-       a.identificatienummeraanduiding,
-       a.status                  as nummeraanduidingstatus,
-       a.gemeente,
-       a.woonplaats,
-       a.straatnaam,
-       a.huisnummer,
-       a.huisletter,
-       a.huisnummertoevoeging,
-       a.postcode,
-       st_centroid(sp.geometrie) as geometrie_centroide,
-       sp.geometrie
-from v_standplaats_actueel sp
-         join vb_adres a on sp.heeftalshoofdadres = a.identificatienummeraanduiding
-union all
-select spa.objectid,
-       false                      as ishoofdadres,
-       spa.status,
-       spa.identificatie,
-       a.identificatienummeraanduiding,
-       a.status                   as nummeraanduidingstatus,
-       a.gemeente,
-       a.woonplaats,
-       a.straatnaam,
-       a.huisnummer,
-       a.huisletter,
-       a.huisnummertoevoeging,
-       a.postcode,
-       st_centroid(spa.geometrie) as geometrie_centroide,
-       spa.geometrie
-from v_standplaats_actueel spa
-         join standplaats_nevenadres spna on
-    (spna.identificatie = spa.identificatie
-        and spna.voorkomenidentificatie = spa.voorkomenidentificatie)
-         join vb_adres a on
-    spa.heeftalshoofdadres = a.identificatienummeraanduiding;
+select (row_number() over ())::integer as objectid,
+       qry.ishoofdadres,
+       qry.status,
+       qry.identificatie,
+       qry.identificatienummeraanduiding,
+       qry.nummeraanduidingstatus,
+       qry.gemeente,
+       qry.woonplaats,
+       qry.straatnaam,
+       qry.huisnummer,
+       qry.huisletter,
+       qry.huisnummertoevoeging,
+       qry.postcode,
+       qry.geometrie_centroide,
+       qry.geometrie
+from (select true                      as ishoofdadres,
+             sp.status,
+             sp.identificatie,
+             a.identificatienummeraanduiding,
+             a.status                  as nummeraanduidingstatus,
+             a.gemeente,
+             a.woonplaats,
+             a.straatnaam,
+             a.huisnummer,
+             a.huisletter,
+             a.huisnummertoevoeging,
+             a.postcode,
+             st_centroid(sp.geometrie) as geometrie_centroide,
+             sp.geometrie
+      from v_standplaats_actueel sp
+               join vb_adres a on sp.heeftalshoofdadres = a.identificatienummeraanduiding
+      union all
+      select false                      as ishoofdadres,
+             spa.status,
+             spa.identificatie,
+             a.identificatienummeraanduiding,
+             a.status                   as nummeraanduidingstatus,
+             a.gemeente,
+             a.woonplaats,
+             a.straatnaam,
+             a.huisnummer,
+             a.huisletter,
+             a.huisnummertoevoeging,
+             a.postcode,
+             st_centroid(spa.geometrie) as geometrie_centroide,
+             spa.geometrie
+      from v_standplaats_actueel spa
+               join standplaats_nevenadres spna on
+          (spna.identificatie = spa.identificatie
+              and spna.voorkomenidentificatie = spa.voorkomenidentificatie)
+               join vb_adres a on
+          spa.heeftalshoofdadres = a.identificatienummeraanduiding) qry;
 
 comment on view vb_standplaats_adres is 'standplaats met adres en puntlocatie';
 
 
 -- Vervangt vb_vbo_adres. Gemeentevelden zijn nog niet beschikbaar.
 create or replace view vb_verblijfsobject_adres as
-select vo.objectid,
-       true                      as ishoofdadres,
-       vo.status,
-       vo.identificatie,
-       a.identificatienummeraanduiding,
-       a.status                  as nummeraanduidingstatus,
-       a.gemeente,
-       a.woonplaats,
-       a.straatnaam,
-       a.huisnummer,
-       a.huisletter,
-       a.huisnummertoevoeging,
-       a.postcode,
-       vbod.maaktdeeluitvan,
-       array_to_string(
-               (select array_agg(vg.gebruiksdoel)
-                from verblijfsobject_gebruiksdoel vg
-                where (vg.identificatie = vo.identificatie and vg.voorkomenidentificatie = vo.voorkomenidentificatie))
-           , ', ')               as gebruiksdoelen,
-       vo.oppervlakte,
-       st_centroid(vo.geometrie) as geometrie_centroide,
-       vo.geometrie
-from v_verblijfsobject_actueel vo
-         join vb_adres a on vo.heeftalshoofdadres = a.identificatienummeraanduiding
-         join verblijfsobject_maaktdeeluitvan vbod
-              on vo.identificatie = vbod.identificatie and vo.voorkomenidentificatie = vbod.voorkomenidentificatie
-union all
-select voa.objectid,
-       false                      as ishoofdadres,
-       voa.status,
-       voa.identificatie,
-       a.identificatienummeraanduiding,
-       a.status                   as nummeraanduidingstatus,
-       a.gemeente,
-       a.woonplaats,
-       a.straatnaam,
-       a.huisnummer,
-       a.huisletter,
-       a.huisnummertoevoeging,
-       a.postcode,
-       vbod.maaktdeeluitvan,
-       array_to_string(
-               (select array_agg(vg.gebruiksdoel)
-                from verblijfsobject_gebruiksdoel vg
-                where (vg.identificatie = voa.identificatie and vg.voorkomenidentificatie = voa.voorkomenidentificatie))
-           , ', ')                as gebruiksdoelen,
-       voa.oppervlakte,
-       st_centroid(voa.geometrie) as geometrie_centroide,
-       voa.geometrie
-from v_verblijfsobject_actueel voa
-         join verblijfsobject_nevenadres vona on
-    (vona.identificatie = voa.identificatie
-        and vona.voorkomenidentificatie = voa.voorkomenidentificatie)
-         join vb_adres a on
-    voa.heeftalshoofdadres = a.identificatienummeraanduiding
-         join verblijfsobject_maaktdeeluitvan vbod
-              on voa.identificatie = vbod.identificatie and voa.voorkomenidentificatie = vbod.voorkomenidentificatie;
+select (row_number() over ())::integer as objectid,
+       qry.ishoofdadres,
+       qry.status,
+       qry.identificatie,
+       qry.identificatienummeraanduiding,
+       qry.nummeraanduidingstatus,
+       qry.gemeente,
+       qry.woonplaats,
+       qry.straatnaam,
+       qry.huisnummer,
+       qry.huisletter,
+       qry.huisnummertoevoeging,
+       qry.postcode,
+       qry.maaktdeeluitvan,
+       qry.gebruiksdoelen,
+       qry.oppervlakte,
+       qry.geometrie_centroide,
+       qry.geometrie
+from (select true                      as ishoofdadres,
+             vo.status,
+             vo.identificatie,
+             a.identificatienummeraanduiding,
+             a.status                  as nummeraanduidingstatus,
+             a.gemeente,
+             a.woonplaats,
+             a.straatnaam,
+             a.huisnummer,
+             a.huisletter,
+             a.huisnummertoevoeging,
+             a.postcode,
+             vbod.maaktdeeluitvan,
+             array_to_string(
+                     (select array_agg(vg.gebruiksdoel)
+                      from verblijfsobject_gebruiksdoel vg
+                      where (vg.identificatie = vo.identificatie and
+                             vg.voorkomenidentificatie = vo.voorkomenidentificatie))
+                 , ', ')               as gebruiksdoelen,
+             vo.oppervlakte,
+             st_centroid(vo.geometrie) as geometrie_centroide,
+             vo.geometrie
+      from v_verblijfsobject_actueel vo
+               join vb_adres a on vo.heeftalshoofdadres = a.identificatienummeraanduiding
+               join verblijfsobject_maaktdeeluitvan vbod
+                    on vo.identificatie = vbod.identificatie and vo.voorkomenidentificatie = vbod.voorkomenidentificatie
+      union all
+      select false                      as ishoofdadres,
+             voa.status,
+             voa.identificatie,
+             a.identificatienummeraanduiding,
+             a.status                   as nummeraanduidingstatus,
+             a.gemeente,
+             a.woonplaats,
+             a.straatnaam,
+             a.huisnummer,
+             a.huisletter,
+             a.huisnummertoevoeging,
+             a.postcode,
+             vbod.maaktdeeluitvan,
+             array_to_string(
+                     (select array_agg(vg.gebruiksdoel)
+                      from verblijfsobject_gebruiksdoel vg
+                      where (vg.identificatie = voa.identificatie and
+                             vg.voorkomenidentificatie = voa.voorkomenidentificatie))
+                 , ', ')                as gebruiksdoelen,
+             voa.oppervlakte,
+             st_centroid(voa.geometrie) as geometrie_centroide,
+             voa.geometrie
+      from v_verblijfsobject_actueel voa
+               join verblijfsobject_nevenadres vona on
+          (vona.identificatie = voa.identificatie
+              and vona.voorkomenidentificatie = voa.voorkomenidentificatie)
+               join vb_adres a on
+          voa.heeftalshoofdadres = a.identificatienummeraanduiding
+               join verblijfsobject_maaktdeeluitvan vbod
+                    on voa.identificatie = vbod.identificatie and
+                       voa.voorkomenidentificatie = vbod.voorkomenidentificatie) qry;
 
 comment on view vb_verblijfsobject_adres is 'verblijfsobject met adres, pandverwijzing, gebruiksdoel en puntlocatie';
 
@@ -183,67 +229,84 @@ comment on view vb_verblijfsobject_adres is 'verblijfsobject met adres, pandverw
 -- vervangt vb_benoemd_obj_adres alle objecten met een (neven)adres
 create or replace view vb_adresseerbaar_object_geometrie as
 select (row_number() over ())::integer as objectid,
-       vla.ishoofdadres,
-       vla.status,
-       vla.identificatie,
-       vla.identificatienummeraanduiding,
-       vla.nummeraanduidingstatus,
-       vla.gemeente,
-       vla.woonplaats,
-       vla.straatnaam,
-       vla.huisnummer,
-       vla.huisletter,
-       vla.huisnummertoevoeging,
-       vla.postcode,
-       'ligplaats'                     as soort,
-       null                            as maaktdeeluitvan,
-       null                            as gebruiksdoelen,
-       null                            as oppervlakte,
-       vla.geometrie_centroide,
-       vla.geometrie
-from vb_ligplaats_adres vla
-union all
-select (row_number() over ())::integer as objectid,
-       vsa.ishoofdadres,
-       vsa.status,
-       vsa.identificatie,
-       vsa.identificatienummeraanduiding,
-       vsa.nummeraanduidingstatus,
-       vsa.gemeente,
-       vsa.woonplaats,
-       vsa.straatnaam,
-       vsa.huisnummer,
-       vsa.huisletter,
-       vsa.huisnummertoevoeging,
-       vsa.postcode,
-       'standplaats'                   as soort,
-       null                            as maaktdeeluitvan,
-       null                            as gebruiksdoelen,
-       null                            as oppervlakte,
-       vsa.geometrie_centroide,
-       vsa.geometrie
-from vb_standplaats_adres vsa
-union all
-select (row_number() over ())::integer as objectid,
-       vva.ishoofdadres,
-       vva.status,
-       vva.identificatie,
-       vva.identificatienummeraanduiding,
-       vva.nummeraanduidingstatus,
-       vva.gemeente,
-       vva.woonplaats,
-       vva.straatnaam,
-       vva.huisnummer,
-       vva.huisletter,
-       vva.huisnummertoevoeging,
-       vva.postcode,
-       'verblijfsobject'               as soort,
-       vva.maaktdeeluitvan,
-       vva.gebruiksdoelen,
-       vva.oppervlakte,
-       vva.geometrie_centroide,
-       vva.geometrie
-from vb_verblijfsobject_adres vva;
+       qry.ishoofdadres,
+       qry.status,
+       qry.identificatie,
+       qry.identificatienummeraanduiding,
+       qry.nummeraanduidingstatus,
+       qry.gemeente,
+       qry.woonplaats,
+       qry.straatnaam,
+       qry.huisnummer,
+       qry.huisletter,
+       qry.huisnummertoevoeging,
+       qry.postcode,
+       qry.soort,
+       qry.maaktdeeluitvan,
+       qry.gebruiksdoelen,
+       qry.oppervlakte,
+       qry.geometrie_centroide,
+       qry.geometrie
+from (
+         select vla.ishoofdadres,
+                vla.status,
+                vla.identificatie,
+                vla.identificatienummeraanduiding,
+                vla.nummeraanduidingstatus,
+                vla.gemeente,
+                vla.woonplaats,
+                vla.straatnaam,
+                vla.huisnummer,
+                vla.huisletter,
+                vla.huisnummertoevoeging,
+                vla.postcode,
+                'ligplaats'   as soort,
+                null          as maaktdeeluitvan,
+                null          as gebruiksdoelen,
+                null::integer as oppervlakte,
+                vla.geometrie_centroide,
+                vla.geometrie
+         from vb_ligplaats_adres vla
+         union all
+         select vsa.ishoofdadres,
+                vsa.status,
+                vsa.identificatie,
+                vsa.identificatienummeraanduiding,
+                vsa.nummeraanduidingstatus,
+                vsa.gemeente,
+                vsa.woonplaats,
+                vsa.straatnaam,
+                vsa.huisnummer,
+                vsa.huisletter,
+                vsa.huisnummertoevoeging,
+                vsa.postcode,
+                'standplaats' as soort,
+                null          as maaktdeeluitvan,
+                null          as gebruiksdoelen,
+                null::integer as oppervlakte,
+                vsa.geometrie_centroide,
+                vsa.geometrie
+         from vb_standplaats_adres vsa
+         union all
+         select vva.ishoofdadres,
+                vva.status,
+                vva.identificatie,
+                vva.identificatienummeraanduiding,
+                vva.nummeraanduidingstatus,
+                vva.gemeente,
+                vva.woonplaats,
+                vva.straatnaam,
+                vva.huisnummer,
+                vva.huisletter,
+                vva.huisnummertoevoeging,
+                vva.postcode,
+                'verblijfsobject' as soort,
+                vva.maaktdeeluitvan,
+                vva.gebruiksdoelen,
+                vva.oppervlakte,
+                vva.geometrie_centroide,
+                vva.geometrie
+         from vb_verblijfsobject_adres vva) qry;
 
 comment on
     view vb_adresseerbaar_object_geometrie is 'alle adresseerbare objecten (ligplaatst, standplaats, verblijfsobject) met adres, gebruiksdoel, pand en (afgeleide) geometrie.';

--- a/datamodel/extra_scripts/postgresql/209_bag2_rsgb_views.sql
+++ b/datamodel/extra_scripts/postgresql/209_bag2_rsgb_views.sql
@@ -1,0 +1,371 @@
+-- veranderd het search_path in de database naar het public schema om aan het public schema de nieuwe materialized views toe te voegen.
+-- Via de BRMO GUI kunnen deze materialized views vervolgens automatisch ververst worden.
+set search_path = public,bag;
+
+-- Vervangt mb_adres. Gemeentevelden zijn nog niet beschikbaar.
+create materialized view mb_adres_bag as
+select na.objectid,
+       na.identificatie  as identificatienummeraanduiding,
+       na.status,
+       na.begingeldigheid,
+       null              as gemeente,    -- Gemeente-woonplaats relatie nog niet beschikbaar (BRMO-104)
+       wp.naam           as woonplaats,
+       opr.naam          as straatnaam,
+       na.huisnummer,
+       na.huisletter,
+       na.huisnummertoevoeging,
+       na.postcode,
+       opr.identificatie as identificatieopenbareruimte,
+       wp.identificatie  as identificatiewoonplaats,
+       null              as gemeentecode -- Gemeente-woonplaats relatie nog niet beschikbaar (BRMO-104)
+from v_nummeraanduiding_actueel na
+         left join v_openbareruimte_actueel opr on (opr.identificatie = na.ligtaan)
+         left join v_woonplaats_actueel wp on (wp.identificatie = opr.ligtin)
+with no data;
+
+create index mb_adres_bag_identificatie on mb_adres_bag using btree (identificatienummeraanduiding);
+create unique index mb_adres_bag_objectid on mb_adres_bag using btree (objectid);
+comment on materialized view mb_adres_bag is 'volledig actueel adres zonder locatie';
+
+
+-- maakt een materialized view van vb_adresseerbaar_object_geometrie tbv performance bij zeer grote datasets.
+create materialized view mb_adresseerbaar_object_geometrie_bag as
+select (row_number() over ())::integer as objectid,
+       qry.ishoofdadres,
+       qry.status,
+       qry.identificatie,
+       qry.identificatienummeraanduiding,
+       qry.nummeraanduidingstatus,
+       qry.gemeente,
+       qry.woonplaats,
+       qry.straatnaam,
+       qry.huisnummer,
+       qry.huisletter,
+       qry.huisnummertoevoeging,
+       qry.postcode,
+       qry.soort,
+       qry.maaktdeeluitvan,
+       qry.gebruiksdoelen,
+       qry.oppervlakte,
+       qry.geometrie_centroide,
+       qry.geometrie
+from (select vla.ishoofdadres,
+             vla.status,
+             vla.identificatie,
+             vla.identificatienummeraanduiding,
+             vla.nummeraanduidingstatus,
+             vla.gemeente,
+             vla.woonplaats,
+             vla.straatnaam,
+             vla.huisnummer,
+             vla.huisletter,
+             vla.huisnummertoevoeging,
+             vla.postcode,
+             'ligplaats' as soort,
+             null        as maaktdeeluitvan,
+             null        as gebruiksdoelen,
+             null        as oppervlakte,
+             vla.geometrie_centroide,
+             vla.geometrie
+      from bag.vb_ligplaats_adres vla
+      union all
+      select vsa.ishoofdadres,
+             vsa.status,
+             vsa.identificatie,
+             vsa.identificatienummeraanduiding,
+             vsa.nummeraanduidingstatus,
+             vsa.gemeente,
+             vsa.woonplaats,
+             vsa.straatnaam,
+             vsa.huisnummer,
+             vsa.huisletter,
+             vsa.huisnummertoevoeging,
+             vsa.postcode,
+             'standplaats' as soort,
+             null          as maaktdeeluitvan,
+             null          as gebruiksdoelen,
+             null          as oppervlakte,
+             vsa.geometrie_centroide,
+             vsa.geometrie
+      from bag.vb_standplaats_adres vsa
+      union all
+      select vva.ishoofdadres,
+             vva.status,
+             vva.identificatie,
+             vva.identificatienummeraanduiding,
+             vva.nummeraanduidingstatus,
+             vva.gemeente,
+             vva.woonplaats,
+             vva.straatnaam,
+             vva.huisnummer,
+             vva.huisletter,
+             vva.huisnummertoevoeging,
+             vva.postcode,
+             'verblijfsobject'     as soort,
+             vva.maaktdeeluitvan,
+             vva.gebruiksdoelen,
+             vva.oppervlakte::text as oppervlakte,
+             vva.geometrie_centroide,
+             vva.geometrie
+      from bag.vb_verblijfsobject_adres vva) qry
+with no data;
+
+create index mb_adresseerbaar_object_geometrie_bag_geom on mb_adresseerbaar_object_geometrie_bag using gist (geometrie);
+create index mb_adresseerbaar_object_geometrie_bag_centroid on mb_adresseerbaar_object_geometrie_bag using gist (geometrie_centroide);
+create index mb_adresseerbaar_object_geometrie_bag_identificatie on mb_adresseerbaar_object_geometrie_bag using btree (identificatienummeraanduiding);
+create unique index mb_adresseerbaar_object_geometrie_bag_objectid on mb_adresseerbaar_object_geometrie_bag using btree (objectid);
+
+comment on
+    materialized view mb_adresseerbaar_object_geometrie_bag is 'alle adresseerbare objecten (ligplaatst, standplaats, verblijfsobject) met adres, gebruiksdoel, pand en (afgeleide) geometrie.';
+
+--Maakt dezelfde materialized view aan als mb_kad_onrrnd_zk_adres, maar de BAG gegevens worden uit mb_adresseerbaar_object_geometrie_bag gehaald.
+create materialized view mb_kad_onrrnd_zk_adres_bag as
+select (row_number() over ())::integer                                                    as objectid,
+       qry.identif                                                                        as koz_identif,
+       koz.dat_beg_geldh                                                                  as begin_geldigheid,
+       to_date((koz.dat_beg_geldh)::text, 'YYYY-MM-DD'::text)                             as begin_geldigheid_datum,
+       bok.fk_nn_lh_tgo_identif                                                           as benoemdobj_identif,
+       qry.type,
+       (((coalesce(qry.ka_sectie, ''::character varying))::text || ' '::text) ||
+        (coalesce(qry.ka_perceelnummer, ''::character varying))::text)                    as aanduiding,
+       (((((((coalesce(qry.ka_kad_gemeentecode, ''::character varying))::text || ' '::text) ||
+            (coalesce(qry.ka_sectie, ''::character varying))::text) || ' '::text) ||
+          (coalesce(qry.ka_perceelnummer, ''::character varying))::text) || ' '::text) ||
+        (coalesce(qry.ka_appartementsindex, ''::character varying))::text)                as aanduiding2,
+       qry.ka_sectie                                                                      as sectie,
+       qry.ka_perceelnummer                                                               as perceelnummer,
+       qry.ka_appartementsindex                                                           as appartementsindex,
+       qry.ka_kad_gemeentecode                                                            as gemeentecode,
+       qry.aand_soort_grootte,
+       (qry.grootte_perceel)::integer                                                     as grootte_perceel,
+       st_area(qry.begrenzing_perceel)                                                    as oppervlakte_geom,
+       qry.ka_deelperceelnummer                                                           as deelperceelnummer,
+       qry.omschr_deelperceel,
+       b.datum                                                                            as verkoop_datum,
+       koz.cu_aard_cultuur_onbebouwd                                                      as aard_cultuur_onbebouwd,
+       (koz.ks_bedrag)::integer                                                           as bedrag,
+       koz.ks_koopjaar                                                                    as koopjaar,
+       koz.ks_meer_onroerendgoed                                                          as meer_onroerendgoed,
+       koz.ks_valutasoort                                                                 as valutasoort,
+       koz.lo_loc__omschr                                                                 as loc_omschr,
+       array_to_string((select array_agg((((((((((((((((((((('id: '::text ||
+                                                             (coalesce(koza.kadaster_identif_aantek, ''::character varying))::text) ||
+                                                            ', '::text) || 'aard: '::text) ||
+                                                          (coalesce(koza.aard_aantek_kad_obj, ''::character varying))::text) ||
+                                                         ', '::text) || 'begin: '::text) ||
+                                                       (coalesce(koza.begindatum_aantek_kad_obj, ''::character varying))::text) ||
+                                                      ', '::text) || 'beschrijving: '::text) ||
+                                                    (coalesce(koza.beschrijving_aantek_kad_obj, ''::character varying))::text) ||
+                                                   ', '::text) || 'eind: '::text) ||
+                                                 (coalesce(koza.eindd_aantek_kad_obj, ''::character varying))::text) ||
+                                                ', '::text) || 'koz-id: '::text) ||
+                                              coalesce(koza.fk_4koz_kad_identif, (0)::numeric(15, 0))) || ', '::text) ||
+                                            'subject-id: '::text) ||
+                                           (coalesce(koza.fk_5pes_sc_identif, ''::character varying))::text) ||
+                                          '; '::text)) as array_agg
+                        from kad_onrrnd_zk_aantek koza
+                        where (koza.fk_4koz_kad_identif = koz.kad_identif)), ' & '::text) as aantekeningen,
+       maogb.identificatienummeraanduiding,
+       maogb.nummeraanduidingstatus,
+       maogb.gemeente,
+       maogb.woonplaats,
+       maogb.straatnaam,
+       maogb.huisnummer,
+       maogb.huisletter,
+       maogb.huisnummertoevoeging,
+       maogb.postcode,
+       maogb.gebruiksdoelen,
+       maogb.oppervlakte,
+       st_x(st_transform(st_setsrid(st_centroid(qry.begrenzing_perceel), 28992), 4326))   as lon,
+       st_y(st_transform(st_setsrid(st_centroid(qry.begrenzing_perceel), 28992), 4326))   as lat,
+       qry.begrenzing_perceel
+from (((((select p.sc_kad_identif                 as identif,
+                 'perceel'::character varying(11) as type,
+                 p.ka_sectie,
+                 p.ka_perceelnummer,
+                 null::character varying(4)       as ka_appartementsindex,
+                 p.ka_kad_gemeentecode,
+                 p.aand_soort_grootte,
+                 p.grootte_perceel,
+                 p.ka_deelperceelnummer,
+                 p.omschr_deelperceel,
+                 p.begrenzing_perceel
+          from kad_perceel p
+          union all
+          select ar.sc_kad_identif                    as identif,
+                 'appartement'::character varying(11) as type,
+                 ar.ka_sectie,
+                 ar.ka_perceelnummer,
+                 ar.ka_appartementsindex,
+                 ar.ka_kad_gemeentecode,
+                 null::character varying(2)           as aand_soort_grootte,
+                 null::numeric(8, 0)                  as grootte_perceel,
+                 null::character varying(4)           as ka_deelperceelnummer,
+                 null::character varying(1120)        as omschr_deelperceel,
+                 kp.begrenzing_perceel
+          from ((mb_util_app_re_kad_perceel v
+              join kad_perceel kp on ((v.perceel_identif = kp.sc_kad_identif)))
+                   join app_re ar on (((v.app_re_identif)::numeric = ar.sc_kad_identif)))) qry
+    join kad_onrrnd_zk koz on ((koz.kad_identif = qry.identif)))
+    left join benoemd_obj_kad_onrrnd_zk bok on ((bok.fk_nn_rh_koz_kad_identif = qry.identif)))
+    left join mb_adresseerbaar_object_geometrie_bag maogb on (((bok.fk_nn_lh_tgo_identif)::bpchar = maogb.identificatie)))
+         left join (select brondocument.ref_id,
+                           max(brondocument.datum) as datum
+                    from brondocument
+                    where ((brondocument.omschrijving)::text = 'Akte van Koop en Verkoop'::text)
+                    group by brondocument.ref_id) b on (((koz.kad_identif)::text = (b.ref_id)::text)))
+with no data;
+
+comment on materialized view mb_kad_onrrnd_zk_adres_bag is 'alle kadastrale onroerende zaken (perceel en appartementsrecht) met opgezochte verkoop datum, objectid voor geoserver/arcgis en BAG adres';
+create index mb_kad_onrrnd_zk_adres_bag_begrenzing_perceel_idx on mb_kad_onrrnd_zk_adres_bag using gist (begrenzing_perceel);
+create index mb_kad_onrrnd_zk_adres_bag_identif on mb_kad_onrrnd_zk_adres_bag using btree (koz_identif);
+create unique index mb_kad_onrrnd_zk_adres_bag_objectid on mb_kad_onrrnd_zk_adres_bag using btree (objectid);
+
+--Maakt dezelfde materialized view aan als mb_koz_rechth, maar de BAG gegevens worden uit mb_kad_onrrnd_zk_adres_bag gehaald.
+create materialized view mb_koz_rechth_bag as
+select row_number() over ()::integer                                as objectid,
+       koz.koz_identif,
+       koz.begin_geldigheid,
+       to_date(koz.begin_geldigheid::text, 'YYYY-MM-DD'::text)      as begin_geldigheid_datum,
+       koz.type,
+       (coalesce(koz.sectie, ''::character varying)::text || ' '::text) ||
+       coalesce(koz.perceelnummer, ''::character varying)::text     as aanduiding,
+       (((((coalesce(koz.gemeentecode, ''::character varying)::text || ' '::text) ||
+           coalesce(koz.sectie, ''::character varying)::text) || ' '::text) ||
+         coalesce(koz.perceelnummer, ''::character varying)::text) || ' '::text) ||
+       coalesce(koz.appartementsindex, ''::character varying)::text as aanduiding2,
+       koz.sectie,
+       koz.perceelnummer,
+       koz.appartementsindex,
+       koz.gemeentecode,
+       koz.aand_soort_grootte,
+       koz.grootte_perceel,
+       koz.oppervlakte_geom,
+       koz.deelperceelnummer,
+       koz.omschr_deelperceel,
+       koz.verkoop_datum,
+       koz.aard_cultuur_onbebouwd,
+       koz.bedrag,
+       koz.koopjaar,
+       koz.meer_onroerendgoed,
+       koz.valutasoort,
+       koz.loc_omschr,
+       zrr.zr_identif,
+       zrr.ingangsdatum_recht,
+       zrr.subject_identif,
+       zrr.aandeel,
+       zrr.omschr_aard_verkregen_recht,
+       zrr.indic_betrokken_in_splitsing,
+       zrr.soort,
+       zrr.geslachtsnaam,
+       zrr.voorvoegsel,
+       zrr.voornamen,
+       zrr.aand_naamgebruik,
+       zrr.geslachtsaand,
+       zrr.naam,
+       zrr.woonadres,
+       zrr.geboortedatum,
+       zrr.geboorteplaats,
+       zrr.overlijdensdatum,
+       zrr.bsn,
+       zrr.organisatie_naam,
+       zrr.rechtsvorm,
+       zrr.statutaire_zetel,
+       zrr.rsin,
+       zrr.kvk_nummer,
+       zrr.aantekeningen,
+       koz.gemeente,
+       koz.woonplaats,
+       koz.straatnaam,
+       koz.huisnummer,
+       koz.huisletter,
+       koz.huisnummertoevoeging,
+       koz.postcode,
+       koz.lon,
+       koz.lat,
+       koz.begrenzing_perceel
+from mb_zr_rechth zrr
+         right join mb_kad_onrrnd_zk_adres_bag koz on zrr.koz_identif = koz.koz_identif
+with no data;
+
+comment on materialized view mb_kad_onrrnd_zk_adres_bag is 'kadastrale percelen een appartementsrechten met rechten en rechthebbenden en objectid voor geoserver/arcgis';
+-- View indexes:
+create index mb_koz_rechth_bag_begrenzing_perceel_idx on mb_koz_rechth_bag using gist (begrenzing_perceel);
+create index mb_koz_rechth_bag_identif on mb_koz_rechth_bag using btree (koz_identif);
+create unique index mb_koz_rechth_bag_objectid on mb_koz_rechth_bag using btree (objectid);
+
+
+--Maakt dezelfde materialized view aan als mb_avg_koz_rechth, maar de BAG gegevens worden uit mb_kad_onrrnd_zk_adres_bag gehaald.
+create materialized view mb_avg_koz_rechth_bag as
+select row_number() over ()::integer                                as objectid,
+       koz.koz_identif,
+       koz.begin_geldigheid,
+       to_date(koz.begin_geldigheid::text, 'YYYY-MM-DD'::text)      as begin_geldigheid_datum,
+       koz.type,
+       (coalesce(koz.sectie, ''::character varying)::text || ' '::text) ||
+       coalesce(koz.perceelnummer, ''::character varying)::text     as aanduiding,
+       (((((coalesce(koz.gemeentecode, ''::character varying)::text || ' '::text) ||
+           coalesce(koz.sectie, ''::character varying)::text) || ' '::text) ||
+         coalesce(koz.perceelnummer, ''::character varying)::text) || ' '::text) ||
+       coalesce(koz.appartementsindex, ''::character varying)::text as aanduiding2,
+       koz.sectie,
+       koz.perceelnummer,
+       koz.appartementsindex,
+       koz.gemeentecode,
+       koz.aand_soort_grootte,
+       koz.grootte_perceel,
+       koz.oppervlakte_geom,
+       koz.deelperceelnummer,
+       koz.omschr_deelperceel,
+       koz.verkoop_datum,
+       koz.aard_cultuur_onbebouwd,
+       koz.bedrag,
+       koz.koopjaar,
+       koz.meer_onroerendgoed,
+       koz.valutasoort,
+       koz.loc_omschr,
+       zrr.zr_identif,
+       zrr.ingangsdatum_recht,
+       zrr.subject_identif,
+       zrr.aandeel,
+       zrr.omschr_aard_verkregen_recht,
+       zrr.indic_betrokken_in_splitsing,
+       zrr.soort,
+       zrr.geslachtsnaam,
+       zrr.voorvoegsel,
+       zrr.voornamen,
+       zrr.aand_naamgebruik,
+       zrr.geslachtsaand,
+       zrr.naam,
+       zrr.woonadres,
+       zrr.geboortedatum,
+       zrr.geboorteplaats,
+       zrr.overlijdensdatum,
+       zrr.bsn,
+       zrr.organisatie_naam,
+       zrr.rechtsvorm,
+       zrr.statutaire_zetel,
+       zrr.rsin,
+       zrr.kvk_nummer,
+       zrr.aantekeningen,
+       koz.gemeente,
+       koz.woonplaats,
+       koz.straatnaam,
+       koz.huisnummer,
+       koz.huisletter,
+       koz.huisnummertoevoeging,
+       koz.postcode,
+       koz.lon,
+       koz.lat,
+       koz.begrenzing_perceel
+from mb_avg_zr_rechth zrr
+         right join mb_kad_onrrnd_zk_adres_bag koz on zrr.koz_identif = koz.koz_identif
+with no data;
+
+comment on materialized view mb_kad_onrrnd_zk_adres_bag is 'kadastrale percelen een appartementsrechten met rechten en rechthebbenden geschoond voor avg en objectid voor geoserver/arcgis';
+-- View indexes:
+create index mb_avg_koz_rechth_bag_begrenzing_perceel_idx on mb_avg_koz_rechth_bag using gist (begrenzing_perceel);
+create index mb_avg_koz_rechth_bag_identif on mb_avg_koz_rechth_bag using btree (koz_identif);
+create unique index mb_avg_koz_rechth_bag_objectid on mb_avg_koz_rechth_bag using btree (objectid);
+
+

--- a/datamodel/pom.xml
+++ b/datamodel/pom.xml
@@ -450,8 +450,13 @@
                                 <database.properties.file>postgis.properties</database.properties.file>
                                 <project.version>${project.version}</project.version>
                                 <database.upgrade>${database.upgrade}</database.upgrade>
+                                <bag.dburl>jdbc:postgresql:rsgb?currentSchema=bag</bag.dburl>
+                                <bag.dbuser>rsgb</bag.dbuser>
+                                <bag.dbpassword>rsgb</bag.dbpassword>
                             </systemPropertyVariables>
                             <excludedGroups>skip-pgsql</excludedGroups>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <argLine>${surefireArgLine}</argLine>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -469,8 +474,13 @@
                                 <database.properties.file>oracle.properties</database.properties.file>
                                 <project.version>${project.version}</project.version>
                                 <database.upgrade>${database.upgrade}</database.upgrade>
+                                <bag.dburl>jdbc:oracle:thin:@127.0.0.1:1521:XE?oracle.net.disableOob=true</bag.dburl>
+                                <bag.dbuser>JENKINS_BAG</bag.dbuser>
+                                <bag.dbpassword>jenkins_bag</bag.dbpassword>
                             </systemPropertyVariables>
                             <excludedGroups>skip-oracle</excludedGroups>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <argLine>${surefireArgLine}</argLine>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -490,6 +500,8 @@
                                 <database.upgrade>${database.upgrade}</database.upgrade>
                             </systemPropertyVariables>
                             <excludedGroups>skip-mssql</excludedGroups>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <argLine>${surefireArgLine}</argLine>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/datamodel/src/test/java/nl/b3p/brmo/datamodel/BAGViewsTest.java
+++ b/datamodel/src/test/java/nl/b3p/brmo/datamodel/BAGViewsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2021 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
+package nl.b3p.brmo.datamodel;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.dbunit.database.DatabaseConfig;
+import org.dbunit.database.DatabaseConnection;
+import org.dbunit.database.IDatabaseConnection;
+import org.dbunit.dataset.DataSetException;
+import org.dbunit.dataset.ITable;
+import org.dbunit.ext.oracle.Oracle10DataTypeFactory;
+import org.dbunit.ext.postgresql.PostgresqlDataTypeFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+/**
+ * Test de BAG 2 basis views.
+ *
+ * @author mprins
+ */
+public class BAGViewsTest {
+    private static final Log LOG = LogFactory.getLog(BAGViewsTest.class);
+    private static final String dbUrl = System.getProperty("bag.dburl");
+    private static final String dbUser = System.getProperty("bag.dbuser", "rsgb");
+    private static final String dbPass = System.getProperty("bag.dbpassword", "rsgb");
+    private IDatabaseConnection bag;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        assumeFalse(StringUtils.isEmpty(dbUrl), "skipping integration test: missing database url");
+        bag = new DatabaseConnection(DriverManager.getConnection(dbUrl, dbUser, dbPass));
+
+        if (dbUrl.contains("postgresql")) {
+            bag.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new PostgresqlDataTypeFactory());
+            bag.getConfig().setProperty(DatabaseConfig.FEATURE_QUALIFIED_TABLE_NAMES, false);
+        }
+        if (dbUrl.contains("oracle")) {
+            bag.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new Oracle10DataTypeFactory());
+            bag.getConfig().setProperty(DatabaseConfig.FEATURE_SKIP_ORACLE_RECYCLEBIN_TABLES, true);
+            bag.getConfig().setProperty(DatabaseConfig.FEATURE_CASE_SENSITIVE_TABLE_NAMES, false);
+        }
+    }
+
+    @AfterEach
+    void cleanup() throws SQLException {
+        if (null != bag) bag.close();
+    }
+
+    /**
+     * test of de bekende set met views in de database bestaan.
+     *
+     * @throws SQLException als opzoeken in de dabase mislukt
+     */
+    @Test
+    public void testBasisViewsBAG() throws SQLException, DataSetException {
+        ITable views = null;
+        if (dbUrl.contains("oracle")) {
+            views = bag.createQueryTable("views", "SELECT VIEW_NAME AS name FROM USER_VIEWS");
+        }
+        if (dbUrl.contains("postgresql")) {
+            views = bag.createQueryTable("views", "SELECT oid::regclass::text as name FROM pg_class WHERE relkind = 'v'");
+        }
+
+        List<String> viewsFound = new ArrayList<>();
+        String vName;
+        for (int i = 0; i < views.getRowCount(); i++) {
+            vName = views.getValue(i, "name").toString().toLowerCase(Locale.ROOT);
+            if (vName.startsWith("vb_")) {
+                viewsFound.add(vName);
+            }
+        }
+
+        LOG.debug("gevonden views: " + viewsFound);
+        assertNotNull(viewsFound, "Geen views gevonden");
+        assertFalse(viewsFound.isEmpty(), "Geen views gevonden");
+
+        List<String> expectedViews = Arrays.asList(
+                // bag 2 views
+                "vb_adresseerbaar_object_geometrie", "vb_verblijfsobject_adres", "vb_standplaats_adres", "vb_ligplaats_adres", "vb_adres");
+
+        // alles lower-case (ORACLE!) en gesorteerd vergelijken
+        viewsFound.replaceAll(String::toLowerCase);
+        expectedViews.replaceAll(String::toLowerCase);
+        Collections.sort(viewsFound);
+        Collections.sort(expectedViews);
+        assertEquals(expectedViews, viewsFound, "lijsten met basis views zijn ongelijk");
+    }
+}
+

--- a/datamodel/src/test/java/nl/b3p/brmo/datamodel/MaterializedViewsTest.java
+++ b/datamodel/src/test/java/nl/b3p/brmo/datamodel/MaterializedViewsTest.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) 2021 B3Partners B.V.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ */
 package nl.b3p.brmo.datamodel;
 
 import nl.b3p.brmo.test.util.database.ViewUtils;
@@ -24,7 +30,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /**
@@ -33,8 +42,6 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 public class MaterializedViewsTest {
     private static final Log LOG = LogFactory.getLog(MaterializedViewsTest.class);
     private static String currentVersion;
-    private IDatabaseConnection db;
-    private BasicDataSource ds;
     /**
      * properties uit {@code <DB smaak>.properties} en
      * {@code local.<DB smaak>.properties}.
@@ -42,21 +49,20 @@ public class MaterializedViewsTest {
      * @see #loadProps()
      */
     protected final Properties params = new Properties();
-
     /**
      * {@code true} als we met een Oracle database bezig zijn.
      */
     protected boolean isOracle;
-
     /**
      * {@code true} als we met een MS SQL Server database bezig zijn.
      */
     protected boolean isMsSQL;
-
     /**
      * {@code true} als we met een Postgis database bezig zijn.
      */
     protected boolean isPostgis;
+    private IDatabaseConnection db;
+    private BasicDataSource ds;
 
     /**
      * init versienummer.
@@ -73,7 +79,7 @@ public class MaterializedViewsTest {
      */
     @BeforeAll
     public static void checkDatabaseIsProvided() {
-        assumeFalse(System.getProperty("database.properties.file")==null, "Verwacht database omgeving te zijn aangegeven.");
+        assumeFalse(System.getProperty("database.properties.file") == null, "Verwacht database omgeving te zijn aangegeven.");
     }
 
     @BeforeEach
@@ -133,7 +139,7 @@ public class MaterializedViewsTest {
     }
 
     /**
-     * test of de bekende set met materialized in de database bestaan.
+     * test of de bekende set met materialized views in de rsgb database bestaan.
      *
      * @throws SQLException als opzoeken in de dabase mislukt
      */
@@ -162,7 +168,13 @@ public class MaterializedViewsTest {
                     "mb_avg_zr_rechth",
                     "mb_koz_rechth",
                     "mb_avg_koz_rechth",
-                    "mb_kad_onrrnd_zk_archief"
+                    "mb_kad_onrrnd_zk_archief",
+                    // bag 2
+                    "mb_adres_bag",
+                    "mb_adresseerbaar_object_geometrie_bag",
+                    "mb_avg_koz_rechth_bag",
+                    "mb_kad_onrrnd_zk_adres_bag",
+                    "mb_koz_rechth_bag"
             );
 
             // alles lower-case (ORACLE!) en gesorteerd vergelijken

--- a/datamodel/upgrade_scripts/2.2.0-2.2.1/oracle/bag.sql
+++ b/datamodel/upgrade_scripts/2.2.0-2.2.1/oracle/bag.sql
@@ -1,0 +1,18 @@
+--
+-- upgrade Oracle RSGB datamodel van 2.2.0 naar 2.2.1
+--
+
+WHENEVER SQLERROR EXIT SQL.SQLCODE
+
+-- BRMO-130 / GH #1231 De BAG 2 views moeten vervangen worden
+drop view vb_adresseerbaar_object_geometrie;
+drop view vb_verblijfsobject_adres;
+drop view vb_standplaats_adres;
+drop view vb_ligplaats_adres;
+drop view vb_adres;
+
+
+-- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
+INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.0_naar_2.2.1','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';
+-- versienummer update
+UPDATE brmo_metadata SET waarde='2.2.1' WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/2.2.0-2.2.1/oracle/bag.sql
+++ b/datamodel/upgrade_scripts/2.2.0-2.2.1/oracle/bag.sql
@@ -11,6 +11,13 @@ drop view vb_standplaats_adres;
 drop view vb_ligplaats_adres;
 drop view vb_adres;
 
+DECLARE
+BEGIN
+  EXECUTE IMMEDIATE 'CREATE TABLE brmo_metadata(naam VARCHAR2(255 CHAR) NOT NULL,waarde VARCHAR2(255 CHAR),PRIMARY KEY (naam));';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLCODE = -955 THEN NULL; ELSE RAISE; END IF;
+END;
+MERGE INTO brmo_metadata USING DUAL ON (naam = 'brmoversie') WHEN NOT MATCHED THEN INSERT (naam) VALUES('brmoversie');
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.0_naar_2.2.1','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/2.2.0-2.2.1/postgresql/bag.sql
+++ b/datamodel/upgrade_scripts/2.2.0-2.2.1/postgresql/bag.sql
@@ -1,0 +1,18 @@
+--
+-- upgrade PostgreSQL RSGB datamodel van 2.2.0 naar 2.2.1
+--
+
+set search_path = bag,public;
+
+-- BRMO-130 / GH #1231 De BAG 2 views moeten vervangen worden
+drop view vb_adresseerbaar_object_geometrie;
+drop view vb_verblijfsobject_adres;
+drop view vb_standplaats_adres;
+drop view vb_ligplaats_adres;
+drop view vb_adres;
+
+
+-- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
+INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.0_naar_2.2.1','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';
+-- versienummer update
+UPDATE brmo_metadata SET waarde='2.2.1' WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/2.2.0-2.2.1/postgresql/bag.sql
+++ b/datamodel/upgrade_scripts/2.2.0-2.2.1/postgresql/bag.sql
@@ -11,6 +11,8 @@ drop view vb_standplaats_adres;
 drop view vb_ligplaats_adres;
 drop view vb_adres;
 
+CREATE TABLE IF NOT EXISTS brmo_metadata(naam CHARACTER VARYING(255) NOT NULL,waarde CHARACTER VARYING(255),CONSTRAINT brmo_metadata_pk PRIMARY KEY (naam));
+INSERT INTO brmo_metadata(naam) VALUES('brmoversie') ON CONFLICT DO NOTHING;
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.0_naar_2.2.1','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/new-version-upgrades.sh
+++ b/datamodel/upgrade_scripts/new-version-upgrades.sh
@@ -21,7 +21,7 @@ mkdir -p "$PREVRELEASE-$NEXTRELEASE"/{oracle,postgresql,sqlserver}
 for DB in Oracle PostgreSQL SQLserver; do
   DIR=$PREVRELEASE-$NEXTRELEASE/${DB,,}
   echo Migratie bestanden aanmaken voor $DB in $DIR
-  for b in rsgb rsgbbgt staging; do
+  for b in bag rsgb rsgbbgt staging; do
     if [ -f "$DIR/$b.sql" ]; then
       echo Bestand $DIR/$b.sql bestaal al.
     else
@@ -49,6 +49,12 @@ for DB in Oracle PostgreSQL SQLserver; do
         echo $'\n'"CREATE TABLE IF NOT EXISTS brmo_metadata(naam CHARACTER VARYING(255) NOT NULL,waarde CHARACTER VARYING(255),CONSTRAINT brmo_metadata_pk PRIMARY KEY (naam));" >>$DIR/$b.sql
         echo $"INSERT INTO brmo_metadata(naam) VALUES('brmoversie') ON CONFLICT DO NOTHING;" >>$DIR/$b.sql
       fi
+      if [ "${DB}" == "PostgreSQL" ] && [ "${b}" == "bag" ]; then
+        echo $'\n'"set search_path = bag,public;" >>$DIR/$b.sql
+      fi
+      if [ "${DB}" == "PostgreSQL" ] && [ "${b}" == "rsgb" ]; then
+        echo $'\n'"set search_path = public,bag;" >>$DIR/$b.sql
+      fi
 
       echo $'\n\n'-- onderstaande dienen als laatste stappen van een upgrade uitgevoerd >>$DIR/$b.sql
       if [ "${DB}" == "SQLserver" ]; then
@@ -62,5 +68,5 @@ for DB in Oracle PostgreSQL SQLserver; do
   done
 done
 
-#git add "$PREVRELEASE-$NEXTRELEASE"/
-#git commit -m "Migratie bestanden aanmaken voor upgrade $PREVRELEASE-$NEXTRELEASE"
+git add "$PREVRELEASE-$NEXTRELEASE"/
+git commit -m "Migratie bestanden aanmaken voor upgrade $PREVRELEASE-$NEXTRELEASE"

--- a/datamodel/upgrade_scripts/new-version-upgrades.sh
+++ b/datamodel/upgrade_scripts/new-version-upgrades.sh
@@ -29,7 +29,7 @@ for DB in Oracle PostgreSQL SQLserver; do
 
       if [ "$DB" == "Oracle" ]; then
         echo $'\n'WHENEVER SQLERROR EXIT SQL.SQLCODE >>$DIR/$b.sql
-        if [ "${b}" == "rsgbbgt" ]; then
+        if [ "${b}" == "rsgbbgt" ] || [ "${b}" == "bag" ]; then
           echo $'\n\n'"DECLARE" >>$DIR/$b.sql
           echo $"BEGIN" >>$DIR/$b.sql
           echo $"  EXECUTE IMMEDIATE 'CREATE TABLE brmo_metadata(naam VARCHAR2(255 CHAR) NOT NULL,waarde VARCHAR2(255 CHAR),PRIMARY KEY (naam));';" >>$DIR/$b.sql
@@ -46,11 +46,11 @@ for DB in Oracle PostgreSQL SQLserver; do
         echo $"INSERT INTO brmo_metadata(naam) SELECT naam FROM brmo_metadata WHERE NOT('brmoversie' IN (SELECT naam FROM brmo_metadata));" >>$DIR/$b.sql
       fi
       if [ "${DB}" == "PostgreSQL" ] && [ "${b}" == "rsgbbgt" ]; then
+        if [ "${b}" == "bag" ]; then
+            echo $'\n'"set search_path = bag,public;" >>$DIR/$b.sql
+        fi
         echo $'\n'"CREATE TABLE IF NOT EXISTS brmo_metadata(naam CHARACTER VARYING(255) NOT NULL,waarde CHARACTER VARYING(255),CONSTRAINT brmo_metadata_pk PRIMARY KEY (naam));" >>$DIR/$b.sql
         echo $"INSERT INTO brmo_metadata(naam) VALUES('brmoversie') ON CONFLICT DO NOTHING;" >>$DIR/$b.sql
-      fi
-      if [ "${DB}" == "PostgreSQL" ] && [ "${b}" == "bag" ]; then
-        echo $'\n'"set search_path = bag,public;" >>$DIR/$b.sql
       fi
       if [ "${DB}" == "PostgreSQL" ] && [ "${b}" == "rsgb" ]; then
         echo $'\n'"set search_path = public,bag;" >>$DIR/$b.sql

--- a/pom.xml
+++ b/pom.xml
@@ -844,6 +844,7 @@
                             <exclude>**/*IntegrationTest.java</exclude>
                         </excludes>
                         <skipTests>${test.onlyITs}</skipTests>
+                        <!--suppress UnresolvedMavenProperty -->
                         <argLine>${surefireArgLine}</argLine>
                     </configuration>
                 </plugin>
@@ -861,6 +862,7 @@
                         <useFile>false</useFile>
                         <skipTests>!${test.onlyITs}</skipTests>
                         <skipITs>!${test.onlyITs}</skipITs>
+                        <!--suppress UnresolvedMavenProperty -->
                         <argLine>${failsafeArgLine}</argLine>
                     </configuration>
                     <executions>


### PR DESCRIPTION
- [x] voeg kolom oppervlakte toe aan `vb_verblijfsobject_adres` en `vb_adresseerbaar_object_geometrie`
- [x] voorkom overlappende `objectid` waarden in samengestelde views
  - [x] upgrade procedure
- [x] voegt de volgende 5 BAG 2 RSGB views toe:
  - `mb_adres_bag` 
  - `mb_adresseerbaar_object_geometrie_bag`
  - `mb_kad_onrrnd_zk_adres_bag`
  - `mb_koz_rechth_bag`
  - `mb_avg_koz_rechth_bag`
  - [x] upgrade procedure
- [x] integratie test voor de BAG 2 views


close BRMO-130