### PR TITLE
[BRMO-137] Upgrade PostGIS JDBC driver van 2.5.1 naar 2021.1.0

### DIFF
--- a/brmo-dist/assembly.xml
+++ b/brmo-dist/assembly.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 https://maven.apache.org/xsd/assembly-2.0.0.xsd">
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 https://maven.apache.org/xsd/assembly-2.1.0.xsd">
     <id>bin</id>
     <formats>
         <format>zip</format>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <hibernate.version>5.6.5.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
-        <geotools.version>26.1</geotools.version>
+        <geotools.version>26.2</geotools.version>
         <jdbc-util.version>11.0-SNAPSHOT</jdbc-util.version>
         <jts.version>1.18.2</jts.version>
         <itextpdf.version>7.2.1</itextpdf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,11 +64,11 @@
         <hibernate.version>5.6.5.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
         <geotools.version>26.1</geotools.version>
-        <jdbc-util.version>10.2</jdbc-util.version>
+        <jdbc-util.version>11.0-SNAPSHOT</jdbc-util.version>
         <jts.version>1.18.2</jts.version>
         <itextpdf.version>7.2.1</itextpdf.version>
         <postgresql.jdbc.version>42.3.1</postgresql.jdbc.version>
-        <postgresql.postgis-jdbc.version>2.5.1</postgresql.postgis-jdbc.version>
+        <postgresql.postgis-jdbc.version>2021.1.0</postgresql.postgis-jdbc.version>
         <oracle.jdbc.version>21.4.0.0.1</oracle.jdbc.version>
         <oracle.jdbc.artifact>ojdbc11</oracle.jdbc.artifact>
         <sqlserver.jdbc.version>9.4.1.jre11</sqlserver.jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -624,7 +624,7 @@
             <dependency>
                 <groupId>org.dbunit</groupId>
                 <artifactId>dbunit</artifactId>
-                <version>2.7.2</version>
+                <version>2.7.3-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -624,7 +624,7 @@
             <dependency>
                 <groupId>org.dbunit</groupId>
                 <artifactId>dbunit</artifactId>
-                <version>2.7.3-SNAPSHOT</version>
+                <version>2.7.3-RC1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <hibernate.version>5.6.5.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
         <geotools.version>26.2</geotools.version>
-        <jdbc-util.version>11.0-SNAPSHOT</jdbc-util.version>
+        <jdbc-util.version>11.0</jdbc-util.version>
         <jts.version>1.18.2</jts.version>
         <itextpdf.version>7.2.1</itextpdf.version>
         <postgresql.jdbc.version>42.3.1</postgresql.jdbc.version>


### PR DESCRIPTION
- [x] Upgrade PostGIS JDBC driver van 2.5.1 naar 2021.1.0, nl.b3p:jdbc-util 10.2 ➜ 11.0-SNAPSHOT
- [x]  Upgrade org.dbunit:dbunit 2.7.2 ➜ 2.7.3-SNAPSHOT
- [x] Upgrade org.dbunit:dbunit 2.7.3-SNAPSHOT ➜ 2.7.3-RC1
- [x] release note instructie
- [x] upgrade nl.b3p:jdbc-util 11.0-SNAPSHOT ➜ 11.0


**let op** dat de postgis-jdbc en postgis-geometry in de tomcat `lib` directory vervangen moeten worden

depends on ~~https://github.com/B3Partners/jdbc-util/pull/262~~ [released 11.0](https://github.com/B3Partners/jdbc-util/releases/tag/jdbc-util-11.0)
depends on ~~https://sourceforge.net/p/dbunit/feature-requests/251/~~

resolves BRMO-137