### PR TITLE
Bump mssql-jdbc van 9.4.1.jre11 naar 10.2.0.jre11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,8 +33,7 @@ updates:
           - ">= 10"
       - dependency-name: com.microsoft.sqlserver:mssql-jdbc
         versions:
-          - "9.5.x"
-          - "10.1.x"
+          - "10.3.x"
 
 
   - package-ecosystem: "github-actions"

--- a/bgt-loader/README.md
+++ b/bgt-loader/README.md
@@ -126,7 +126,7 @@ te geven om met SQL server te verbinden.
 Voorbeeldcommando om alleen een paar feature types te laden in SQL Server:
 
 ```shell
-brmo-bgt-loader download initial --connection="jdbc:sqlserver://localhost:1433;databaseName=bgt" --password="bgt@1234" --feature-types=wijk,buurt --no-geo-filter
+brmo-bgt-loader download initial --connection="jdbc:sqlserver://localhost:1433;databaseName=bgt;encrypt=false" --password="bgt@1234" --feature-types=wijk,buurt --no-geo-filter
 ```
 Voor Docker Desktop op Windows of Mac: gebruik `host.docker.internal` in plaats van `localhost`.
 

--- a/bgt-loader/pom.xml
+++ b/bgt-loader/pom.xml
@@ -337,7 +337,7 @@ SPDX-License-Identifier: MIT
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <systemPropertyVariables>
-                                <db.connectionString>jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;applicationName=bgt-loader-test;instance=${mssql.instancename}</db.connectionString>
+                                <db.connectionString>jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;applicationName=bgt-loader-test;encrypt=false;instance=${mssql.instancename}</db.connectionString>
                                 <db.user>sa</db.user>
                                 <db.password>Password12!</db.password>
                             </systemPropertyVariables>

--- a/bgt-loader/src/main/resources/BGTLoader.properties
+++ b/bgt-loader/src/main/resources/BGTLoader.properties
@@ -27,7 +27,7 @@ dialect=Database dialect (${COMPLETION-CANDIDATES}), default: ${DEFAULT-VALUE}
 connection=JDBC connection string for the database, examples:
 connection.0=PostGIS: ${DEFAULT-VALUE} (default)
 connection.1=Oracle:  jdbc:oracle:thin:@localhost:1521:XE
-connection.2=MSSQL:   jdbc:sqlserver://localhost:1433;databaseName=bgt
+connection.2=MSSQL:   jdbc:sqlserver://localhost:1433;databaseName=bgt;encrypt=false
 user=Database user, default: ${DEFAULT-VALUE}
 password=Database password, default: ${DEFAULT-VALUE}
 <file>[0]=File or URL to load (must have .zip, .gml or .xml extension)

--- a/brmo-commandline/src/test/resources/mssql.properties
+++ b/brmo-commandline/src/test/resources/mssql.properties
@@ -3,29 +3,29 @@
 dbtype=sqlserver
 
 # rsgb database gegevens
-rsgb.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;applicationName=brmo-commandline-test;instance=${mssql.instancename}
+rsgb.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;encrypt=false;applicationName=brmo-commandline-test;instance=${mssql.instancename}
 rsgb.user=sa
 rsgb.password=Password12!
 
 # staging database gegevens
-staging.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;applicationName=brmo-commandline-test;instance=${mssql.instancename}
+staging.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;encrypt=false;applicationName=brmo-commandline-test;instance=${mssql.instancename}
 staging.user=sa
 staging.password=Password12!
 
 # rsgbbgt database gegevens
-#rsgbbgt.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;applicationName=brmo-commandline-test;instance=${mssql.instancename}
+#rsgbbgt.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;encrypt=false;applicationName=brmo-commandline-test;instance=${mssql.instancename}
 #rsgbbgt.user=sa
 #rsgbbgt.password=Password12!
 
 # lokaal
-#rsgb.url=jdbc:sqlserver://localhost:1401;databaseName=rsgb;instance=sql1
+#rsgb.url=jdbc:sqlserver://localhost:1401;databaseName=rsgb;encrypt=false;instance=sql1
 #rsgb.user=sa
 #rsgb.passwd=YourStrong!Passw0rd
 #
-#staging.url=jdbc:sqlserver://localhost:1401;databaseName=staging;instance=sql1
+#staging.url=jdbc:sqlserver://localhost:1401;databaseName=staging;encrypt=false;instance=sql1
 #staging.user=sa
 #staging.passwd=YourStrong!Passw0rd
 #
-#rsgbbgt.url=jdbc:sqlserver://localhost:1401;databaseName=rsgbbgt;instance=sql1
+#rsgbbgt.url=jdbc:sqlserver://localhost:1401;databaseName=rsgbbgt;encrypt=false;instance=sql1
 #rsgbbgt.user=sa
 #rsgbbgt.passwd=YourStrong!Passw0rd

--- a/brmo-loader/src/test/resources/sqlserver.properties
+++ b/brmo-loader/src/test/resources/sqlserver.properties
@@ -11,19 +11,19 @@ rsgb.user=sa
 rsgb.passwd=Password12!
 # regular jdbc
 rsgb.jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
-rsgb.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;applicationName=brmo-loader-test;instance=${mssql.instancename}
+rsgb.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;encrypt=false;applicationName=brmo-loader-test;instance=${mssql.instancename}
 
 staging.jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
-staging.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;applicationName=brmo-loader-test;instance=${mssql.instancename}
+staging.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;encrypt=false;applicationName=brmo-loader-test;instance=${mssql.instancename}
 staging.user=sa
 staging.passwd=Password12!
 
 rsgbbgt.jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
-rsgbbgt.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;applicationName=brmo-loader-test;instance=${mssql.instancename}
+rsgbbgt.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;encrypt=false;applicationName=brmo-loader-test;instance=${mssql.instancename}
 rsgbbgt.user=sa
 rsgbbgt.passwd=Password12!
 
 topnl.jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
-topnl.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=topnl;applicationName=brmo-loader-test;instance=${mssql.instancename}
+topnl.jdbc.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=topnl;encrypt=false;applicationName=brmo-loader-test;instance=${mssql.instancename}
 topnl.user=sa
 topnl.passwd=Password12!

--- a/brmo-persistence/src/test/resources/connections.properties
+++ b/brmo-persistence/src/test/resources/connections.properties
@@ -10,7 +10,5 @@ postgresql.driverClass=org.postgresql.Driver
 
 microsoftsqlserver.user=sa
 microsoftsqlserver.password=Password12!
-# microsoftsqlserver.url=jdbc:jtds:sqlserver://127.0.0.1:1433/staging;instance=${mssql.instancename}
-# microsoftsqlserver.driverClass=net.sourceforge.jtds.jdbc.Driver
-microsoftsqlserver.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;applicationName=brmo-loader-test;instance=${mssql.instancename}
+microsoftsqlserver.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;encrypt=false;applicationName=brmo-loader-test;instance=${mssql.instancename}
 microsoftsqlserver.driverClass=com.microsoft.sqlserver.jdbc.SQLServerDriver

--- a/brmo-service/src/test/resources/sqlserver.properties
+++ b/brmo-service/src/test/resources/sqlserver.properties
@@ -4,16 +4,16 @@ jdbc.validationQuery=select 1
 
 rsgb.username=sa
 rsgb.password=Password12!
-rsgb.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;instance=${mssql.instancename}
+rsgb.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;encrypt=false;instance=${mssql.instancename}
 
 staging.username=sa
 staging.password=Password12!
-staging.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;instance=${mssql.instancename}
+staging.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;encrypt=false;instance=${mssql.instancename}
 
-rsgbbgt.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;instance=${mssql.instancename}
+rsgbbgt.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;encrypt=false;instance=${mssql.instancename}
 rsgbbgt.username=sa
 rsgbbgt.password=Password12!
 
-topnl.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=topnl;instance=${mssql.instancename}
+topnl.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=topnl;encrypt=false;instance=${mssql.instancename}
 topnl.username=sa
 topnl.password=Password12!

--- a/brmo-soap/src/test/resources/sqlserver.properties
+++ b/brmo-soap/src/test/resources/sqlserver.properties
@@ -2,10 +2,10 @@ dbtype=sqlserver
 
 rsgb.username=sa
 rsgb.password=Password12!
-rsgb.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;instance=${mssql.instancename}
+rsgb.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;encrypt=false;instance=${mssql.instancename}
 
 staging.username=sa
 staging.password=Password12!
-staging.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;instance=${mssql.instancename}
+staging.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;encrypt=false;instance=${mssql.instancename}
 
 jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver

--- a/brmo-stufbg204/src/test/resources/sqlserver.properties
+++ b/brmo-stufbg204/src/test/resources/sqlserver.properties
@@ -4,8 +4,8 @@ jdbc.validationQuery=select 1
 
 rsgb.username=sa
 rsgb.password=Password12!
-rsgb.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;instance=${mssql.instancename}
+rsgb.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;encrypt=false;instance=${mssql.instancename}
 
 staging.username=sa
 staging.password=Password12!
-staging.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;instance=${mssql.instancename}
+staging.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;encrypt=false;instance=${mssql.instancename}

--- a/brmo-test-util/src/test/java/nl/b3p/brmo/test/util/database/dbunit/DBUnitExportRSGB.java
+++ b/brmo-test-util/src/test/java/nl/b3p/brmo/test/util/database/dbunit/DBUnitExportRSGB.java
@@ -43,13 +43,13 @@ public class DBUnitExportRSGB {
 //    private static final String _passwd = "rsgb";
     // ms sql / jtds
     // private static final String _driverClass = "net.sourceforge.jtds.jdbc.Driver";
-    // private static final String _jdbcConnection = "jdbc:jtds:sqlserver://192.168.1.15:1433/itest_brmo_rsgb;instance=SQLEXPRESS";
+    // private static final String _jdbcConnection = "jdbc:jtds:sqlserver://192.168.1.15:1433/itest_brmo_rsgb;encrypt=false;instance=SQLEXPRESS";
     // private static final String _user = "brmotest";
     // private static final String _passwd = "brmotest";
 
     // ms sql
      private static final String _driverClass = "com.microsoft.sqlserver.jdbc.SQLServerDriver";
-     private static final String _jdbcConnection = "jdbc:sqlserver://localhost:1401;databaseName=rsgb;instance=sql1";
+     private static final String _jdbcConnection = "jdbc:sqlserver://localhost:1401;databaseName=rsgb;encrypt=false;instance=sql1";
      private static final String _user = "sa";
      private static final String _passwd = "YourStrong!Passw0rd";
 

--- a/datamodel/src/test/resources/sqlserver.properties
+++ b/datamodel/src/test/resources/sqlserver.properties
@@ -2,14 +2,14 @@
 jdbc.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
 dbtype=sqlserver
 
-rsgb.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;instance=${mssql.instancename}
+rsgb.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=rsgb;encrypt=false;instance=${mssql.instancename}
 rsgb.username=sa
 rsgb.password=Password12!
 
-staging.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;instance=${mssql.instancename}
+staging.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=staging;encrypt=false;instance=${mssql.instancename}
 staging.username=sa
 staging.password=Password12!
 
-rsgbbgt.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;instance=${mssql.instancename}
+rsgbbgt.url=jdbc:sqlserver://127.0.0.1:1433;databaseName=bgttest;encrypt=false;instance=${mssql.instancename}
 rsgbbgt.username=sa
 rsgbbgt.password=Password12!

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <postgresql.postgis-jdbc.version>2021.1.0</postgresql.postgis-jdbc.version>
         <oracle.jdbc.version>21.4.0.0.1</oracle.jdbc.version>
         <oracle.jdbc.artifact>ojdbc11</oracle.jdbc.artifact>
-        <sqlserver.jdbc.version>9.4.1.jre11</sqlserver.jdbc.version>
+        <sqlserver.jdbc.version>10.2.0.jre11</sqlserver.jdbc.version>
         <mssql.instancename />
         <skip-windows />
         <javasimon.version>4.2.0</javasimon.version>


### PR DESCRIPTION
deze nieuwe versie heeft default true voor TLS; maar voor test databases hebben we geen certificaat, dus wordt die op false ingesteld in de connect urls