### PR TITLE
Use logger instead of System.err directly

### DIFF
--- a/bgt-loader/src/main/java/nl/b3p/brmo/bgt/loader/cli/BGTLoaderMain.java
+++ b/bgt-loader/src/main/java/nl/b3p/brmo/bgt/loader/cli/BGTLoaderMain.java
@@ -138,12 +138,12 @@ public class BGTLoaderMain implements IVersionProvider {
             } else if (file.matches(".*\\.[xg]ml")) {
                 loadXml(new File(file), writer);
             } else {
-                System.err.println(getMessageFormattedString("load.invalid_extension", file));
+                log.error(getMessageFormattedString("load.invalid_extension", file));
                 return ExitCode.USAGE;
             }
 
             if (writer.getProgress() == null) {
-                System.err.println(getBundleString("error.no_feature_types"));
+                log.error(getBundleString("error.no_feature_types"));
                 return ExitCode.SOFTWARE;
             }
             db.setMetadataValue(Metadata.LOADER_VERSION, getLoaderVersion());
@@ -224,7 +224,7 @@ public class BGTLoaderMain implements IVersionProvider {
                         "UTF8",
                         false,
                         true
-                );
+                )
         ) {
             if (debugHttpSeeks) {
                 System.out.println();
@@ -259,7 +259,7 @@ public class BGTLoaderMain implements IVersionProvider {
 
             if (selected.size() > 1) {
                 // Only report total percentage when more than one entry
-                Long totalSize = selected.stream().map(ZipArchiveEntry::getSize).reduce(0L, Long::sum);
+                long totalSize = selected.stream().map(ZipArchiveEntry::getSize).reduce(0L, Long::sum);
                 Long totalCompressedSize = selected.stream().map(ZipArchiveEntry::getCompressedSize).reduce(0L, Long::sum);
                 progressReporter.setTotalBytes(totalSize);
                 if (showSelected) {

--- a/bgt-loader/src/main/java/nl/b3p/brmo/bgt/loader/cli/DownloadCommand.java
+++ b/bgt-loader/src/main/java/nl/b3p/brmo/bgt/loader/cli/DownloadCommand.java
@@ -82,7 +82,7 @@ public class DownloadCommand {
     ) throws Exception {
 
         if (extractSelectionOptions.getGeoFilterWkt() == null && !noGeoFilter) {
-            System.err.println(getBundleString("download.no_geo_filter"));
+            log.error(getBundleString("download.no_geo_filter"));
             return ExitCode.USAGE;
         }
 
@@ -172,7 +172,7 @@ public class DownloadCommand {
                 deltaIdTimeTo = OffsetDateTime.parse(s);
             }
             if (deltaId == null) {
-                System.err.println(getBundleString("download.no_delta_id"));
+                log.error(getBundleString("download.no_delta_id"));
                 return ExitCode.SOFTWARE;
             }
             ExtractSelectionOptions extractSelectionOptions = new ExtractSelectionOptions();
@@ -213,7 +213,7 @@ public class DownloadCommand {
                 }
                 if (i == response.getDeltas().size()) {
                     // TODO automatically do initial load depending on option
-                    System.err.println(getBundleString("download.current_delta_not_found"));
+                    log.error(getBundleString("download.current_delta_not_found"));
                     return ExitCode.SOFTWARE;
                 }
 

--- a/bgt-loader/src/main/resources/bgt-loader-cli-log4.properties
+++ b/bgt-loader/src/main/resources/bgt-loader-cli-log4.properties
@@ -2,13 +2,23 @@
 #
 # SPDX-License-Identifier: MIT
 
-log4j.rootLogger=error,console
+log4j.rootLogger=error,stdout,stderr
 log4j.logger.nl.b3p=info
 
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.target=System.out
-log4j.appender.console.immediateFlush=true
-log4j.appender.console.encoding=UTF-8
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.filter.filter1=org.apache.log4j.varia.LevelRangeFilter
+log4j.appender.stdout.filter.filter1.levelMin=trace
+log4j.appender.stdout.filter.filter1.levelMax=info
+log4j.appender.stdout.target=System.out
+log4j.appender.stdout.immediateFlush=true
+log4j.appender.stdout.encoding=UTF-8
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %m%n
 
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %m%n
+log4j.appender.stderr=org.apache.log4j.ConsoleAppender
+log4j.appender.stderr.threshold=warn
+log4j.appender.stderr.target=System.err
+log4j.appender.stderr.immediateFlush=true
+log4j.appender.stderr.encoding=UTF-8
+log4j.appender.stderr.layout=org.apache.log4j.PatternLayout
+log4j.appender.stderr.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %m%n


### PR DESCRIPTION
[BRMO-140] When using brmo-service log messages would not appear in the log file but still be sent to stderr.

[BRMO-140]: https://b3partners.atlassian.net/browse/BRMO-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ