### PR TITLE
Change update scripts to modify brmo_metadata.waarde column type to clob for BGT

### DIFF
--- a/datamodel/upgrade_scripts/2.2.0-2.2.1/oracle/rsgbbgt.sql
+++ b/datamodel/upgrade_scripts/2.2.0-2.2.1/oracle/rsgbbgt.sql
@@ -7,12 +7,17 @@ WHENEVER SQLERROR EXIT SQL.SQLCODE
 
 DECLARE
 BEGIN
-  EXECUTE IMMEDIATE 'CREATE TABLE brmo_metadata(naam VARCHAR2(255 CHAR) NOT NULL,waarde VARCHAR2(255 CHAR),PRIMARY KEY (naam));';
+  EXECUTE IMMEDIATE 'CREATE TABLE brmo_metadata(naam VARCHAR2(255 CHAR) NOT NULL,waarde CLOB,PRIMARY KEY (naam));';
   EXCEPTION WHEN OTHERS THEN
     IF SQLCODE = -955 THEN NULL; ELSE RAISE; END IF;
 END;
 MERGE INTO brmo_metadata USING DUAL ON (naam = 'brmoversie') WHEN NOT MATCHED THEN INSERT (naam) VALUES('brmoversie');
 
+-- Update existing brmo_metadata table to use clob type for waarde
+ALTER TABLE brmo_metadata ADD (temp clob);
+UPDATE BRMO_METADATA SET temp = waarde;
+ALTER TABLE brmo_metadata DROP COLUMN waarde;
+ALTER TABLE brmo_metadata RENAME COLUMN temp to waarde;
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.0_naar_2.2.1','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/2.2.0-2.2.1/postgresql/rsgbbgt.sql
+++ b/datamodel/upgrade_scripts/2.2.0-2.2.1/postgresql/rsgbbgt.sql
@@ -2,7 +2,10 @@
 -- upgrade PostgreSQL RSGBBGT datamodel van 2.2.0 naar 2.2.1 
 --
 
-CREATE TABLE IF NOT EXISTS brmo_metadata(naam CHARACTER VARYING(255) NOT NULL,waarde CHARACTER VARYING(255),CONSTRAINT brmo_metadata_pk PRIMARY KEY (naam));
+CREATE TABLE IF NOT EXISTS brmo_metadata(naam CHARACTER VARYING(255) NOT NULL,waarde TEXT,CONSTRAINT brmo_metadata_pk PRIMARY KEY (naam));
+-- Update existing brmo_metadata table to use clob type for waarde
+ALTER TABLE brmo_metadata ALTER COLUMN waarde TYPE TEXT;
+
 INSERT INTO brmo_metadata(naam) VALUES('brmoversie') ON CONFLICT DO NOTHING;
 
 

--- a/datamodel/upgrade_scripts/2.2.0-2.2.1/sqlserver/rsgbbgt.sql
+++ b/datamodel/upgrade_scripts/2.2.0-2.2.1/sqlserver/rsgbbgt.sql
@@ -3,8 +3,10 @@
 --
 
 IF OBJECT_ID('brmo_metadata', 'U') IS NULL
-CREATE TABLE brmo_metadata(naam VARCHAR(255) NOT NULL,waarde VARCHAR(255),PRIMARY KEY (naam));
+CREATE TABLE brmo_metadata(naam VARCHAR(255) NOT NULL,waarde NTEXT,PRIMARY KEY (naam));
 GO
+ALTER TABLE brmo_metadata ALTER COLUMN waarde NTEXT;
+
 INSERT INTO brmo_metadata(naam) SELECT naam FROM brmo_metadata WHERE NOT('brmoversie' IN (SELECT naam FROM brmo_metadata));
 
 


### PR DESCRIPTION
The default varchar(255) type can't fit geo filter or feature types selection, this could lead to failure loading BGT.