### PR TITLE
fix upgrade scripts voor 2.2.2

### DIFF
--- a/.build/ci/pgsql-execute-upgrades.sh
+++ b/.build/ci/pgsql-execute-upgrades.sh
@@ -16,11 +16,9 @@ echo "Huidige snapshot:" $CURSNAPSHOT", vorige release: "$PREVRELEASE", komende 
 echo "Verwerk upgrade script voor: " $1
 
 DB_NAME=$1
-DB_SCHEMA="public"
 if [ "bag" = $1 ]; then
   # bag is geen database, maar een schema in rsgb database
   DB_NAME=rsgb
-  DB_SCHEMA=$1
 fi
 psql -U postgres -h localhost -d $DB_NAME -f ./datamodel/upgrade_scripts/$PREVRELEASE-$NEXTRELEASE/postgresql/$1.sql
-psql -U postgres -h localhost -d $DB_NAME  -c "select * from $DB_SCHEMA.brmo_metadata"
+psql -U postgres -h localhost -d $DB_NAME  -c "select * from brmo_metadata"

--- a/datamodel/src/test/java/nl/b3p/brmo/datamodel/DatabaseUpgradeTest.java
+++ b/datamodel/src/test/java/nl/b3p/brmo/datamodel/DatabaseUpgradeTest.java
@@ -126,7 +126,7 @@ public class DatabaseUpgradeTest {
         } else if (this.isPostgis) {
             db.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new PostgresqlDataTypeFactory());
         } else {
-            fail("Geen ondersteunde database aangegegeven.");
+            fail("Geen ondersteunde database aangegeven.");
         }
     }
 

--- a/datamodel/upgrade_scripts/2.2.0-2.2.1/postgresql/bag.sql
+++ b/datamodel/upgrade_scripts/2.2.0-2.2.1/postgresql/bag.sql
@@ -11,11 +11,7 @@ DROP VIEW IF EXISTS bag.vb_standplaats_adres;
 DROP VIEW IF EXISTS bag.vb_ligplaats_adres;
 DROP VIEW IF EXISTS bag.vb_adres;
 
-CREATE SCHEMA IF NOT EXISTS bag;
-CREATE TABLE IF NOT EXISTS bag.brmo_metadata(naam CHARACTER VARYING(255) NOT NULL,waarde CHARACTER VARYING(255),CONSTRAINT brmo_metadata_pk PRIMARY KEY (naam));
-INSERT INTO bag.brmo_metadata(naam) VALUES('brmoversie') ON CONFLICT DO NOTHING;
-
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
-INSERT INTO bag.brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.0_naar_2.2.1','vorige versie was ' || waarde FROM bag.brmo_metadata WHERE naam='brmoversie';
+INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.0_naar_2.2.1','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';
 -- versienummer update
-UPDATE bag.brmo_metadata SET waarde='2.2.1' WHERE naam='brmoversie';
+UPDATE brmo_metadata SET waarde='2.2.1' WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/2.2.1-2.2.2/oracle/bag.sql
+++ b/datamodel/upgrade_scripts/2.2.1-2.2.2/oracle/bag.sql
@@ -3,18 +3,18 @@
 --
 
 WHENEVER SQLERROR EXIT SQL.SQLCODE
-\n\nBEGIN
-\n\n    EXECUTE IMMEDIATE 'CREATE TABLE brmo_metadata(naam VARCHAR2(255 CHAR) NOT NULL, waarde CLOB, PRIMARY KEY (naam))';
-\n\nEXCEPTION
-\n\nWHEN OTHERS THEN
-\n\nIF
-\n\n    SQLCODE = -955 THEN
-\n\n    NULL;
-\n\nELSE RAISE;
-\n\nEND IF;
-\n\nEND;
-\n\n/
-\n\nMERGE INTO brmo_metadata USING DUAL ON (naam = 'brmoversie') WHEN NOT MATCHED THEN INSERT (naam) VALUES('brmoversie');
+BEGIN
+    EXECUTE IMMEDIATE 'CREATE TABLE brmo_metadata(naam VARCHAR2(255 CHAR) NOT NULL, waarde CLOB, PRIMARY KEY (naam))';
+EXCEPTION
+WHEN OTHERS THEN
+IF
+    SQLCODE = -955 THEN
+    NULL;
+ELSE RAISE;
+END IF;
+END;
+/
+MERGE INTO brmo_metadata USING DUAL ON (naam = 'brmoversie') WHEN NOT MATCHED THEN INSERT (naam) VALUES('brmoversie');
 
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd

--- a/datamodel/upgrade_scripts/2.2.1-2.2.2/oracle/rsgbbgt.sql
+++ b/datamodel/upgrade_scripts/2.2.1-2.2.2/oracle/rsgbbgt.sql
@@ -3,18 +3,18 @@
 --
 
 WHENEVER SQLERROR EXIT SQL.SQLCODE
-\n\nBEGIN
-\n\n    EXECUTE IMMEDIATE 'CREATE TABLE brmo_metadata(naam VARCHAR2(255 CHAR) NOT NULL, waarde CLOB, PRIMARY KEY (naam))';
-\n\nEXCEPTION
-\n\nWHEN OTHERS THEN
-\n\nIF
-\n\n    SQLCODE = -955 THEN
-\n\n    NULL;
-\n\nELSE RAISE;
-\n\nEND IF;
-\n\nEND;
-\n\n/
-\n\nMERGE INTO brmo_metadata USING DUAL ON (naam = 'brmoversie') WHEN NOT MATCHED THEN INSERT (naam) VALUES('brmoversie');
+BEGIN
+    EXECUTE IMMEDIATE 'CREATE TABLE brmo_metadata(naam VARCHAR2(255 CHAR) NOT NULL, waarde CLOB, PRIMARY KEY (naam))';
+EXCEPTION
+WHEN OTHERS THEN
+IF
+    SQLCODE = -955 THEN
+    NULL;
+ELSE RAISE;
+END IF;
+END;
+/
+MERGE INTO brmo_metadata USING DUAL ON (naam = 'brmoversie') WHEN NOT MATCHED THEN INSERT (naam) VALUES('brmoversie');
 
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd

--- a/datamodel/upgrade_scripts/2.2.1-2.2.2/postgresql/bag.sql
+++ b/datamodel/upgrade_scripts/2.2.1-2.2.2/postgresql/bag.sql
@@ -2,6 +2,10 @@
 -- upgrade PostgreSQL BAG datamodel van 2.2.1 naar 2.2.2 
 --
 
+CREATE SCHEMA IF NOT EXISTS bag;
+
+SET search_path = bag,public;
+
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.1_naar_2.2.2','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/2.2.1-2.2.2/postgresql/rsgbbgt.sql
+++ b/datamodel/upgrade_scripts/2.2.1-2.2.2/postgresql/rsgbbgt.sql
@@ -2,7 +2,7 @@
 -- upgrade PostgreSQL RSGBBGT datamodel van 2.2.1 naar 2.2.2 
 --
 
-CREATE TABLE IF NOT EXISTS brmo_metadata(naam CHARACTER VARYING(255) NOT NULL,waarde CHARACTER VARYING(255),CONSTRAINT brmo_metadata_pk PRIMARY KEY (naam));
+CREATE TABLE IF NOT EXISTS brmo_metadata(naam CHARACTER VARYING(255) NOT NULL, waarde TEXT, CONSTRAINT brmo_metadata_pk PRIMARY KEY (naam));
 INSERT INTO brmo_metadata(naam) VALUES('brmoversie') ON CONFLICT DO NOTHING;
 
 

--- a/datamodel/upgrade_scripts/2.2.1-2.2.2/sqlserver/bag.sql
+++ b/datamodel/upgrade_scripts/2.2.1-2.2.2/sqlserver/bag.sql
@@ -1,9 +1,0 @@
--- 
--- upgrade SQLserver BAG datamodel van 2.2.1 naar 2.2.2 
---
-
-
--- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
-INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.1_naar_2.2.2','vorige versie was ' + waarde FROM brmo_metadata WHERE naam='brmoversie';
--- versienummer update
-UPDATE brmo_metadata SET waarde='2.2.2' WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/2.2.1-2.2.2/sqlserver/rsgbbgt.sql
+++ b/datamodel/upgrade_scripts/2.2.1-2.2.2/sqlserver/rsgbbgt.sql
@@ -3,7 +3,7 @@
 --
 
 IF OBJECT_ID('brmo_metadata', 'U') IS NULL
-CREATE TABLE brmo_metadata(naam VARCHAR(255) NOT NULL,waarde VARCHAR(255),PRIMARY KEY (naam));
+CREATE TABLE brmo_metadata(naam VARCHAR(255) NOT NULL, waarde NTEXT, PRIMARY KEY (naam));
 GO
 INSERT INTO brmo_metadata(naam) SELECT naam FROM brmo_metadata WHERE NOT('brmoversie' IN (SELECT naam FROM brmo_metadata));
 

--- a/datamodel/upgrade_scripts/new-version-upgrades.sh
+++ b/datamodel/upgrade_scripts/new-version-upgrades.sh
@@ -25,53 +25,68 @@ for DB in Oracle PostgreSQL SQLserver; do
     if [ -f "$DIR/$b.sql" ]; then
       echo Bestand $DIR/$b.sql bestaal al.
     else
-      echo -- $'\n'-- upgrade $DB ${b^^} datamodel van $PREVRELEASE naar $NEXTRELEASE $n $'\n'-- >$DIR/$b.sql
+      echo -- $'\n'-- upgrade $DB ${b^^} datamodel van $PREVRELEASE naar $NEXTRELEASE $'\n'-- >$DIR/$b.sql
 
       if [ "$DB" == "Oracle" ]; then
         echo $'\n'WHENEVER SQLERROR EXIT SQL.SQLCODE >>$DIR/$b.sql
         if [ "${b}" == "rsgbbgt" ] || [ "${b}" == "bag" ]; then
-          echo $"\n\nBEGIN" >>$DIR/$b.sql
-          echo $"\n\n    EXECUTE IMMEDIATE 'CREATE TABLE brmo_metadata(naam VARCHAR2(255 CHAR) NOT NULL, waarde CLOB, PRIMARY KEY (naam))';" >>$DIR/$b.sql
-          echo $"\n\nEXCEPTION" >>$DIR/$b.sql
-          echo $"\n\nWHEN OTHERS THEN" >>$DIR/$b.sql
-          echo $"\n\nIF" >>$DIR/$b.sql
-          echo $"\n\n    SQLCODE = -955 THEN" >>$DIR/$b.sql
-          echo $"\n\n    NULL;" >>$DIR/$b.sql
-          echo $"\n\nELSE RAISE;" >>$DIR/$b.sql
-          echo $"\n\nEND IF;" >>$DIR/$b.sql
-          echo $"\n\nEND;" >>$DIR/$b.sql
-          echo $"\n\n/" >>$DIR/$b.sql
-          echo $"\n\nMERGE INTO brmo_metadata USING DUAL ON (naam = 'brmoversie') WHEN NOT MATCHED THEN INSERT (naam) VALUES('brmoversie');" >>$DIR/$b.sql
+          # brmo_metadata tabel aanmaken in oracle bag en rsgbbgt schema als die niet bestaat
+          echo $'\n\n'
+          echo $"BEGIN" >>$DIR/$b.sql
+          echo $"    EXECUTE IMMEDIATE 'CREATE TABLE brmo_metadata(naam VARCHAR2(255 CHAR) NOT NULL, waarde CLOB, PRIMARY KEY (naam))';" >>$DIR/$b.sql
+          echo $"EXCEPTION" >>$DIR/$b.sql
+          echo $"WHEN OTHERS THEN" >>$DIR/$b.sql
+          echo $"IF" >>$DIR/$b.sql
+          echo $"    SQLCODE = -955 THEN" >>$DIR/$b.sql
+          echo $"    NULL;" >>$DIR/$b.sql
+          echo $"ELSE RAISE;" >>$DIR/$b.sql
+          echo $"END IF;" >>$DIR/$b.sql
+          echo $"END;" >>$DIR/$b.sql
+          echo $"/" >>$DIR/$b.sql
+          echo $"MERGE INTO brmo_metadata USING DUAL ON (naam = 'brmoversie') WHEN NOT MATCHED THEN INSERT (naam) VALUES('brmoversie');" >>$DIR/$b.sql
         fi
       fi
+
       if [ "${DB}" == "SQLserver" ] && [ "${b}" == "rsgbbgt" ]; then
+        # brmo_metadata tabel aanmaken in sqlserver rsgbbgt schema als die niet bestaat
         echo $'\n'"IF OBJECT_ID('brmo_metadata', 'U') IS NULL" >>$DIR/$b.sql
-        echo $"CREATE TABLE brmo_metadata(naam VARCHAR(255) NOT NULL,waarde VARCHAR(255),PRIMARY KEY (naam));" >>$DIR/$b.sql
+        echo $"CREATE TABLE brmo_metadata(naam VARCHAR(255) NOT NULL, waarde NTEXT, PRIMARY KEY (naam));" >>$DIR/$b.sql
         echo $"GO" >>$DIR/$b.sql
         echo $"INSERT INTO brmo_metadata(naam) SELECT naam FROM brmo_metadata WHERE NOT('brmoversie' IN (SELECT naam FROM brmo_metadata));" >>$DIR/$b.sql
       fi
-      if [ "${DB}" == "PostgreSQL" ] && [ "${b}" == "rsgbbgt" ]; then
-        if [ "${b}" == "bag" ]; then
-            echo $'\n'"set search_path = bag,public;" >>$DIR/$b.sql
+
+      if [ "${DB}" == "PostgreSQL" ]; then
+        if [ "${b}" == "rsgbbgt" ]; then
+          echo $'\n'"CREATE TABLE IF NOT EXISTS brmo_metadata(naam CHARACTER VARYING(255) NOT NULL, waarde TEXT, CONSTRAINT brmo_metadata_pk PRIMARY KEY (naam));" >>$DIR/$b.sql
+          echo $"INSERT INTO brmo_metadata(naam) VALUES('brmoversie') ON CONFLICT DO NOTHING;" >>$DIR/$b.sql
         fi
-        echo $'\n'"CREATE TABLE IF NOT EXISTS brmo_metadata(naam CHARACTER VARYING(255) NOT NULL,waarde CHARACTER VARYING(255),CONSTRAINT brmo_metadata_pk PRIMARY KEY (naam));" >>$DIR/$b.sql
-        echo $"INSERT INTO brmo_metadata(naam) VALUES('brmoversie') ON CONFLICT DO NOTHING;" >>$DIR/$b.sql
-      fi
-      if [ "${DB}" == "PostgreSQL" ] && [ "${b}" == "rsgb" ]; then
-        echo $'\n'"set search_path = public,bag;" >>$DIR/$b.sql
+
+        if [ "${b}" == "bag" ]; then
+          echo $'\n'"CREATE SCHEMA IF NOT EXISTS bag;" >>$DIR/$b.sql
+          echo $'\n'"SET search_path = bag,public;" >>$DIR/$b.sql
+        fi
+
+        if [ "${b}" == "rsgb" ]; then
+          echo $'\n'"set search_path = public,bag;" >>$DIR/$b.sql
+        fi
       fi
 
       echo $'\n\n'-- onderstaande dienen als laatste stappen van een upgrade uitgevoerd >>$DIR/$b.sql
       if [ "${DB}" == "SQLserver" ]; then
         echo "INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_"$PREVRELEASE"_naar_"$NEXTRELEASE"','vorige versie was ' + waarde FROM brmo_metadata WHERE naam='brmoversie';" >>$DIR/$b.sql
+        echo -- versienummer update >>$DIR/$b.sql
+        echo "UPDATE brmo_metadata SET waarde='$NEXTRELEASE' WHERE naam='brmoversie';" >>$DIR/$b.sql
       else
         echo "INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_"$PREVRELEASE"_naar_"$NEXTRELEASE"','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';" >>$DIR/$b.sql
+        echo -- versienummer update >>$DIR/$b.sql
+        echo "UPDATE brmo_metadata SET waarde='$NEXTRELEASE' WHERE naam='brmoversie';" >>$DIR/$b.sql
       fi
-      echo -- versienummer update >>$DIR/$b.sql
-      echo "UPDATE brmo_metadata SET waarde='$NEXTRELEASE' WHERE naam='brmoversie';" >>$DIR/$b.sql
     fi
   done
 done
+
+# geen ondersteuning voor bag 2 in sql server
+rm $PREVRELEASE-$NEXTRELEASE/sqlserver/bag.sql
 
 git add "$PREVRELEASE-$NEXTRELEASE"/
 git commit -m "Migratie bestanden aanmaken voor upgrade $PREVRELEASE-$NEXTRELEASE"


### PR DESCRIPTION
- [x] fix oracle upgrade scripts voor 2.2.2: funky newline chars verwijderd
- [x] fix postgres upgrade scripts voor 2.2.2: geen `brmo_metadata` tabel maken in bag schema, bijwerken bag upgrade 2.2.0-2.2.1
- [x] fix sqlserver upgrade scripts voor 2.2.2; geen bag upgrade script 

gebruik een text/clob voor `waarde` kolom in `rsgbbgt.brmo_metadata` tabel