### PR TITLE
[SUPPORT-12989] Hou `com.sun.mail:jakarta.mail` en `com.sun.activation:jakarta.activation` uit de war file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -495,6 +495,17 @@
                 <groupId>com.sun.xml.ws</groupId>
                 <artifactId>jaxws-rt</artifactId>
                 <version>2.3.5</version>
+                <exclusions>
+                    <!-- deze komen in de Tomcat lib, moeten dus niet in de war file terecht komen -->
+                    <exclusion>
+                        <groupId>com.sun.mail</groupId>
+                        <artifactId>jakarta.mail</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.sun.activation</groupId>
+                        <artifactId>jakarta.activation</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.json</groupId>


### PR DESCRIPTION
Bij upgrade van de JAXWS runtime library (#1263) zijn mail/activation transitieve dependencies meegekomen... dat is niet de bedoeling want die hebben we ook in de `tomcat/lib` zitten omdat er een JDNI mail session wordt gebruikt.

De extra mail en activation jars in de webapp zorgen voor classloader problemen waardoor het onmogelijk is om mail te versturen vanuit de brmo-service

```
[INFO] +- com.sun.xml.ws:jaxws-rt:jar:2.3.5:compile
[INFO] |  +- com.sun.xml.ws:policy:jar:2.7.10:compile
[INFO] |  +- com.sun.xml.bind:jaxb-impl:jar:2.3.5:compile
[INFO] |  +- org.glassfish.ha:ha-api:jar:3.1.13:compile
[INFO] |  +- org.glassfish.external:management-api:jar:3.2.3:compile
[INFO] |  +- org.glassfish.gmbal:gmbal-api-only:jar:4.0.3:compile
[INFO] |  +- org.jvnet.staxex:stax-ex:jar:1.8.3:compile
[INFO] |  +- com.sun.xml.stream.buffer:streambuffer:jar:1.5.10:compile
[INFO] |  +- org.jvnet.mimepull:mimepull:jar:1.9.15:compile
[INFO] |  +- com.sun.xml.fastinfoset:FastInfoset:jar:1.2.18:compile
[INFO] |  +- com.sun.activation:jakarta.activation:jar:1.2.2:compile
[INFO] |  +- com.sun.mail:jakarta.mail:jar:1.6.7:compile
[INFO] |  +- com.sun.xml.messaging.saaj:saaj-impl:jar:1.5.3:runtime
[INFO] |  +- com.fasterxml.woodstox:woodstox-core:jar:6.2.6:runtime
[INFO] |  +- org.codehaus.woodstox:stax2-api:jar:4.2.1:runtime
[INFO] |  +- jakarta.xml.ws:jakarta.xml.ws-api:jar:2.3.3:compile
[INFO] |  +- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:compile
[INFO] |  +- jakarta.xml.soap:jakarta.xml.soap-api:jar:1.4.2:compile
[INFO] |  +- jakarta.jws:jakarta.jws-api:jar:2.1.0:compile
[INFO] |  \- jakarta.annotation:jakarta.annotation-api:jar:1.3.5:compile
```

closes SUPPORT-12989