### PR TITLE
Gebruik PostGIS Alpine docker images

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,18 +19,20 @@ jobs:
     name: Java ${{ matrix.java }} / PostGIS ${{ matrix.postgis }}
     runs-on: [ ubuntu-20.04 ]
     strategy:
+      fail-fast: false
       matrix:
         java: [ 11 ]
         java-dist: [ 'temurin' ]
         # docker image tags from https://hub.docker.com/r/postgis/postgis/tags?page=1&ordering=last_updated
         # zie ook https://www.postgresql.org/support/versioning/
-        postgis: [ # tot 12-2022
-            10-2.5,
-          # tot 11-2023  
-            11-3.1,
-            12-3.2,
-            13-3.2,
-            14-3.2 ]
+        postgis: 
+            # tot 12-2022
+            - 10-2.5-alpine
+            # tot 11-2023  
+            - 11-3.1-alpine
+            - 12-3.2-alpine
+            - 13-3.2-alpine
+            - 14-3.2-alpine
 
     services:
       postgres:


### PR DESCRIPTION
kleinere base images ➜ snellere download