### PR TITLE
[BRMO-110][BRMO-134] Gemeente Weesp gaat op in gemeente Amsterdam

### DIFF
--- a/datamodel/extra_scripts/oracle/111_insert_gemeente.sql
+++ b/datamodel/extra_scripts/oracle/111_insert_gemeente.sql
@@ -308,7 +308,6 @@ INSERT INTO gemeente (code, naam) VALUES (289, 'Wageningen');
 INSERT INTO gemeente (code, naam) VALUES (629, 'Wassenaar');
 INSERT INTO gemeente (code, naam) VALUES (852, 'Waterland');
 INSERT INTO gemeente (code, naam) VALUES (988, 'Weert');
-INSERT INTO gemeente (code, naam) VALUES (457, 'Weesp');
 INSERT INTO gemeente (code, naam) VALUES (1960, 'West Betuwe');
 INSERT INTO gemeente (code, naam) VALUES (668, 'West Maas en Waal');
 INSERT INTO gemeente (code, naam) VALUES (1969, 'Westerkwartier');

--- a/datamodel/extra_scripts/postgresql/111_insert_gemeente.sql
+++ b/datamodel/extra_scripts/postgresql/111_insert_gemeente.sql
@@ -307,7 +307,6 @@ INSERT INTO gemeente (code, naam) VALUES (289, 'Wageningen');
 INSERT INTO gemeente (code, naam) VALUES (629, 'Wassenaar');
 INSERT INTO gemeente (code, naam) VALUES (852, 'Waterland');
 INSERT INTO gemeente (code, naam) VALUES (988, 'Weert');
-INSERT INTO gemeente (code, naam) VALUES (457, 'Weesp');
 INSERT INTO gemeente (code, naam) VALUES (1960, 'West Betuwe');
 INSERT INTO gemeente (code, naam) VALUES (668, 'West Maas en Waal');
 INSERT INTO gemeente (code, naam) VALUES (1969, 'Westerkwartier');

--- a/datamodel/extra_scripts/sqlserver/111_insert_gemeente.sql
+++ b/datamodel/extra_scripts/sqlserver/111_insert_gemeente.sql
@@ -310,7 +310,6 @@ INSERT INTO gemeente (code, naam) VALUES (289, 'Wageningen');
 INSERT INTO gemeente (code, naam) VALUES (629, 'Wassenaar');
 INSERT INTO gemeente (code, naam) VALUES (852, 'Waterland');
 INSERT INTO gemeente (code, naam) VALUES (988, 'Weert');
-INSERT INTO gemeente (code, naam) VALUES (457, 'Weesp');
 INSERT INTO gemeente (code, naam) VALUES (1960, 'West Betuwe');
 INSERT INTO gemeente (code, naam) VALUES (668, 'West Maas en Waal');
 INSERT INTO gemeente (code, naam) VALUES (1969, 'Westerkwartier');

--- a/datamodel/pom.xml
+++ b/datamodel/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <filename.base.201_update_wnplts_gemcode>201_update_wnplts_gemcode</filename.base.201_update_wnplts_gemcode>
         <!-- LET OP als deze file bestaat zal het specifieke profiel geactiveerd worden en wordt het rsgb model niet gebouwd -->
-        <filename.GEM-WPL-zipfile>GEM-WPL-RELATIE-04012022.zip</filename.GEM-WPL-zipfile>
+        <filename.GEM-WPL-zipfile>GEM-WPL-RELATIE-21032022.zip</filename.GEM-WPL-zipfile>
     </properties>
     <dependencies>
         <dependency>

--- a/datamodel/utility_scripts/oracle/120_vervallen_gemeenten.sql
+++ b/datamodel/utility_scripts/oracle/120_vervallen_gemeenten.sql
@@ -415,5 +415,17 @@ INSERT INTO gemeente (dat_beg_geldh, code, naam) SELECT '2022-01-01', 1991, 'Maa
 INSERT INTO gemeente (dat_beg_geldh, code, naam) SELECT '2022-01-01', 1982, 'Land van Cuijk' FROM dual WHERE NOT EXISTS (SELECT code FROM gemeente WHERE code = 1982);
 
 UPDATE brmo_metadata SET waarde = '2022.0' WHERE naam = 'update_gem_tabel';
+COMMIT;
 
+
+SET TRANSACTION NAME 'mrt2022';
+-- Samenvoegen van gemeente Weesp (457) met Amsterdam (363)
+UPDATE gemeente SET datum_einde_geldh = '2022-03-24' WHERE code IN (457);
+UPDATE gemeente SET dat_beg_geldh = '2009-01-01'     WHERE code IN (457) AND dat_beg_geldh IS NULL;
+
+INSERT INTO gemeente_archief SELECT * FROM gemeente WHERE code IN (457);
+UPDATE wnplts SET fk_7gem_code=null WHERE fk_7gem_code         IN (457);
+DELETE FROM gemeente WHERE code                                IN (457);
+
+UPDATE brmo_metadata SET waarde = '2022.1' WHERE naam = 'update_gem_tabel';
 COMMIT;

--- a/datamodel/utility_scripts/oracle/201_update_wnplts_gemcode.sql
+++ b/datamodel/utility_scripts/oracle/201_update_wnplts_gemcode.sql
@@ -1,6 +1,6 @@
 -- Update gemeente/woonplaats relatie koppelscript
--- Gegenereerd op: 2022-01-04T09:01:18.344991+01:00
--- StandTechnischeDatum van bronbestand: 2022-01-04
+-- Gegenereerd op: 2022-03-21T10:46:54.109766+01:00
+-- StandTechnischeDatum van bronbestand: 2022-03-21
 UPDATE wnplts SET fk_7gem_code = 893 WHERE identif = '1125';
 UPDATE wnplts SET fk_7gem_code = 1771 WHERE identif = '1126';
 UPDATE wnplts SET fk_7gem_code = 1771 WHERE identif = '1127';
@@ -48,7 +48,6 @@ UPDATE wnplts SET fk_7gem_code = 687 WHERE identif = '1008';
 UPDATE wnplts SET fk_7gem_code = 687 WHERE identif = '1009';
 UPDATE wnplts SET fk_7gem_code = 777 WHERE identif = '1010';
 UPDATE wnplts SET fk_7gem_code = 406 WHERE identif = '1011';
-UPDATE wnplts SET fk_7gem_code = 457 WHERE identif = '1012';
 UPDATE wnplts SET fk_7gem_code = 342 WHERE identif = '1013';
 UPDATE wnplts SET fk_7gem_code = 342 WHERE identif = '1014';
 UPDATE wnplts SET fk_7gem_code = 622 WHERE identif = '1015';
@@ -2513,7 +2512,6 @@ UPDATE wnplts SET fk_7gem_code = 1978 WHERE identif = '3627';
 UPDATE wnplts SET fk_7gem_code = 1978 WHERE identif = '3628';
 UPDATE wnplts SET fk_7gem_code = 175 WHERE identif = '3629';
 UPDATE wnplts SET fk_7gem_code = 175 WHERE identif = '3630';
-UPDATE wnplts SET fk_7gem_code = 457 WHERE identif = '3631';
 UPDATE wnplts SET fk_7gem_code = 1942 WHERE identif = '3632';
 UPDATE wnplts SET fk_7gem_code = 1699 WHERE identif = '3633';
 UPDATE wnplts SET fk_7gem_code = 1699 WHERE identif = '3634';
@@ -2570,6 +2568,8 @@ UPDATE wnplts SET fk_7gem_code = 93 WHERE identif = '2621';
 UPDATE wnplts SET fk_7gem_code = 1966 WHERE identif = '3484';
 UPDATE wnplts SET fk_7gem_code = 74 WHERE identif = '3558';
 UPDATE wnplts SET fk_7gem_code = 166 WHERE identif = '3559';
+UPDATE wnplts SET fk_7gem_code = 363 WHERE identif = '3631';
+UPDATE wnplts SET fk_7gem_code = 363 WHERE identif = '1012';
 UPDATE wnplts SET fk_7gem_code = 1991 WHERE identif = '1849';
 UPDATE wnplts SET fk_7gem_code = 1991 WHERE identif = '1848';
 UPDATE wnplts SET fk_7gem_code = 1991 WHERE identif = '1852';

--- a/datamodel/utility_scripts/postgresql/120_vervallen_gemeenten.sql
+++ b/datamodel/utility_scripts/postgresql/120_vervallen_gemeenten.sql
@@ -411,3 +411,16 @@ INSERT INTO gemeente (dat_beg_geldh, code, naam) SELECT '2022-01-01', 1982, 'Lan
 
 UPDATE brmo_metadata SET waarde = '2022.0' WHERE naam = 'update_gem_tabel';
 COMMIT;
+
+
+BEGIN TRANSACTION;
+-- Samenvoegen van gemeente Weesp (457) met Amsterdam (363)
+UPDATE gemeente SET datum_einde_geldh = '2022-03-24' WHERE code IN (457);
+UPDATE gemeente SET dat_beg_geldh = '2009-01-01'     WHERE code IN (457) AND dat_beg_geldh IS NULL;
+
+INSERT INTO gemeente_archief SELECT * FROM gemeente WHERE code IN (457);
+UPDATE wnplts SET fk_7gem_code=null WHERE fk_7gem_code         IN (457);
+DELETE FROM gemeente WHERE code                                IN (457);
+
+UPDATE brmo_metadata SET waarde = '2022.1' WHERE naam = 'update_gem_tabel';
+COMMIT;

--- a/datamodel/utility_scripts/postgresql/201_update_wnplts_gemcode.sql
+++ b/datamodel/utility_scripts/postgresql/201_update_wnplts_gemcode.sql
@@ -1,6 +1,6 @@
 -- Update gemeente/woonplaats relatie koppelscript
--- Gegenereerd op: 2022-01-04T09:01:18.344991+01:00
--- StandTechnischeDatum van bronbestand: 2022-01-04
+-- Gegenereerd op: 2022-03-21T10:46:54.109766+01:00
+-- StandTechnischeDatum van bronbestand: 2022-03-21
 UPDATE wnplts SET fk_7gem_code = 893 WHERE identif = '1125';
 UPDATE wnplts SET fk_7gem_code = 1771 WHERE identif = '1126';
 UPDATE wnplts SET fk_7gem_code = 1771 WHERE identif = '1127';
@@ -48,7 +48,6 @@ UPDATE wnplts SET fk_7gem_code = 687 WHERE identif = '1008';
 UPDATE wnplts SET fk_7gem_code = 687 WHERE identif = '1009';
 UPDATE wnplts SET fk_7gem_code = 777 WHERE identif = '1010';
 UPDATE wnplts SET fk_7gem_code = 406 WHERE identif = '1011';
-UPDATE wnplts SET fk_7gem_code = 457 WHERE identif = '1012';
 UPDATE wnplts SET fk_7gem_code = 342 WHERE identif = '1013';
 UPDATE wnplts SET fk_7gem_code = 342 WHERE identif = '1014';
 UPDATE wnplts SET fk_7gem_code = 622 WHERE identif = '1015';
@@ -2513,7 +2512,6 @@ UPDATE wnplts SET fk_7gem_code = 1978 WHERE identif = '3627';
 UPDATE wnplts SET fk_7gem_code = 1978 WHERE identif = '3628';
 UPDATE wnplts SET fk_7gem_code = 175 WHERE identif = '3629';
 UPDATE wnplts SET fk_7gem_code = 175 WHERE identif = '3630';
-UPDATE wnplts SET fk_7gem_code = 457 WHERE identif = '3631';
 UPDATE wnplts SET fk_7gem_code = 1942 WHERE identif = '3632';
 UPDATE wnplts SET fk_7gem_code = 1699 WHERE identif = '3633';
 UPDATE wnplts SET fk_7gem_code = 1699 WHERE identif = '3634';
@@ -2570,6 +2568,8 @@ UPDATE wnplts SET fk_7gem_code = 93 WHERE identif = '2621';
 UPDATE wnplts SET fk_7gem_code = 1966 WHERE identif = '3484';
 UPDATE wnplts SET fk_7gem_code = 74 WHERE identif = '3558';
 UPDATE wnplts SET fk_7gem_code = 166 WHERE identif = '3559';
+UPDATE wnplts SET fk_7gem_code = 363 WHERE identif = '3631';
+UPDATE wnplts SET fk_7gem_code = 363 WHERE identif = '1012';
 UPDATE wnplts SET fk_7gem_code = 1991 WHERE identif = '1849';
 UPDATE wnplts SET fk_7gem_code = 1991 WHERE identif = '1848';
 UPDATE wnplts SET fk_7gem_code = 1991 WHERE identif = '1852';

--- a/datamodel/utility_scripts/sqlserver/120_vervallen_gemeenten.sql
+++ b/datamodel/utility_scripts/sqlserver/120_vervallen_gemeenten.sql
@@ -412,3 +412,16 @@ IF NOT EXISTS (SELECT * FROM gemeente WHERE code = 1982) INSERT INTO gemeente (d
 
 UPDATE brmo_metadata SET waarde = '2022.0' WHERE naam = 'update_gem_tabel';
 COMMIT;
+
+
+BEGIN TRANSACTION;
+-- Samenvoegen van gemeente Weesp (457) met Amsterdam (363)
+UPDATE gemeente SET datum_einde_geldh = '2022-03-24' WHERE code IN (457);
+UPDATE gemeente SET dat_beg_geldh = '2009-01-01'     WHERE code IN (457) AND dat_beg_geldh IS NULL;
+
+INSERT INTO gemeente_archief SELECT * FROM gemeente WHERE code IN (457);
+UPDATE wnplts SET fk_7gem_code=null WHERE fk_7gem_code         IN (457);
+DELETE FROM gemeente WHERE code                                IN (457);
+
+UPDATE brmo_metadata SET waarde = '2022.1' WHERE naam = 'update_gem_tabel';
+COMMIT;

--- a/datamodel/utility_scripts/sqlserver/201_update_wnplts_gemcode.sql
+++ b/datamodel/utility_scripts/sqlserver/201_update_wnplts_gemcode.sql
@@ -1,6 +1,6 @@
 -- Update gemeente/woonplaats relatie koppelscript
--- Gegenereerd op: 2022-01-04T09:01:18.344991+01:00
--- StandTechnischeDatum van bronbestand: 2022-01-04
+-- Gegenereerd op: 2022-03-21T10:46:54.109766+01:00
+-- StandTechnischeDatum van bronbestand: 2022-03-21
 UPDATE wnplts SET fk_7gem_code = 893 WHERE identif = '1125';
 UPDATE wnplts SET fk_7gem_code = 1771 WHERE identif = '1126';
 UPDATE wnplts SET fk_7gem_code = 1771 WHERE identif = '1127';
@@ -48,7 +48,6 @@ UPDATE wnplts SET fk_7gem_code = 687 WHERE identif = '1008';
 UPDATE wnplts SET fk_7gem_code = 687 WHERE identif = '1009';
 UPDATE wnplts SET fk_7gem_code = 777 WHERE identif = '1010';
 UPDATE wnplts SET fk_7gem_code = 406 WHERE identif = '1011';
-UPDATE wnplts SET fk_7gem_code = 457 WHERE identif = '1012';
 UPDATE wnplts SET fk_7gem_code = 342 WHERE identif = '1013';
 UPDATE wnplts SET fk_7gem_code = 342 WHERE identif = '1014';
 UPDATE wnplts SET fk_7gem_code = 622 WHERE identif = '1015';
@@ -2513,7 +2512,6 @@ UPDATE wnplts SET fk_7gem_code = 1978 WHERE identif = '3627';
 UPDATE wnplts SET fk_7gem_code = 1978 WHERE identif = '3628';
 UPDATE wnplts SET fk_7gem_code = 175 WHERE identif = '3629';
 UPDATE wnplts SET fk_7gem_code = 175 WHERE identif = '3630';
-UPDATE wnplts SET fk_7gem_code = 457 WHERE identif = '3631';
 UPDATE wnplts SET fk_7gem_code = 1942 WHERE identif = '3632';
 UPDATE wnplts SET fk_7gem_code = 1699 WHERE identif = '3633';
 UPDATE wnplts SET fk_7gem_code = 1699 WHERE identif = '3634';
@@ -2570,6 +2568,8 @@ UPDATE wnplts SET fk_7gem_code = 93 WHERE identif = '2621';
 UPDATE wnplts SET fk_7gem_code = 1966 WHERE identif = '3484';
 UPDATE wnplts SET fk_7gem_code = 74 WHERE identif = '3558';
 UPDATE wnplts SET fk_7gem_code = 166 WHERE identif = '3559';
+UPDATE wnplts SET fk_7gem_code = 363 WHERE identif = '3631';
+UPDATE wnplts SET fk_7gem_code = 363 WHERE identif = '1012';
 UPDATE wnplts SET fk_7gem_code = 1991 WHERE identif = '1849';
 UPDATE wnplts SET fk_7gem_code = 1991 WHERE identif = '1848';
 UPDATE wnplts SET fk_7gem_code = 1991 WHERE identif = '1852';


### PR DESCRIPTION
# Wijzigingen
Met ingang van 24 maart 2022
- Weesp (457) gaat op in gemeente Amsterdam (363).

## aangepast
- [x] update `120_vervallen_gemeenten.sql` on gemeente tabel bij te werken (resolves BRMO-110)
- [x] update `201_update_wnplts_gemcode.sql` om gemeente / woonplaats koppeling bij te werken (resolves BRMO-134)
 
# instructies

- Voer de het SQL script `120_vervallen_gemeenten.sql` uit in de RSGB database om de gemeentelijke herindelingen tot en met 24 maart 2022 te verwerken
- Voer de het SQL script `201_update_wnplts_gemcode.sql` uit in de RSGB database om de gemeente / woonplaats koppeling bij te werken

## Bestanden
Scripts voor de verschillende database smaken

### PostgreSQL
- https://github.com/B3Partners/brmo/blob/master/datamodel/utility_scripts/postgresql/120_vervallen_gemeenten.sql
- https://github.com/B3Partners/brmo/blob/master/datamodel/utility_scripts/postgresql/201_update_wnplts_gemcode.sql

### Oracle
- https://github.com/B3Partners/brmo/blob/master/datamodel/utility_scripts/oracle/120_vervallen_gemeenten.sql
- https://github.com/B3Partners/brmo/blob/master/datamodel/utility_scripts/oracle/201_update_wnplts_gemcode.sql

### SQL Server
- https://github.com/B3Partners/brmo/blob/master/datamodel/utility_scripts/sqlserver/120_vervallen_gemeenten.sql
- https://github.com/B3Partners/brmo/blob/master/datamodel/utility_scripts/sqlserver/201_update_wnplts_gemcode.sql


