### PR TITLE
Bump geotools.version 26.3 ➜ 26.4

### DIFF
--- a/.mvn/owasp-suppression.xml
+++ b/.mvn/owasp-suppression.xml
@@ -89,4 +89,11 @@
         <packageUrl regex="true">^pkg:maven/(?!org\.apache\.james/).*$</packageUrl>
         <cpe>cpe:/a:apache:james</cpe>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   any GeoTools 26.4 artifact is not CDE
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.geotools[.a-z]*/[a-z]+[.]?[-a-z0-9]*[.]?[-a-z]*\@26\.4$</packageUrl>
+        <cpe>cpe:/a:cde:cde</cpe>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <hibernate.version>5.6.7.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
-        <geotools.version>26.3</geotools.version>
-        <jdbc-util.version>11.3</jdbc-util.version>
+        <geotools.version>26.4</geotools.version>
+        <jdbc-util.version>11.4</jdbc-util.version>
         <jts.version>1.18.2</jts.version>
         <itextpdf.version>7.2.2</itextpdf.version>
         <postgresql.jdbc.version>42.3.3</postgresql.jdbc.version>


### PR DESCRIPTION
en update jdbc-util.version 11.3 ➜ 11.4-SNAPSHOT

en negeer false positive foor CDE op GeoTools 26.4 artifacten, zie ook  https://github.com/jeremylong/DependencyCheck/issues/4348#issuecomment-1096519200

depends: 
- [x] https://github.com/B3Partners/jdbc-util/pull/310