### PR TITLE
Migratie bestanden aanmaken voor upgrade 2.2.2-2.3.0

### DIFF
--- a/.build/ci/getlastRelease.sh
+++ b/.build/ci/getlastRelease.sh
@@ -7,10 +7,10 @@ MINOR="${NEXTRELEASE##*.}"
 PREVMINOR=$(($MINOR-1))
 PREVRELEASE=$MAJOR.$PREVMINOR
 
-#if [ $CURSNAPSHOT = "2.2.0-SNAPSHOT" ]
-#then
-#    PREVRELEASE="2.1.0"
-#fi
+if [ $CURSNAPSHOT = "2.3.0-SNAPSHOT" ]
+then
+    PREVRELEASE="2.2.2"
+fi
 echo "Huidige snapshot:" $CURSNAPSHOT", vorige, te downloaden, release: "$PREVRELEASE", komende release: "$NEXTRELEASE
 
 REMOTE_FILE="https://repo.b3p.nl/nexus/repository/public/nl/b3p/brmo-dist/${PREVRELEASE}/brmo-dist-${PREVRELEASE}-bin.zip"

--- a/.build/ci/oracle-execute-upgrades.sh
+++ b/.build/ci/oracle-execute-upgrades.sh
@@ -7,10 +7,10 @@ MINOR="${NEXTRELEASE##*.}"
 PREVMINOR=$(($MINOR-1))
 PREVRELEASE=$MAJOR.$PREVMINOR
 
-#if [ $CURSNAPSHOT = "2.2.0-SNAPSHOT" ]
-#then
-#    PREVRELEASE="2.1.0"
-#fi
+if [ $CURSNAPSHOT = "2.3.0-SNAPSHOT" ]
+then
+    PREVRELEASE="2.2.2"
+fi
 
 echo "Huidige snapshot:" $CURSNAPSHOT", vorige release: "$PREVRELEASE", komende release: "$NEXTRELEASE
 echo "Verwerk upgrade script voor:" $1

--- a/.build/ci/pgsql-execute-upgrades.sh
+++ b/.build/ci/pgsql-execute-upgrades.sh
@@ -7,10 +7,10 @@ MINOR="${NEXTRELEASE##*.}"
 PREVMINOR=$(($MINOR-1))
 PREVRELEASE=$MAJOR.$PREVMINOR
 
-#if [ $CURSNAPSHOT = "2.2.0-SNAPSHOT" ]
-#then
-#    PREVRELEASE="2.1.0"
-#fi
+if [ $CURSNAPSHOT = "2.3.0-SNAPSHOT" ]
+then
+    PREVRELEASE="2.2.2"
+fi
 
 echo "Huidige snapshot:" $CURSNAPSHOT", vorige release: "$PREVRELEASE", komende release: "$NEXTRELEASE
 echo "Verwerk upgrade script voor: " $1

--- a/.jenkins/execute-upgrades-oracle.sh
+++ b/.jenkins/execute-upgrades-oracle.sh
@@ -6,10 +6,10 @@ MINOR="${NEXTRELEASE##*.}"
 PREVMINOR=$(($MINOR-1))
 PREVRELEASE=$MAJOR.$PREVMINOR
 
-#if [ $CURSNAPSHOT = "2.2.0-SNAPSHOT" ]
-#then
-#    PREVRELEASE="2.1.0"
-#fi
+if [ $CURSNAPSHOT = "2.3.0-SNAPSHOT" ]
+then
+    PREVRELEASE="2.2.2"
+fi
 
 echo "Huidige snapshot:" $CURSNAPSHOT", vorige release: "$PREVRELEASE", komende release: "$NEXTRELEASE
 echo "Verwerk upgrade script voor: " $1

--- a/datamodel/src/test/java/nl/b3p/brmo/datamodel/DatabaseUpgradeTest.java
+++ b/datamodel/src/test/java/nl/b3p/brmo/datamodel/DatabaseUpgradeTest.java
@@ -92,9 +92,9 @@ public class DatabaseUpgradeTest {
         LOG.debug("release patch is: " + patch);
         previousRelease = nextRelease.substring(0, nextRelease.lastIndexOf(".")) + "." + (patch - 1);
         // HACK voor bump
-//        if (nextRelease.equalsIgnoreCase("2.2.0")){
-//            previousRelease = "2.1.0";
-//        }
+        if (nextRelease.equalsIgnoreCase("2.3.0")){
+            previousRelease = "2.2.2";
+        }
         LOG.debug("vorige release is: " + previousRelease);
 
         assumeTrue(previousRelease.matches("(\\d+\\.)(\\d+\\.)(\\d)"));

--- a/datamodel/src/test/java/nl/b3p/brmo/datamodel/P8RestAPIIntegrationTest.java
+++ b/datamodel/src/test/java/nl/b3p/brmo/datamodel/P8RestAPIIntegrationTest.java
@@ -37,7 +37,7 @@ import static org.hamcrest.Matchers.equalTo;
  * testcases om te kijken of we de P8 rest api niet stuk maken als er iets aan de views wordt geleuteld.
  * In deze integratie test alleen de niet-data specifieke endpoints testen.
  * <p>
- * deze test los draaien met: {@code mvn -Dit.test=P8RestAPIIntegrationTest verify -Pp8}
+ * deze test los draaien met: {@code mvn -Dit.test=P8RestAPIIntegrationTest verify -Pp8 -pl :datamodel}
  *
  * @author mark
  */

--- a/datamodel/src/test/java/nl/b3p/brmo/datamodel/P8ServicesIntegrationTest.java
+++ b/datamodel/src/test/java/nl/b3p/brmo/datamodel/P8ServicesIntegrationTest.java
@@ -30,7 +30,9 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.sql.SQLException;
 
-import static net.javacrumbs.jsonunit.JsonAssert.*;
+import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
+import static net.javacrumbs.jsonunit.JsonAssert.when;
+import static net.javacrumbs.jsonunit.JsonAssert.whenIgnoringPaths;
 import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -40,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * testcases om te kijken of we de P8 rest api niet stuk maken als er iets aan de views wordt geleuteld.
  * We testen alleen PostgreSQL.
  * <p>
- * deze test los draaien met: {@code mvn -Dit.test=P8ServicesIntegrationTest -Dtest.onlyITs=true verify -Pp8}
+ * deze test los draaien met: {@code mvn -Dit.test=P8ServicesIntegrationTest -Dtest.onlyITs=true verify -Pp8 -pl :datamodel}
  * <p>
  * <strong>Door een bug in de P8 api wordt het tijdstip (GMT) van uitvragen toegevoegd aan de datum begin geldigheid,
  * daarom wordt op een aantal plaatsen de datum niet gechecked</strong>
@@ -96,14 +98,18 @@ public class P8ServicesIntegrationTest extends P8TestFramework {
         assertJsonEquals(
                 "{\"kadastrale_percelen\":[{\"kadastrale_code\":\"VDG00B1708\",\"gemeente_code\":\"VDG00\"," +
                         "\"sectie\":\"B\",\"perceelnummer\":1708,\"oppervlakte\":65,\"straat\":\"Oosterstraat\"," +
-                        "\"huisnummer\":\"33\",\"postcode\":\"3134NM\",\"woonplaats\":\"Vlaardingen\"," +
-                        "\"percnr17\":\"VDG00B1708\"},{\"kadastrale_code\":\"VDG00B1708\"," +
-                        "\"gemeente_code\":\"VDG00\",\"sectie\":\"B\",\"perceelnummer\":1708,\"oppervlakte\":65," +
-                        "\"straat\":\"Oosterstraat\",\"huisnummer\":\"35\",\"postcode\":\"3134NM\"," +
-                        "\"woonplaats\":\"Vlaardingen\",\"percnr17\":\"VDG00B1708\"}," +
-                        "{\"kadastrale_code\":\"VDG00B1709\",\"gemeente_code\":\"VDG00\",\"sectie\":\"B\"," +
-                        "\"perceelnummer\":1709,\"oppervlakte\":65,\"straat\":\"Oosterstraat\",\"huisnummer\":\"29\"," +
-                        "\"postcode\":\"3134NM\",\"woonplaats\":\"Vlaardingen\",\"percnr17\":\"VDG00B1709\"}]," +
+                        "\"huisnummer\":\"33\",\"postcode\":\"3134NM\",\"woonplaats\":\"Vlaardingen\",\"percnr17\":" +
+                        "\"VDG00B1708\",\"omschrijving\":\"OOSTERSTR 33, 3134NM VLAARDINGEN  (1 meer adressen)\"," +
+                        "\"bedrag\":\"\",\"koopjaar\":\"\",\"valuta\":\"\",\"soortgrootte\":\"1\"}," +
+                        "{\"kadastrale_code\":\"VDG00B1708\",\"gemeente_code\":\"VDG00\",\"sectie\":\"B\"," +
+                        "\"perceelnummer\":1708,\"oppervlakte\":65,\"straat\":\"Oosterstraat\",\"huisnummer\":\"35\"," +
+                        "\"postcode\":\"3134NM\",\"woonplaats\":\"Vlaardingen\",\"percnr17\":\"VDG00B1708\"," +
+                        "\"omschrijving\":\"OOSTERSTR 33, 3134NM VLAARDINGEN  (1 meer adressen)\",\"bedrag\":\"\"," +
+                        "\"koopjaar\":\"\",\"valuta\":\"\",\"soortgrootte\":\"1\"},{\"kadastrale_code\":\"VDG00B1709\"," +
+                        "\"gemeente_code\":\"VDG00\",\"sectie\":\"B\",\"perceelnummer\":1709,\"oppervlakte\":65," +
+                        "\"straat\":\"Oosterstraat\",\"huisnummer\":\"29\",\"postcode\":\"3134NM\",\"woonplaats\":" +
+                        "Vlaardingen\",\"percnr17\":\"VDG00B1709\",\"omschrijving\":\"OOSTERSTR 29, 3134NM VLAARDINGEN\"," +
+                        "\"bedrag\":\"192500\",\"koopjaar\":\"2003\",\"valuta\":\"Euro\",\"soortgrootte\":\"1\"}]," +
                         "\"offset\":\"0\",\"limit\":\"3\",\"total_item_count\":1000}",
                 body,
                 when(IGNORING_ARRAY_ORDER)
@@ -126,28 +132,25 @@ public class P8ServicesIntegrationTest extends P8TestFramework {
         assertNotNull(body, "Response body mag niet null zijn.");
         assertJsonEquals(
                 "{\"kadastrale_code\":\"VDG00B1708\",\"gemeente_code\":\"VDG00\",\"sectie\":\"B\"," +
-                        "\"perceelnummer\":1708,\"oppervlakte\":65,\"adres\":\"OOSTERSTR 33, 3134NM VLAARDINGEN  (1 " +
-                        "meer adressen)\",\"postcode\":\"3134NM\",\"woonplaats\":\"Vlaardingen\"," +
-                        "\"gemeente\":\"Vlaardingen\",\"geom\":\"MULTIPOLYGON (((83442.009 435842.213, 83445.535 " +
-                        "435831.176, 83451.303 435833.022, 83447.831 435844.075, 83442.009 435842.213)))\"," +
-                        "\"rechten\":[{\"subject\":{\"naam\":\"5a063d4c 251bf\",\"type\":\"perceel\"," +
-                        "\"persoonid\":\"NL.KAD.Persoon.157125580\",\"woonplaats\":\"Vlaardingen\"}," +
-                        "\"aandeel\":\"1\\/1\",\"recht_soort\":\"Erfpacht (recht van)\"," +
-                        "\"datum_ingang\":\"2012-12-31T11:51:50+00:00\"},{\"subject\":{\"naam\":\"Gemeente " +
-                        "Vlaardingen (Kad Gem Vlaardingen Sectie B)\",\"type\":\"perceel\",\"persoonid\":\"NL.KAD" +
-                        ".Persoon.159287767\",\"woonplaats\":\"Vlaardingen\"},\"aandeel\":\"1\\/1\"," +
-                        "\"recht_soort\":\"Eigendom (recht van)\",\"datum_ingang\":\"2012-12-31T11:51:50+00:00\"}," +
-                        "{\"subject\":{\"naam\":\"5a063d4c 251bf\",\"type\":\"perceel\",\"persoonid\":\"NL.KAD" +
-                        ".Persoon.157125580\",\"woonplaats\":\"Vlaardingen\"},\"aandeel\":\"1\\/1\"," +
-                        "\"recht_soort\":\"Erfpacht (recht van)\",\"datum_ingang\":\"2012-12-31T11:51:50+00:00\"}," +
-                        "{\"subject\":{\"naam\":\"Gemeente Vlaardingen (Kad Gem Vlaardingen Sectie B)\"," +
-                        "\"type\":\"perceel\",\"persoonid\":\"NL.KAD.Persoon.159287767\"," +
-                        "\"woonplaats\":\"Vlaardingen\"},\"aandeel\":\"1\\/1\",\"recht_soort\":\"Eigendom (recht van)" +
-                        "\",\"datum_ingang\":\"2012-12-31T11:51:50+00:00\"}]," +
-                        "\"adressen\":[{\"woonplaats\":\"Vlaardingen\",\"straat\":\"Oosterstraat\"," +
-                        "\"postcode\":\"3134NM\",\"huisnummer\":\"33\",\"postadres\":false}," +
-                        "{\"woonplaats\":\"Vlaardingen\",\"straat\":\"Oosterstraat\",\"postcode\":\"3134NM\"," +
-                        "\"huisnummer\":\"35\",\"postadres\":false}]}",
+                        "\"perceelnummer\":1708,\"oppervlakte\":65,\"adres\":\"OOSTERSTR 33, 3134NM VLAARDINGEN  (1 meer adressen)\"" +
+                        ",\"postcode\":\"3134NM\",\"woonplaats\":\"Vlaardingen\",\"gemeente\":\"Vlaardingen\"," +
+                        "\"geom\":\"MULTIPOLYGON (((83442.009 435842.213, 83445.535 435831.176, 83451.303 435833.022, 83447.831 435844.075, 83442.009 435842.213)))\"," +
+                        "\"omschrijving\":\"OOSTERSTR 33, 3134NM VLAARDINGEN  (1 meer adressen)\",\"bedrag\":\"\"," +
+                        "\"koopjaar\":\"\",\"valuta\":\"\",\"soortgrootte\":\"1\",\"rechten\":[{\"subject\":{\"naam\":" +
+                        "\"5a063d4c 251bf\",\"type\":\"perceel\",\"persoonid\":\"NL.KAD.Persoon.157125580\",\"woonplaats\"" +
+                        ":\"Vlaardingen\"},\"aandeel\":\"1\\/1\",\"recht_soort\":\"Erfpacht (recht van)\",\"datum_ingang\"" +
+                        ":\"2012-12-31T13:48:28+00:00\"},{\"subject\":{\"naam\":\"Gemeente Vlaardingen (Kad Gem Vlaardingen Sectie B)\"," +
+                        "\"type\":\"perceel\",\"persoonid\":\"NL.KAD.Persoon.159287767\",\"woonplaats\":\"Vlaardingen\"}," +
+                        "\"aandeel\":\"1\\/1\",\"recht_soort\":\"Eigendom (recht van)\",\"datum_ingang\":\"2012-12-31T13:48:28+00:00\"}," +
+                        "{\"subject\":{\"naam\":\"5a063d4c 251bf\",\"type\":\"perceel\",\"persoonid\":\"NL.KAD.Persoon.157125580\"," +
+                        "\"woonplaats\":\"Vlaardingen\"},\"aandeel\":\"1\\/1\",\"recht_soort\":\"Erfpacht (recht van)\"," +
+                        "\"datum_ingang\":\"2012-12-31T13:48:28+00:00\"},{\"subject\":{\"naam\":\"Gemeente Vlaardingen (Kad Gem Vlaardingen Sectie B)\"," +
+                        "\"type\":\"perceel\",\"persoonid\":\"NL.KAD.Persoon.159287767\",\"woonplaats\":\"Vlaardingen\"}," +
+                        "\"aandeel\":\"1\\/1\",\"recht_soort\":\"Eigendom (recht van)\",\"datum_ingang\":" +
+                        "\"2012-12-31T13:48:28+00:00\"}],\"adressen\":[{\"woonplaats\":\"Vlaardingen\",\"straat\":" +
+                        "\"Oosterstraat\",\"postcode\":\"3134NM\",\"huisnummer\":\"33\",\"postadres\":false},{\"woonplaats\":" +
+                        "\"Vlaardingen\",\"straat\":\"Oosterstraat\",\"postcode\":\"3134NM\",\"huisnummer\":\"35\"," +
+                        "\"postadres\":false}]}",
                 body,
                 //when(IGNORING_ARRAY_ORDER),
                 whenIgnoringPaths("rechten[*].datum_ingang")
@@ -168,7 +171,18 @@ public class P8ServicesIntegrationTest extends P8TestFramework {
         assertThat("Response status is OK.", response.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
         assertNotNull(body, "Response body mag niet null zijn.");
         assertJsonEquals(
-                "{\"kadastrale_percelen\":[{\"kadastrale_code\":\"VDG00B1708\",\"gemeente_code\":\"VDG00\",\"sectie\":\"B\",\"perceelnummer\":1708,\"oppervlakte\":65,\"straat\":\"Oosterstraat\",\"huisnummer\":\"33\",\"postcode\":\"3134NM\",\"woonplaats\":\"Vlaardingen\",\"percnr17\":\"VDG00B1708\"},{\"kadastrale_code\":\"VDG00B1708\",\"gemeente_code\":\"VDG00\",\"sectie\":\"B\",\"perceelnummer\":1708,\"oppervlakte\":65,\"straat\":\"Oosterstraat\",\"huisnummer\":\"35\",\"postcode\":\"3134NM\",\"woonplaats\":\"Vlaardingen\",\"percnr17\":\"VDG00B1708\"},{\"kadastrale_code\":\"VDG00B1709\",\"gemeente_code\":\"VDG00\",\"sectie\":\"B\",\"perceelnummer\":1709,\"oppervlakte\":65,\"straat\":\"Oosterstraat\",\"huisnummer\":\"29\",\"postcode\":\"3134NM\",\"woonplaats\":\"Vlaardingen\",\"percnr17\":\"VDG00B1709\"}],\"offset\":\"0\",\"limit\":\"3\",\"total_item_count\":1000}",
+                "{\"kadastrale_percelen\":[{\"kadastrale_code\":\"VDG00B1708\",\"gemeente_code\":\"VDG00\"," +
+                "\"sectie\":\"B\",\"perceelnummer\":1708,\"oppervlakte\":65,\"straat\":\"Oosterstraat\",\"huisnummer\":\"33\"," +
+                "\"postcode\":\"3134NM\",\"woonplaats\":\"Vlaardingen\",\"percnr17\":\"VDG00B1708\",\"omschrijving\":" +
+                "\"OOSTERSTR 33, 3134NM VLAARDINGEN  (1 meer adressen)\",\"bedrag\":\"\",\"koopjaar\":\"\",\"valuta\":\"\"," +
+                "\"soortgrootte\":\"1\"},{\"kadastrale_code\":\"VDG00B1708\",\"gemeente_code\":\"VDG00\",\"sectie\":\"B\"," +
+                "\"perceelnummer\":1708,\"oppervlakte\":65,\"straat\":\"Oosterstraat\",\"huisnummer\":\"35\",\"postcode\":\"3134NM\"," +
+                "\"woonplaats\":\"Vlaardingen\",\"percnr17\":\"VDG00B1708\",\"omschrijving\":" +
+                "\"OOSTERSTR 33, 3134NM VLAARDINGEN  (1 meer adressen)\",\"bedrag\":\"\",\"koopjaar\":\"\",\"valuta\":\"\"," +
+                "\"soortgrootte\":\"1\"},{\"kadastrale_code\":\"VDG00B1709\",\"gemeente_code\":\"VDG00\",\"sectie\":\"B\"," +
+                "\"perceelnummer\":1709,\"oppervlakte\":65,\"straat\":\"Oosterstraat\",\"huisnummer\":\"29\",\"postcode\":\"3134NM\"," +
+                "\"woonplaats\":\"Vlaardingen\",\"percnr17\":\"VDG00B1709\",\"omschrijving\":\"OOSTERSTR 29, 3134NM VLAARDINGEN\"," +
+                "\"bedrag\":\"192500\",\"koopjaar\":\"2003\",\"valuta\":\"Euro\",\"soortgrootte\":\"1\"}],\"offset\":\"0\",\"limit\":\"3\",\"total_item_count\":1000}",
                 body,
                 when(IGNORING_ARRAY_ORDER)
         );
@@ -190,14 +204,13 @@ public class P8ServicesIntegrationTest extends P8TestFramework {
         assertNotNull(body, "Response body mag niet null zijn.");
         assertJsonEquals(
                 "{\"kadastrale_percelen\":[{\"kadastrale_code\":\"VDG00B1712\",\"gemeente_code\":\"VDG00\"," +
-                        "\"sectie\":\"B\",\"perceelnummer\":1712,\"oppervlakte\":68,\"percnr17\":\"VDG00B1712\"," +
-                        "\"aandeel\":\"1\\/2\",\"rechtsoort\":\"Erfpacht (recht van)\"," +
-                        "\"datum_ingang\":\"2012-12-31T11:54:49+00:00\"}],\"offset\":\"0\",\"limit\":\"3\"," +
-                        "\"total_item_count\":1}",
+                        "\"sectie\":\"B\",\"perceelnummer\":1712,\"oppervlakte\":68,\"percnr17\":\"VDG00B1712\",\"aandeel\":\"1\\/2\"," +
+                        "\"rechtsoort\":\"Erfpacht (recht van)\",\"datum_ingang\":\"2012-12-31T13:49:09+00:00\"}],\"offset\":\"0\"," +
+                        "\"limit\":\"3\",\"total_item_count\":1}",
                 body
                 // when(IGNORING_ARRAY_ORDER)
                 // TODO bug in P8; verzint een tijdstip aan datums
-                ,whenIgnoringPaths("kadastrale_percelen[0].datum_ingang")
+                , whenIgnoringPaths("kadastrale_percelen[0].datum_ingang")
 
         );
     }
@@ -215,7 +228,10 @@ public class P8ServicesIntegrationTest extends P8TestFramework {
         assertThat("Response status is OK.", response.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
         assertNotNull(body, "Response body mag niet null zijn.");
         assertJsonEquals(
-                "{\"subjectid\":\"NL.KAD.Persoon.157450463\",\"type\":\"KadastraalNatuurlijkSubject\",\"adres\":\"Oosterstraat 17, 3134NM VLAARDINGEN\",\"natuurlijk_subject\":{\"voornaam\":\"d941\",\"achternaam\":\"abda6a2\",\"geslacht\":\"M\",\"geboorte_datum\":\"1964-01-09T09:07:45+00:00\",\"geboorte_plaats\":\"4379c2\"}}",
+                "{\"subjectid\":\"NL.KAD.Persoon.157450463\",\"type\":\"KadastraalNatuurlijkSubject\"," +
+                        "\"adres\":\"Oosterstraat 17, 3134NM VLAARDINGEN\",\"natuurlijk_subject\":{\"voornaam\":\"d941\"," +
+                        "\"achternaam\":\"abda6a2\",\"geslacht\":\"M\",\"geboorte_datum\":\"1964-01-09T13:49:22+00:00\"," +
+                        "\"geboorte_plaats\":\"4379c2\"}}",
                 body,
                 // TODO bug in P8; verzint een tijdstip aan datums
                 whenIgnoringPaths("natuurlijk_subject.geboorte_datum")
@@ -235,8 +251,13 @@ public class P8ServicesIntegrationTest extends P8TestFramework {
         LOG.debug("antwoord: " + body);
         assertThat("Response status is OK.", response.getStatusLine().getStatusCode(), equalTo(HttpStatus.SC_OK));
         assertNotNull(body, "Response body mag niet null zijn.");
-        assertJsonEquals(
-                "{\"subjecten\":[{\"subjectid\":\"NL.KAD.Persoon.158819809\",\"voornamen\":\"7efe9\",\"achternaam\":\"ec3e8\",\"geslacht\":\"V\",\"adres\":\"\"},{\"subjectid\":\"NL.KAD.Persoon.157125580\",\"voornamen\":\"5a063d4c\",\"achternaam\":\"251bf\",\"geslacht\":\"M\",\"geboorte_datum\":{},\"adres\":\"Oosterstraat 35, 3134NM VLAARDINGEN\"},{\"subjectid\":\"NL.KAD.Persoon.158911578\",\"voornamen\":\"73427d 7345\",\"achternaam\":\"11fba2\",\"geslacht\":\"M\",\"geboorte_datum\":{},\"adres\":\"van der Waalsstraat 86, 3132TN VLAARDINGEN\"}],\"offset\":\"0\",\"limit\":\"3\",\"total_item_count\":1000}",
+        assertJsonEquals("{\"subjecten\":[{\"subjectid\":\"NL.KAD.Persoon.158819809\",\"voornamen\":\"7efe9\"," +
+                "\"achternaam\":\"ec3e8\",\"geslacht\":\"V\",\"adres\":\"\"},{\"subjectid\":\"NL.KAD.Persoon.157125580\"," +
+                "\"voornamen\":\"5a063d4c\",\"achternaam\":\"251bf\",\"geslacht\":\"M\",\"geboorte_datum\":{}," +
+                "\"adres\":\"Oosterstraat 35, 3134NM VLAARDINGEN\"},{\"subjectid\":\"NL.KAD.Persoon.158911578\"," +
+                "\"voornamen\":\"73427d 7345\",\"achternaam\":\"11fba2\",\"geslacht\":\"M\",\"geboorte_datum\":{}," +
+                "\"adres\":\"van der Waalsstraat 86, 3132TN VLAARDINGEN\"}],\"offset\":\"0\",\"limit\":\"3\"," +
+                "\"total_item_count\":1000}",
                 body,
                 when(IGNORING_ARRAY_ORDER)
         );

--- a/datamodel/upgrade_scripts/2.2.2-2.3.0/oracle/bag.sql
+++ b/datamodel/upgrade_scripts/2.2.2-2.3.0/oracle/bag.sql
@@ -1,0 +1,23 @@
+-- 
+-- upgrade Oracle BAG datamodel van 2.2.2 naar 2.3.0 
+--
+
+WHENEVER SQLERROR EXIT SQL.SQLCODE
+BEGIN
+    EXECUTE IMMEDIATE 'CREATE TABLE brmo_metadata(naam VARCHAR2(255 CHAR) NOT NULL, waarde CLOB, PRIMARY KEY (naam))';
+EXCEPTION
+WHEN OTHERS THEN
+IF
+    SQLCODE = -955 THEN
+    NULL;
+ELSE RAISE;
+END IF;
+END;
+/
+MERGE INTO brmo_metadata USING DUAL ON (naam = 'brmoversie') WHEN NOT MATCHED THEN INSERT (naam) VALUES('brmoversie');
+
+
+-- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
+INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.2_naar_2.3.0','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';
+-- versienummer update
+UPDATE brmo_metadata SET waarde='2.3.0' WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/2.2.2-2.3.0/oracle/rsgb.sql
+++ b/datamodel/upgrade_scripts/2.2.2-2.3.0/oracle/rsgb.sql
@@ -1,0 +1,11 @@
+-- 
+-- upgrade Oracle RSGB datamodel van 2.2.2 naar 2.3.0 
+--
+
+WHENEVER SQLERROR EXIT SQL.SQLCODE
+
+
+-- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
+INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.2_naar_2.3.0','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';
+-- versienummer update
+UPDATE brmo_metadata SET waarde='2.3.0' WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/2.2.2-2.3.0/oracle/rsgbbgt.sql
+++ b/datamodel/upgrade_scripts/2.2.2-2.3.0/oracle/rsgbbgt.sql
@@ -1,0 +1,23 @@
+-- 
+-- upgrade Oracle RSGBBGT datamodel van 2.2.2 naar 2.3.0 
+--
+
+WHENEVER SQLERROR EXIT SQL.SQLCODE
+BEGIN
+    EXECUTE IMMEDIATE 'CREATE TABLE brmo_metadata(naam VARCHAR2(255 CHAR) NOT NULL, waarde CLOB, PRIMARY KEY (naam))';
+EXCEPTION
+WHEN OTHERS THEN
+IF
+    SQLCODE = -955 THEN
+    NULL;
+ELSE RAISE;
+END IF;
+END;
+/
+MERGE INTO brmo_metadata USING DUAL ON (naam = 'brmoversie') WHEN NOT MATCHED THEN INSERT (naam) VALUES('brmoversie');
+
+
+-- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
+INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.2_naar_2.3.0','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';
+-- versienummer update
+UPDATE brmo_metadata SET waarde='2.3.0' WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/2.2.2-2.3.0/oracle/staging.sql
+++ b/datamodel/upgrade_scripts/2.2.2-2.3.0/oracle/staging.sql
@@ -1,0 +1,11 @@
+-- 
+-- upgrade Oracle STAGING datamodel van 2.2.2 naar 2.3.0 
+--
+
+WHENEVER SQLERROR EXIT SQL.SQLCODE
+
+
+-- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
+INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.2_naar_2.3.0','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';
+-- versienummer update
+UPDATE brmo_metadata SET waarde='2.3.0' WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/2.2.2-2.3.0/postgresql/bag.sql
+++ b/datamodel/upgrade_scripts/2.2.2-2.3.0/postgresql/bag.sql
@@ -1,0 +1,13 @@
+-- 
+-- upgrade PostgreSQL BAG datamodel van 2.2.2 naar 2.3.0 
+--
+
+CREATE SCHEMA IF NOT EXISTS bag;
+
+SET search_path = bag,public;
+
+
+-- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
+INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.2_naar_2.3.0','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';
+-- versienummer update
+UPDATE brmo_metadata SET waarde='2.3.0' WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/2.2.2-2.3.0/postgresql/rsgb.sql
+++ b/datamodel/upgrade_scripts/2.2.2-2.3.0/postgresql/rsgb.sql
@@ -1,0 +1,11 @@
+-- 
+-- upgrade PostgreSQL RSGB datamodel van 2.2.2 naar 2.3.0 
+--
+
+set search_path = public,bag;
+
+
+-- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
+INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.2_naar_2.3.0','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';
+-- versienummer update
+UPDATE brmo_metadata SET waarde='2.3.0' WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/2.2.2-2.3.0/postgresql/rsgbbgt.sql
+++ b/datamodel/upgrade_scripts/2.2.2-2.3.0/postgresql/rsgbbgt.sql
@@ -1,0 +1,12 @@
+-- 
+-- upgrade PostgreSQL RSGBBGT datamodel van 2.2.2 naar 2.3.0 
+--
+
+CREATE TABLE IF NOT EXISTS brmo_metadata(naam CHARACTER VARYING(255) NOT NULL, waarde TEXT, CONSTRAINT brmo_metadata_pk PRIMARY KEY (naam));
+INSERT INTO brmo_metadata(naam) VALUES('brmoversie') ON CONFLICT DO NOTHING;
+
+
+-- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
+INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.2_naar_2.3.0','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';
+-- versienummer update
+UPDATE brmo_metadata SET waarde='2.3.0' WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/2.2.2-2.3.0/postgresql/staging.sql
+++ b/datamodel/upgrade_scripts/2.2.2-2.3.0/postgresql/staging.sql
@@ -1,0 +1,9 @@
+-- 
+-- upgrade PostgreSQL STAGING datamodel van 2.2.2 naar 2.3.0 
+--
+
+
+-- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
+INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.2_naar_2.3.0','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';
+-- versienummer update
+UPDATE brmo_metadata SET waarde='2.3.0' WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/new-version-upgrades.sh
+++ b/datamodel/upgrade_scripts/new-version-upgrades.sh
@@ -73,4 +73,4 @@ done
 
 
 git add "$PREVRELEASE-$NEXTRELEASE"/
-# git commit -m "Migratie bestanden aanmaken voor upgrade $PREVRELEASE-$NEXTRELEASE"
+git commit -m "Migratie bestanden aanmaken voor upgrade $PREVRELEASE-$NEXTRELEASE"

--- a/datamodel/upgrade_scripts/new-version-upgrades.sh
+++ b/datamodel/upgrade_scripts/new-version-upgrades.sh
@@ -16,9 +16,9 @@ PREVRELEASE=$MAJOR.$PREVMINOR
 
 echo "Huidige snapshot:" $CURSNAPSHOT", vorige release: "$PREVRELEASE", komende release: "$NEXTRELEASE
 
-mkdir -p "$PREVRELEASE-$NEXTRELEASE"/{oracle,postgresql,sqlserver}
+mkdir -p "$PREVRELEASE-$NEXTRELEASE"/{oracle,postgresql}
 
-for DB in Oracle PostgreSQL SQLserver; do
+for DB in Oracle PostgreSQL; do
   DIR=$PREVRELEASE-$NEXTRELEASE/${DB,,}
   echo Migratie bestanden aanmaken voor $DB in $DIR
   for b in bag rsgb rsgbbgt staging; do
@@ -47,14 +47,6 @@ for DB in Oracle PostgreSQL SQLserver; do
         fi
       fi
 
-      if [ "${DB}" == "SQLserver" ] && [ "${b}" == "rsgbbgt" ]; then
-        # brmo_metadata tabel aanmaken in sqlserver rsgbbgt schema als die niet bestaat
-        echo $'\n'"IF OBJECT_ID('brmo_metadata', 'U') IS NULL" >>$DIR/$b.sql
-        echo $"CREATE TABLE brmo_metadata(naam VARCHAR(255) NOT NULL, waarde NTEXT, PRIMARY KEY (naam));" >>$DIR/$b.sql
-        echo $"GO" >>$DIR/$b.sql
-        echo $"INSERT INTO brmo_metadata(naam) SELECT naam FROM brmo_metadata WHERE NOT('brmoversie' IN (SELECT naam FROM brmo_metadata));" >>$DIR/$b.sql
-      fi
-
       if [ "${DB}" == "PostgreSQL" ]; then
         if [ "${b}" == "rsgbbgt" ]; then
           echo $'\n'"CREATE TABLE IF NOT EXISTS brmo_metadata(naam CHARACTER VARYING(255) NOT NULL, waarde TEXT, CONSTRAINT brmo_metadata_pk PRIMARY KEY (naam));" >>$DIR/$b.sql
@@ -72,21 +64,13 @@ for DB in Oracle PostgreSQL SQLserver; do
       fi
 
       echo $'\n\n'-- onderstaande dienen als laatste stappen van een upgrade uitgevoerd >>$DIR/$b.sql
-      if [ "${DB}" == "SQLserver" ]; then
-        echo "INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_"$PREVRELEASE"_naar_"$NEXTRELEASE"','vorige versie was ' + waarde FROM brmo_metadata WHERE naam='brmoversie';" >>$DIR/$b.sql
-        echo -- versienummer update >>$DIR/$b.sql
-        echo "UPDATE brmo_metadata SET waarde='$NEXTRELEASE' WHERE naam='brmoversie';" >>$DIR/$b.sql
-      else
-        echo "INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_"$PREVRELEASE"_naar_"$NEXTRELEASE"','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';" >>$DIR/$b.sql
-        echo -- versienummer update >>$DIR/$b.sql
-        echo "UPDATE brmo_metadata SET waarde='$NEXTRELEASE' WHERE naam='brmoversie';" >>$DIR/$b.sql
-      fi
+      echo "INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_"$PREVRELEASE"_naar_"$NEXTRELEASE"','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';" >>$DIR/$b.sql
+      echo -- versienummer update >>$DIR/$b.sql
+      echo "UPDATE brmo_metadata SET waarde='$NEXTRELEASE' WHERE naam='brmoversie';" >>$DIR/$b.sql
     fi
   done
 done
 
-# geen ondersteuning voor bag 2 in sql server
-rm $PREVRELEASE-$NEXTRELEASE/sqlserver/bag.sql
 
 git add "$PREVRELEASE-$NEXTRELEASE"/
-git commit -m "Migratie bestanden aanmaken voor upgrade $PREVRELEASE-$NEXTRELEASE"
+# git commit -m "Migratie bestanden aanmaken voor upgrade $PREVRELEASE-$NEXTRELEASE"

--- a/docker/src/main/docker/Dockerfile
+++ b/docker/src/main/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM tomcat:9.0.62-jre11-temurin
 
-ARG BRMO_VERSION="2.2.1-SNAPSHOT"
+ARG BRMO_VERSION="2.3.0-SNAPSHOT"
 ARG MAIL_FROM=brmo-no-reply@b3partners.nl
 ARG MAIL_HOST=mail.b3partners.nl
 ARG AJP_ADDRESS=::1

--- a/docker/src/main/docker/pg_conf/Dockerfile
+++ b/docker/src/main/docker/pg_conf/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgis/postgis:14-3.2-alpine
 
 ARG TZ="Europe/Amsterdam"
-ARG BRMO_VERSION="2.2.1-SNAPSHOT"
+ARG BRMO_VERSION="2.3.0-SNAPSHOT"
 
 # get schema export from tailormap persistence
 RUN set -eux; \

--- a/src/site/markdown/developer-notes.md
+++ b/src/site/markdown/developer-notes.md
@@ -11,7 +11,7 @@ Tevens wordt er om een naam voor een tag gevraagd. In principe kan alle informat
 commandline worden meegegeven, bijvoorbeeld:
 
 ```
-mvn release:prepare -l rel-prepare.log -DautoVersionSubmodules=true -DdevelopmentVersion=1.6.1-SNAPSHOT -DreleaseVersion=1.6.0 -Dtag=v1.6.0 -T1
+mvn release:prepare -l rel-prepare.log -DautoVersionSubmodules=true -DdevelopmentVersion=2.3.1-SNAPSHOT -DreleaseVersion=2.3.0 -Dtag=v2.3.0 -T1
 mvn release:perform -l rel-perform.log
 ```
 


### PR DESCRIPTION
Let op: voor MS SQL Server zijn geen upgrade scripts meer beschikbaar, zie BRMO-168