### PR TITLE
vervang org.codehaus.mojo:jaxb2-maven-plugin door org.jvnet.jaxb2.maven2:maven-jaxb2-plugin

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,9 +18,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-#        , 'zulu'
-        java-dist: [ 'temurin' ]
-        windows: [ 'windows-2019', 'windows-2022' ]
+        windows: [ windows-2019, windows-2022 ]
 
     steps:
       - uses: actions/checkout@v3
@@ -38,7 +36,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: ${{ matrix.java-dist }}
+          distribution: 'zulu'
           java-version: ${{ matrix.java }}
 
       - name: Priming build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,9 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
-        windows: [ windows-2019, windows-2022 ]
+#        , 'zulu'
+        java-dist: [ 'temurin' ]
+        windows: [ 'windows-2019', 'windows-2022' ]
 
     steps:
       - uses: actions/checkout@v3
@@ -36,7 +38,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: ${{ matrix.java-dist }}
           java-version: ${{ matrix.java }}
 
       - name: Priming build

--- a/bag2-loader/pom.xml
+++ b/bag2-loader/pom.xml
@@ -127,19 +127,36 @@ SPDX-License-Identifier: MIT
             </resource>
         </resources>
         <plugins>
+            <!--            <plugin>-->
+            <!--            deze plugin is stuk op Windows met Java 11.0.15, zie oa. https://stackoverflow.com/questions/71956115 -->
+            <!--                <groupId>org.codehaus.mojo</groupId>-->
+            <!--                <artifactId>jaxb2-maven-plugin</artifactId>-->
+            <!--                <executions>-->
+            <!--                    <execution>-->
+            <!--                        <id>xjc</id>-->
+            <!--                        <goals>-->
+            <!--                            <goal>xjc</goal>-->
+            <!--                        </goals>-->
+            <!--                    </execution>-->
+            <!--                </executions>-->
+            <!--                <configuration>-->
+            <!--                    <packageName>nl.b3p.brmo.bag2.xml.leveringsdocument</packageName>-->
+            <!--                </configuration>-->
+            <!--            </plugin>-->
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>jaxb2-maven-plugin</artifactId>
+                <groupId>org.jvnet.jaxb2.maven2</groupId>
+                <artifactId>maven-jaxb2-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>xjc</id>
                         <goals>
-                            <goal>xjc</goal>
+                            <goal>generate</goal>
                         </goals>
                     </execution>
                 </executions>
                 <configuration>
-                    <packageName>nl.b3p.brmo.bag2.xml.leveringsdocument</packageName>
+                    <generatePackage>nl.b3p.brmo.bag2.xml.leveringsdocument</generatePackage>
+                    <schemaDirectory>${project.basedir}/src/main/xsd/</schemaDirectory>
+                    <schemaIncludes>**/*.xsd</schemaIncludes>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1051,10 +1051,16 @@
                     <artifactId>openapi-generator-maven-plugin</artifactId>
                     <version>5.4.0</version>
                 </plugin>
+                <!--                <plugin>-->
+                <!--            deze plugin is stuk op Windows met Java 11.0.15, zie oa. https://stackoverflow.com/questions/71956115 -->
+                <!--                    <groupId>org.codehaus.mojo</groupId>-->
+                <!--                    <artifactId>jaxb2-maven-plugin</artifactId>-->
+                <!--                    <version>2.5.0</version>-->
+                <!--                </plugin>-->
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>jaxb2-maven-plugin</artifactId>
-                    <version>2.5.0</version>
+                    <groupId>org.jvnet.jaxb2.maven2</groupId>
+                    <artifactId>maven-jaxb2-plugin</artifactId>
+                    <version>0.15.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
vervang org.codehaus.mojo:jaxb2-maven-plugin door org.jvnet.jaxb2.maven2:maven-jaxb2-plugin die wel werkt met actuele Java 11

verhelp xjc probleem op windows sinds Java upgrade van 11.014.x naar 11.015.x:

```
Error:  Failed to execute goal org.codehaus.mojo:jaxb2-maven-plugin:2.5.0:xjc (xjc) on project bag2-loader: "file:\C:\Users\runneradmin\.m2\repository\org\glassfish\jaxb\jaxb-xjc\2.3.2\jaxb-xjc-2.3.2.jar!\META-INF\versions\9" is not a valid file name: {1}: Invalid file path
```

zie ook: 
- https://stackoverflow.com/questions/71956115/why-does-jaxb2-maven-plugin-xjc-fail-with-corretto-jdk11-0-15-9-but-not-with-tem