### PR TITLE
[BRMO-180] Gebruik relatie SplitsingAfkoopErfpacht in `vb_util_app_re_splitsing`

### DIFF
--- a/datamodel/extra_scripts/oracle/207_brk_views.sql
+++ b/datamodel/extra_scripts/oracle/207_brk_views.sql
@@ -225,9 +225,11 @@ CREATE OR REPLACE VIEW vb_util_app_re_splitsing AS
         JOIN brondocument b2 ON b2.identificatie = b1.identificatie
     WHERE
         ( b2.omschrijving = 'betrokkenBij Ondersplitsing'
-          OR b2.omschrijving = 'betrokkenBij HoofdSplitsing' )
+          OR b2.omschrijving = 'betrokkenBij HoofdSplitsing'
+          OR  b2.omschrijving = 'betrokkenBij SplitsingAfkoopErfpacht')
         AND ( b1.omschrijving = 'ontstaanUit Ondersplitsing'
-              OR b1.omschrijving = 'ontstaanUit HoofdSplitsing' )
+              OR b1.omschrijving = 'ontstaanUit HoofdSplitsing'
+              OR  b1.omschrijving = 'ontstaanUit SplitsingAfkoopErfpacht')
     GROUP BY
         b1.ref_id;
 

--- a/datamodel/extra_scripts/postgresql/207_brk_views.sql
+++ b/datamodel/extra_scripts/postgresql/207_brk_views.sql
@@ -328,10 +328,12 @@ ON
 WHERE
     (
         b2.omschrijving = 'betrokkenBij Ondersplitsing'
-    OR  b2.omschrijving = 'betrokkenBij HoofdSplitsing')
+    OR  b2.omschrijving = 'betrokkenBij HoofdSplitsing'
+    OR  b2.omschrijving = 'betrokkenBij SplitsingAfkoopErfpacht')
 AND (
         b1.omschrijving = 'ontstaanUit Ondersplitsing'
-    OR  b1.omschrijving = 'ontstaanUit HoofdSplitsing')
+    OR  b1.omschrijving = 'ontstaanUit HoofdSplitsing'
+    OR  b1.omschrijving = 'ontstaanUit SplitsingAfkoopErfpacht')
 GROUP BY
     b1.ref_id;
     

--- a/datamodel/upgrade_scripts/2.2.2-2.3.0/oracle/rsgb.sql
+++ b/datamodel/upgrade_scripts/2.2.2-2.3.0/oracle/rsgb.sql
@@ -4,6 +4,23 @@
 
 WHENEVER SQLERROR EXIT SQL.SQLCODE
 
+CREATE OR REPLACE VIEW vb_util_app_re_splitsing AS
+    SELECT
+        b1.ref_id   AS child_identif,
+        MIN(b2.ref_id) AS parent_identif
+    FROM
+        brondocument b1
+        JOIN brondocument b2 ON b2.identificatie = b1.identificatie
+    WHERE
+        ( b2.omschrijving = 'betrokkenBij Ondersplitsing'
+          OR b2.omschrijving = 'betrokkenBij HoofdSplitsing'
+          OR  b2.omschrijving = 'betrokkenBij SplitsingAfkoopErfpacht')
+        AND ( b1.omschrijving = 'ontstaanUit Ondersplitsing'
+              OR b1.omschrijving = 'ontstaanUit HoofdSplitsing'
+              OR  b1.omschrijving = 'ontstaanUit SplitsingAfkoopErfpacht')
+    GROUP BY
+        b1.ref_id;
+
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.2_naar_2.3.0','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/2.2.2-2.3.0/postgresql/rsgb.sql
+++ b/datamodel/upgrade_scripts/2.2.2-2.3.0/postgresql/rsgb.sql
@@ -4,6 +4,28 @@
 
 set search_path = public,bag;
 
+CREATE OR REPLACE VIEW
+    vb_util_app_re_splitsing AS
+SELECT
+    b1.ref_id AS child_identif,
+    min(b2.ref_id) AS parent_identif
+FROM
+    brondocument b1
+JOIN
+    brondocument b2
+ON
+    b2.identificatie = b1.identificatie
+WHERE
+    (
+        b2.omschrijving = 'betrokkenBij Ondersplitsing'
+    OR  b2.omschrijving = 'betrokkenBij HoofdSplitsing'
+    OR  b2.omschrijving = 'betrokkenBij SplitsingAfkoopErfpacht')
+AND (
+        b1.omschrijving = 'ontstaanUit Ondersplitsing'
+    OR  b1.omschrijving = 'ontstaanUit HoofdSplitsing'
+    OR  b1.omschrijving = 'ontstaanUit SplitsingAfkoopErfpacht')
+GROUP BY
+    b1.ref_id;
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.2.2_naar_2.3.0','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';


### PR DESCRIPTION
Gebruik **ook** de relatie SplitsingAfkoopErfpacht van zakelijk recht om percelen onderliggende aan appartementsrechten te herleiden.

fixes BRMO-180