### PR TITLE
nhr-loader: add dedicated NHRException, use in service

### DIFF
--- a/nhr-loader/src/main/java/nl/b3p/brmo/nhr/loader/NHRException.java
+++ b/nhr-loader/src/main/java/nl/b3p/brmo/nhr/loader/NHRException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 B3Partners B.V.
+ */
+package nl.b3p.brmo.nhr.loader;
+
+import nl.b3p.brmo.loader.util.BrmoException;
+import java.util.Map;
+
+/**
+ * Specifieke exception voor NHR foutmeldingen.
+ */
+public class NHRException extends BrmoException {
+    private Map<String, String> errors;
+    private String message;
+
+    public NHRException(Map<String, String> errors) {
+        this.errors = errors;
+
+        StringBuilder errorList = new StringBuilder();
+        for (String key : errors.keySet()) {
+            if (errorList.length() > 0) {
+                errorList.append(", ");
+            }
+
+            errorList.append(key);
+            errorList.append(": ");
+            errorList.append(errors.get(key));
+        }
+
+        message = errorList.toString();
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Map<String, String> getErrors() {
+        return this.errors;
+    }
+}
+

--- a/nhr-loader/src/main/java/nl/b3p/brmo/nhr/loader/NHRLoader.java
+++ b/nhr-loader/src/main/java/nl/b3p/brmo/nhr/loader/NHRLoader.java
@@ -9,6 +9,7 @@ package nl.b3p.brmo.nhr.loader;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import javax.xml.bind.JAXBContext;
@@ -16,7 +17,6 @@ import javax.xml.bind.JAXBElement;
 import javax.xml.bind.Marshaller;
 import javax.xml.ws.BindingProvider;
 import nl.b3p.brmo.loader.BrmoFramework;
-import nl.b3p.brmo.loader.util.BrmoException;
 import nl.kvk.schemas.schemas.hrip.dataservice._2015._02.Dataservice;
 import nl.kvk.schemas.schemas.hrip.dataservice._2015._02.InschrijvingRequestType;
 import nl.kvk.schemas.schemas.hrip.dataservice._2015._02.InschrijvingResponseType;
@@ -64,11 +64,12 @@ public class NHRLoader {
 
         List<MeldingType> errors = response.getMeldingen().getFout();
         if (!errors.isEmpty()) {
-            String errorResponse = "";
+            HashMap<String, String> errorMap = new HashMap<>();
             for (MeldingType melding : errors) {
-                errorResponse += String.format("%s: %s\n", melding.getCode(), melding.getOmschrijving());
+                errorMap.put(melding.getCode(), melding.getOmschrijving());
             }
-            throw new BrmoException(errorResponse.stripTrailing());
+
+            throw new NHRException(errorMap);
         }
 
         // Serialize the XML into the format expected by BRMO.


### PR DESCRIPTION
Als een ongeldig KVK nummer gebruikt wordt, wordt deze nu voor eeuwig opnieuw geprobeerd. Deze PR zorgt ervoor dat de foutmeldingen van de KVK API correct teruggestuurd worden, en dat de requests niet opnieuw geprobeerd worden op ongeldige/onbekende KVK nummers.