### PR TITLE
nhr-loader: manually exclude javamail transitive dependency

### DIFF
--- a/nhr-loader/pom.xml
+++ b/nhr-loader/pom.xml
@@ -43,6 +43,12 @@ Copyright (C) 2022 B3Partners B.V.
         <dependency>
             <groupId>org.apache.wss4j</groupId>
             <artifactId>wss4j-ws-security-common</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.geronimo.javamail</groupId>
+                    <artifactId>geronimo-javamail_1.4_mail</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.cxf</groupId>


### PR DESCRIPTION
wss4j gebruikt de javamail API voor een kleine set functies (ivm MIME). Dit gebruikt de `javax.mail` APIs, en is code die niet aangeroepen wordt (alleen gebruikt voor [SOAP SwA](http://docs.oasis-open.org/wss-m/wss/v1.1.1/os/wss-SwAProfile-v1.1.1-os.html)), dus we kunnen veilig deze dependency vermijden. Anders conflicteert het met de Tomcat-provided javamail implementatie.