### PR TITLE
nhr-loader: embed entire KVK WSDL

### DIFF
--- a/nhr-loader/pom.xml
+++ b/nhr-loader/pom.xml
@@ -154,8 +154,8 @@ Copyright (C) 2022 B3Partners B.V.
                             <sourceRoot>${project.build.directory}/generated-sources/cxf</sourceRoot>
                             <wsdlOptions>
                                 <wsdlOption>
-                                    <wsdl>${basedir}/src/wsdl/KVK-KvKDataservice.wsdl</wsdl>
-                                    <wsdlLocation>http://schemas.kvk.nl/contracts/kvk/dataservice/catalogus/2015/02/KVK-KvKDataservice.wsdl</wsdlLocation>
+                                    <wsdl>${basedir}/src/main/resources/wsdl/KVK-KvKDataservice.wsdl</wsdl>
+                                    <wsdlLocation>classpath:wsdl/KVK-KvKDataservice.wsdl</wsdlLocation>
                                 </wsdlOption>
                             </wsdlOptions>
                         </configuration>

--- a/nhr-loader/src/main/resources/wsdl/KVK-KvKDataservice.wsdl
+++ b/nhr-loader/src/main/resources/wsdl/KVK-KvKDataservice.wsdl
@@ -11,7 +11,7 @@
     <wsdl:types>
         <xs:schema targetNamespace="http://schemas.kvk.nl/schemas/hrip/dataservice/2015/02" elementFormDefault="qualified">
 
-            <xs:import namespace="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02" schemaLocation="http://schemas.kvk.nl/schemas/kvk/dataservice/catalogus/2015/02/Catalogus.xsd"/>
+            <xs:import namespace="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02" schemaLocation="catalogus/Catalogus.xsd"/>
 
             <xs:complexType name="ProductRequestType">
                 <xs:sequence>

--- a/nhr-loader/src/main/resources/wsdl/catalogus/Catalogus.xsd
+++ b/nhr-loader/src/main/resources/wsdl/catalogus/Catalogus.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02"
+           targetNamespace="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02"
+           elementFormDefault="qualified" attributeFormDefault="unqualified"
+           version="schema.v3_0">
+
+    <!-- Catalogus -->
+    <xs:include schemaLocation="CatalogusTypes.xsd"/>
+    <xs:include schemaLocation="CatalogusGegevensGroepen.xsd"/>
+    <xs:include schemaLocation="CatalogusMainTypes.xsd"/>
+
+    <!--*********************************** De Root Elements **********************************-->
+
+    <!--**** Persoon ****-->
+    <xs:element name="naamPersoon" type="NaamPersoonType"/>
+    <xs:element name="natuurlijkPersoon" type="NatuurlijkPersoonType"/>
+    <xs:element name="buitenlandseVennootschap" type="BuitenlandseVennootschapType"/>
+    <xs:element name="eenmanszaakMetMeerdereEigenaren" type="EenmanszaakMetMeerdereEigenarenType"/>
+    <xs:element name="rechtspersoon" type="RechtspersoonType"/>
+    <xs:element name="rechtspersoonInOprichting" type="RechtspersoonInOprichtingType"/>
+    <xs:element name="samenwerkingsverband" type="SamenwerkingsverbandType"/>
+
+    <!--**** MaatschappelijkeActiviteit ****-->
+    <xs:element name="maatschappelijkeActiviteit" type="MaatschappelijkeActiviteitType"/>
+
+    <!--**** Onderneming ****-->
+    <xs:element name="onderneming" type="OndernemingType"/>
+
+    <!--**** Vestiging ****-->
+    <xs:element name="commercieleVestiging" type="CommercieleVestigingType"/>
+    <xs:element name="nietCommercieleVestiging" type="NietCommercieleVestigingType"/>
+
+    <!--**** Adres ****-->
+    <xs:element name="binnenlandsAdres" type="BinnenlandsAdresType"/>
+
+    <!--**** Deponeringen ****-->
+    <xs:element name="deponeringen" type="DeponeringenType"/>
+</xs:schema>

--- a/nhr-loader/src/main/resources/wsdl/catalogus/CatalogusGegevensGroepen.xsd
+++ b/nhr-loader/src/main/resources/wsdl/catalogus/CatalogusGegevensGroepen.xsd
@@ -1,0 +1,440 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02"
+           targetNamespace="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02"
+           elementFormDefault="qualified" attributeFormDefault="unqualified"
+           version="schema.v3_0">
+
+    <xs:include schemaLocation="CatalogusTypes.xsd"/>
+		   
+    <!--**** Activiteiten ****-->
+    <xs:complexType name="ActiviteitenType">
+        <xs:complexContent>
+            <xs:extension base="MetExtraElementenMogenlijkheidType">
+                <xs:sequence>
+                    <xs:element name="omschrijving" type="xs:string" minOccurs="0"/>
+                    <xs:element name="sbiActiviteit" type="SBIActiviteitType" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="ActiviteitenCommercieleVestigingType">
+        <xs:complexContent>
+            <xs:extension base="ActiviteitenType">
+                <xs:sequence>
+                    <xs:element name="exporteert" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="importeert" type="EnumeratieType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!-- **** BeperkingInRechtshandeling ****-->
+    <xs:complexType name="BeperkingInRechtshandelingType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="soort" type="EnumeratieType" minOccurs="0"/>
+                    <xs:choice minOccurs="0">
+                        <xs:element name="uitspraakAanvang" type="RechterlijkeUitspraakType"/>
+                        <xs:element name="uitspraakEinde" type="RechterlijkeUitspraakType"/>
+                    </xs:choice>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!--**** Bevoegdheid ****-->
+    <xs:complexType name="BevoegdheidAansprakelijkeType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="soort" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="beperkingInEuros" type="GeldType" minOccurs="0"/>
+                    <xs:element name="overigeBeperking" type="EnumeratieType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="BevoegdheidBestuurderType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="soort" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="isBevoegdMetAnderePersonen" type="EnumeratieType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="BevoegdheidOverigeFunctionarisType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="soort" type="EnumeratieType"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="BevoegdheidPubliekrechtelijkeFunctionarisType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="soort" type="EnumeratieType"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="BevoegdheidBewindvoerderType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="soort" type="EnumeratieType"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="BijzondereRechtstoestandType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="soort" type="EnumeratieType" minOccurs="0"/>
+                    <xs:choice minOccurs="0">
+                        <xs:element name="uitspraakAanvang" type="RechterlijkeUitspraakType"/>
+                        <xs:element name="uitspraakEinde" type="RechterlijkeUitspraakType"/>
+                    </xs:choice>
+                    <xs:element name="redenEindeInsolventie" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="status" type="EnumeratieType" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>Alleen van toepassing bij een surseance van betaling</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="duur" type="xs:string" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>Alleen van toepassing bij een surseance van betaling</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="isVerlengd" type="EnumeratieType" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>Alleen van toepassing bij een surseance van betaling</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="BuitenlandseRechtstoestandType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="beschrijving" type="xs:string" minOccurs="0"/>
+                    <xs:choice minOccurs="0">
+                        <xs:element name="uitspraakAanvang" type="RechterlijkeUitspraakType"/>
+                        <xs:element name="uitspraakEinde" type="RechterlijkeUitspraakType"/>
+                    </xs:choice>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="RechtspersoonGegevensBuitenlandType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="naam" type="xs:string" minOccurs="0"/>
+                    <xs:element name="plaats" type="xs:string" minOccurs="0"/>
+                    <xs:element name="land" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="inschrijfnummer" type="xs:string" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="BuitenlandseRegistratieGegevensType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="naam" type="xs:string" minOccurs="0"/>
+                    <xs:element name="plaats" type="xs:string" minOccurs="0"/>
+                    <xs:element name="land" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="inschrijfnummer" type="xs:string" minOccurs="0"/>
+                    <!-- Afgeleid gegeven binnen IP-Domein -->
+                    <xs:element name="buitenlandseRegistratie" type="xs:string" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="BuitenlandseVennootschapGegevensType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="heeftHoofdvestigingBuitenNederland" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="omschrijvingRechtsvorm" type="xs:string" minOccurs="0"/>
+                    <xs:element name="datumEersteInschrijvingBuitenland" type="DatumIncompleetType" minOccurs="0"/>
+                    <xs:element name="zetel" type="xs:string" minOccurs="0"/>
+                    <xs:element name="rechtsvormcategorie" type="EnumeratieType"/>
+                    <xs:element name="datumFormeelBuitenlandsSinds" type="DatumIncompleetType" minOccurs="0"/>
+                    <xs:element name="datumAkteOprichting" type="DatumIncompleetType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <!--**** CommanditairKapitaal ****-->
+    <xs:complexType name="CommanditairKapitaalType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="bedrag" type="GeldType" minOccurs="0"/>
+                    <xs:element name="soort" type="EnumeratieType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <!--**** Communicatiegegevens ****-->
+    <xs:complexType name="CommunicatiegegevensType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="communicatienummer" type="CommunicatienummerType" minOccurs="0"
+                                maxOccurs="unbounded"/>
+                    <xs:element name="emailAdres" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="domeinNaam" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <!--**** Duur ****-->
+    <xs:complexType name="DuurType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:choice>
+                    <xs:element name="eindeDuur" type="DatumIncompleetType" minOccurs="0"/>
+                    <xs:element name="heeftOnbepaaldeDuur" type="EnumeratieType" minOccurs="0"/>
+                </xs:choice>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <!--**** FunctieTitel ****-->
+    <xs:complexType name="FunctietitelType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="titel" type="xs:string" minOccurs="0"/>
+                    <xs:element name="isStatutaireTitel" type="EnumeratieType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <!--**** Handlichting ****-->
+    <xs:complexType name="HandlichtingType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="isVerleend" type="EnumeratieType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <!--**** Kapitaal ****-->
+    <xs:complexType name="KapitaalType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="bedrag" type="GeldType" minOccurs="0"/>
+                    <xs:element name="aandeelSamenstelling" type="AandeelSamenstellingType" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <!--**** Locatie ****-->
+    <xs:complexType name="LocatieType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="toevoegingAdres" type="xs:string" minOccurs="0"/>
+                    <xs:element name="afgeschermd" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="adres" type="AdresBinnenOfBuitenlandsType" minOccurs="0"/>
+                    <xs:element name="volledigAdres" type="xs:string" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="AdresBinnenOfBuitenlandsType">
+        <xs:choice>
+            <xs:element name="binnenlandsAdres" type="BinnenlandsAdresType"/>
+            <xs:element name="buitenlandsAdres" type="BuitenlandsAdresType"/>
+        </xs:choice>
+    </xs:complexType>
+    <!--**** Schorsing ****-->
+    <xs:complexType name="SchorsingType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:choice minOccurs="0">
+                        <xs:element name="uitspraakAanvang" type="RechterlijkeUitspraakType"/>
+                        <xs:element name="uitspraakEinde" type="RechterlijkeUitspraakType"/>
+                    </xs:choice>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!--**** TelefoonnummerRegistratie ****-->
+    <xs:complexType name="TelefoonnummerType">
+        <xs:complexContent>
+            <xs:extension base="MetExtraElementenMogenlijkheidType">
+                <xs:sequence>
+                    <xs:element name="toegangscode" type="Alfanumeriek5" minOccurs="0"/>
+                    <xs:element name="nummer" type="Alfanumeriek15"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <!--************************** GegevensGroepen ZONDER Registratie **************************-->
+    <!--**** Aandelen ****-->
+    <xs:complexType name="AandeelSamenstellingType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="aantal" type="Numeriek23DecimaalFractie4"/>
+                    <xs:element name="aandeel" type="AandeelType"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="AandeelType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="soort" type="xs:string"/>
+                    <xs:element name="waarde" type="GeldType"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!--**** BinnenlandsAdres en BuitenlandsAdres ****-->
+    <xs:complexType name="BinnenlandsAdresType">
+        <xs:complexContent>
+            <xs:extension base="MetExtraElementenMogenlijkheidType">
+                <xs:sequence>
+                    <xs:element name="straatnaam" type="xs:string" minOccurs="0"/>
+                    <xs:element name="aanduidingBijHuisnummer" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="huisnummer" type="xs:integer" minOccurs="0"/>
+                    <xs:element name="huisnummerToevoeging" type="xs:string" minOccurs="0"/>
+                    <xs:element name="huisletter" type="Letter" minOccurs="0"/>
+                    <xs:element name="postbusnummer" type="xs:integer" minOccurs="0"/>
+                    <xs:element name="postcode" type="PostcodeType" minOccurs="0"/>
+                    <xs:element name="plaats" type="xs:string" minOccurs="0"/>
+                    <xs:element name="bagId" type="BagIdType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="BuitenlandsAdresType">
+        <xs:complexContent>
+            <xs:extension base="MetExtraElementenMogenlijkheidType">
+                <xs:sequence>
+                    <xs:element name="straatHuisnummer" type="xs:string" minOccurs="0"/>
+                    <xs:element name="postcodeWoonplaats" type="xs:string" minOccurs="0"/>
+                    <xs:element name="regio" type="xs:string" minOccurs="0"/>
+                    <xs:element name="land" type="EnumeratieType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <!--**** BeperkingInHandeling ****-->
+    <xs:complexType name="BeperkingInHandelingType">
+        <xs:complexContent>
+            <xs:extension base="MetExtraElementenMogenlijkheidType">
+                <xs:sequence>
+                    <xs:element name="beperkingInGeld" type="GeldType" minOccurs="0"/>
+                    <xs:element name="soortHandeling" type="EnumeratieType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <!--**** BeperkteVolmacht ****-->
+    <xs:complexType name="BeperkteVolmachtType">
+        <xs:complexContent>
+            <xs:extension base="MetExtraElementenMogenlijkheidType">
+                <xs:sequence>
+                    <xs:element name="beperkingInGeld" type="GeldType" minOccurs="0"/>
+                    <xs:element name="magOpgaveHandelsregisterDoen" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="heeftOverigeVolmacht" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="omschrijvingOverigeVolmacht" type="xs:string" minOccurs="0"/>
+                    <xs:element name="beperkingInHandeling" type="BeperkingInHandelingType" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <!--**** Communicatienummer (Fax-/Telefoonummer) ****-->
+    <xs:complexType name="CommunicatienummerType">
+        <xs:complexContent>
+            <xs:extension base="MetExtraElementenMogenlijkheidType">
+                <xs:sequence>
+                    <xs:element name="toegangscode" type="Alfanumeriek5"/>
+                    <xs:element name="nummer" type="Alfanumeriek15"/>
+                    <xs:element name="soort" type="EnumeratieType"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <!--**** FusieSplitsingVoorstel ****-->
+    <xs:complexType name="FusieSplitsingVoorstelType">
+        <xs:complexContent>
+            <xs:extension base="MetExtraElementenMogenlijkheidType">
+                <xs:sequence>
+                    <xs:element name="rol" type="EnumeratieType"/>
+                    <xs:element name="zuivereSplitsing" type="EnumeratieType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!--**** Liquidatie ****-->
+    <xs:complexType name="LiquidatieType">
+        <xs:complexContent>
+            <xs:extension base="BasisType"/>
+        </xs:complexContent>
+    </xs:complexType>
+    <!--**** Ontbinding ****-->
+    <xs:complexType name="OntbindingType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="aanleiding" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="liquidatie" type="LiquidatieType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <!--**** RechterlijkeUitspraak ****-->
+    <xs:complexType name="RechterlijkeUitspraakType">
+        <xs:complexContent>
+            <xs:extension base="MetExtraElementenMogenlijkheidType">
+                <xs:sequence>
+                    <xs:element name="datum" type="DatumIncompleetType"/>
+                    <xs:element name="naam" type="xs:string"/>
+                    <xs:element name="plaats" type="xs:string"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <!--**** SBIActiviteit ****-->
+    <xs:complexType name="SBIActiviteitType">
+        <xs:complexContent>
+            <xs:extension base="BasisType">
+                <xs:sequence>
+                    <xs:element name="sbiCode" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="isHoofdactiviteit" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="volgorde" type="xs:integer" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>    <!--**** VoornemenTotOntbinding ****-->
+    <xs:complexType name="VoornemenTotOntbindingType">
+        <xs:complexContent>
+            <xs:extension base="BasisType"/>
+        </xs:complexContent>
+    </xs:complexType>
+</xs:schema>

--- a/nhr-loader/src/main/resources/wsdl/catalogus/CatalogusMainTypes.xsd
+++ b/nhr-loader/src/main/resources/wsdl/catalogus/CatalogusMainTypes.xsd
@@ -1,0 +1,636 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		   xmlns="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02"
+		   targetNamespace="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02"
+		   elementFormDefault="qualified" attributeFormDefault="unqualified"
+		   version="schema.v3_0">
+
+	<xs:include schemaLocation="CatalogusRelaties.xsd"/>
+	<xs:include schemaLocation="CatalogusTypes.xsd"/>
+	<xs:include schemaLocation="CatalogusGegevensGroepen.xsd"/>
+
+	<!--**** Persoon ****-->
+	<xs:complexType name="PersoonType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="BasisType">
+				<xs:sequence>
+                  <!-- attributen -->
+                    <xs:element name="bijzondereRechtstoestand" type="BijzondereRechtstoestandType" minOccurs="0"/>
+                    <xs:element name="beperkingInRechtshandeling" type="BeperkingInRechtshandelingType" minOccurs="0"/>
+                    <!-- afgeleid gegeven binnen HR-Domein -->
+                    <xs:element name="persoonRechtsvorm" type="xs:string" minOccurs="0"/>
+                    <xs:element name="volledigeNaam" type="xs:string" minOccurs="0"/>
+                    <!-- Afgeleid gegeven binnen IP-Domein -->
+                    <xs:element name="uitgebreideRechtsvorm" type="xs:string" minOccurs="0"/>
+
+                  <!-- componenten -->
+					<xs:element name="bezoekLocatiePersoon" type="LocatieType" minOccurs="0"/>
+					<xs:element name="postLocatiePersoon" type="LocatieType" minOccurs="0"/>
+                    <!-- relaties -->
+					<xs:element name="heeft" type="FunctievervullingRelatieType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="is" type="FunctievervullingRelatieType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="isEigenaarVan" type="MaatschappelijkeActiviteitRelatieType" minOccurs="0"/>
+					<xs:element name="isVerenigdNaar" type="PersoonRelatieType" minOccurs="0"/>
+					<xs:element name="isVerenigdMet" type="PersoonRelatieType" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="NaamPersoonType">
+		<xs:complexContent>
+			<xs:extension base="PersoonType">
+				<xs:sequence>
+				  <!-- attributen -->
+					<xs:element name="naam" type="xs:string" minOccurs="0"/>
+				  <!-- componenten -->
+					<xs:element name="telefoonnummer" type="TelefoonnummerType" minOccurs="0"/>
+					<xs:element name="adres" type="LocatieType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="NatuurlijkPersoonType">
+		<xs:complexContent>
+			<xs:extension base="PersoonType">
+				<xs:sequence>
+				  <!-- attributen -->
+					<xs:element name="bsn" type="BSNummerType" minOccurs="0"/>
+					<xs:element name="geslachtsnaam" type="xs:string" minOccurs="0"/>
+					<xs:element name="voorvoegselGeslachtsnaam" type="xs:string" minOccurs="0"/>
+					<xs:element name="voornamen" type="xs:string" minOccurs="0"/>
+					<xs:element name="geslachtsaanduiding" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="geboorteplaats" type="xs:string" minOccurs="0"/>
+                    <xs:element name="geboorteland" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="adellijkeTitel" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="aanduidingNaamgebruik" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="geslachtsnaamPartner" type="xs:string" minOccurs="0"/>
+					<xs:element name="voorvoegselGeslachtsnaamPartner" type="xs:string" minOccurs="0"/>
+					<xs:element name="handlichting" type="HandlichtingType" minOccurs="0"/>
+					<xs:element name="geboortedatum" type="DatumIncompleetType" minOccurs="0"/>
+					<xs:element name="overlijdensdatum" type="DatumIncompleetType" minOccurs="0"/>
+					<xs:element name="datumEersteHuwelijk" type="DatumIncompleetType" minOccurs="0"/>
+					<xs:element name="datumGeemigreerd" type="DatumIncompleetType" minOccurs="0"/>
+				  <!-- componenten -->
+					<xs:element name="woonLocatie" type="LocatieType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="NietNatuurlijkPersoonType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="PersoonType">
+				<xs:sequence>
+                  <!-- attributen -->
+					<xs:element name="rsin" type="RSINummerType" minOccurs="0"/>
+					<xs:element name="naamgeving" type="NaamgevingType" minOccurs="0"/>
+					<xs:element name="datumUitschrijving" type="DatumIncompleetType" minOccurs="0"/>
+					<xs:element name="buitenlandseRechtstoestand" type="BuitenlandseRechtstoestandType" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="ontbinding" type="OntbindingType" minOccurs="0"/>
+                    <xs:element name="fusie" type="FusieType" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="splitsing" type="SplitsingType" minOccurs="0" maxOccurs="unbounded"/>
+                    <!-- componenten -->
+                    <!-- relaties -->
+					<xs:element name="heeftGedeponeerd" type="DeponeringRelatieType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="isDochterVan" type="AansprakelijkheidRelatieRegistratieType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="deponeringen" type="DeponeringenType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="BuitenlandseVennootschapType">
+		<xs:complexContent>
+			<xs:extension base="NietNatuurlijkPersoonType">
+				<xs:sequence>
+				  <!-- attributen -->
+                    <xs:element name="buitenlandseRegistratieGegevens" type="BuitenlandseRegistratieGegevensType" minOccurs="0"/>
+                    <xs:element name="landVanOprichting" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="landVanVestiging" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="geplaatstKapitaal" type="KapitaalType" minOccurs="0"/>
+					<xs:element name="buitenlandseVennootschapGegevens" type="BuitenlandseVennootschapGegevensType" minOccurs="0"/>
+
+				  <!-- componenten -->
+					<xs:element name="bezoekLocatie" type="LocatieType" minOccurs="0"/>
+					<xs:element name="postLocatie" type="LocatieType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="EenmanszaakMetMeerdereEigenarenType">
+		<xs:complexContent>
+			<xs:extension base="NietNatuurlijkPersoonType"/>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="AfgeslotenMoederType">
+		<xs:complexContent>
+			<xs:extension base="NietNatuurlijkPersoonType">
+				<xs:sequence>
+					<xs:element name="kvkNummer" type="KvKNummerType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="RechtspersoonType">
+		<xs:complexContent>
+			<xs:extension base="NietNatuurlijkPersoonType">
+				<xs:sequence>
+
+				  <!-- attributen -->
+					<xs:element name="rechtsvorm" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="publiekrechtelijkeRechtsvorm" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="overigePrivaatrechtelijkeRechtsvorm" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="nieuwGemeldeRechtsvorm" type="xs:string" minOccurs="0"/>
+					<xs:element name="zetelGegevensBuitenland" type="RechtspersoonGegevensBuitenlandType" minOccurs="0"/>
+					<xs:element name="statutaireZetel" type="xs:string" minOccurs="0"/>
+					<xs:element name="aanvangStatutaireZetel" type="DatumIncompleetType" minOccurs="0"/>
+					<xs:element name="datumAkteOprichting" type="DatumIncompleetType" minOccurs="0"/>
+					<xs:element name="datumOprichting" type="DatumIncompleetType" minOccurs="0"/>
+					<xs:element name="bedragKostenOprichting" type="GeldType" minOccurs="0"/>
+					<xs:element name="datumEersteInschrijvingHandelsregister" type="DatumIncompleetType" minOccurs="0"/>
+					<xs:element name="datumAkteStatutenwijziging" type="DatumIncompleetType" minOccurs="0"/>
+					<xs:element name="datumLaatsteStatutenwijziging" type="DatumIncompleetType" minOccurs="0"/>
+					<xs:element name="rechtsbevoegdheidVereniging" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="ingangStatuten" type="DatumIncompleetType" minOccurs="0"/>
+					<xs:element name="beleggingsMijMetVeranderlijkKapitaal" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="koninklijkErkend" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="stelselInrichting" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="structuur" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="maatschappelijkKapitaal" type="KapitaalType" minOccurs="0"/>
+					<xs:element name="geplaatstKapitaal" type="KapitaalType" minOccurs="0"/>
+					<xs:element name="gestortKapitaal" type="KapitaalType" minOccurs="0"/>
+
+				  <!-- componenten -->
+					<xs:element name="bezoekLocatie" type="LocatieType" minOccurs="0"/>
+					<xs:element name="postLocatie" type="LocatieType" minOccurs="0"/>
+					<xs:element name="activiteiten" type="ActiviteitenType" minOccurs="0"/>
+					<xs:element name="communicatiegegevens" type="CommunicatiegegevensType" minOccurs="0"/>
+
+				  <!-- attributen -->
+                    <xs:element name="voornemenTotOntbinding" type="VoornemenTotOntbindingType" minOccurs="0"/>
+                    <!-- afgeleid gegeven binnen HR-Domein -->
+                    <xs:element name="activiteitenGestaaktPer" type="DatumIncompleetType" minOccurs="0" />
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="RechtspersoonInOprichtingType">
+		<xs:complexContent>
+			<xs:extension base="NietNatuurlijkPersoonType">
+				<xs:sequence>
+					<xs:element name="doelRechtsvorm" type="EnumeratieType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SamenwerkingsverbandType">
+		<xs:complexContent>
+			<xs:extension base="NietNatuurlijkPersoonType">
+				<xs:sequence>
+					<xs:element name="rechtsvorm" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="aantalCommanditaireVennoten" type="xs:integer" minOccurs="0"/>
+					<xs:element name="duur" type="DuurType" minOccurs="0"/>
+					<xs:element name="commanditairKapitaal" type="CommanditairKapitaalType" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--**** Functievervulling ****-->
+	<xs:complexType name="FunctievervullingType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="BasisType">
+				<xs:sequence>
+					<xs:element name="functietitel" type="FunctietitelType" minOccurs="0"/>
+                    <xs:element name="schorsing" type="SchorsingType" minOccurs="0"/>
+					<xs:choice>
+						<xs:element name="door" type="PersoonRelatieType">
+							<xs:annotation>
+								<xs:documentation>[Persoon] heeft [Functievervulling] door [Persoon]</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="voor" type="PersoonRelatieType">
+							<xs:annotation>
+								<xs:documentation>[Persoon] is [Functievervulling] voor [Persoon]</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:choice>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="AansprakelijkeType">
+		<xs:complexContent>
+			<xs:extension base="FunctievervullingType">
+				<xs:sequence>
+					<xs:element name="functie" type="EnumeratieType" />
+					<xs:element name="handlichting" type="HandlichtingType" minOccurs="0"/>
+					<xs:element name="bevoegdheid" type="BevoegdheidAansprakelijkeType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+    <xs:complexType name="MonistischeBestuurderType">
+		<xs:complexContent>
+			<xs:extension base="MetExtraElementenMogenlijkheidType">
+				<xs:sequence>
+					<xs:element name="registratie" type="RegistratieType" minOccurs="0"/>
+					<xs:element name="rol" type="EnumeratieType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+    </xs:complexType>
+
+	<xs:complexType name="BestuursfunctieType">
+		<xs:complexContent>
+			<xs:extension base="FunctievervullingType">
+				<xs:sequence>
+					<xs:element name="functie" type="EnumeratieType" />
+					<xs:element name="bevoegdheid" type="BevoegdheidBestuurderType" minOccurs="0"/>
+					<xs:element name="wordtVertegenwoordigdDoor" type="NatuurlijkPersoonRelatieType" minOccurs="0"/>
+                    <xs:element name="monistischeBestuurder" type="MonistischeBestuurderType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+    <xs:complexType name="FunctionarisBijzondereRechtstoestandType">
+		<xs:complexContent>
+            <xs:extension base="FunctievervullingType">
+                <xs:sequence>
+                    <xs:element name="functie" type="EnumeratieType"/>
+                    <xs:element name="bevoegdheid" type="BevoegdheidBewindvoerderType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="GemachtigdeType">
+		<xs:complexContent>
+			<xs:extension base="FunctievervullingType">
+				<xs:sequence>
+					<xs:element name="functie" type="EnumeratieType"/>
+					<xs:element name="volmacht" type="VolmachtType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="OverigeFunctionarisType">
+		<xs:complexContent>
+			<xs:extension base="FunctievervullingType">
+				<xs:sequence>
+					<xs:element name="functie" type="EnumeratieType"/>
+					<xs:element name="geplaatstKapitaal" type="KapitaalType" minOccurs="0"/>
+					<xs:element name="gestortKapitaal" type="KapitaalType" minOccurs="0"/>
+                    <xs:element name="bevoegdheid" type="BevoegdheidOverigeFunctionarisType" minOccurs="0"/>
+                    <xs:element name="heeftAfwijkendAansprakelijkheidsbeding" type="EnumeratieType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PubliekrechtelijkeFunctionarisType">
+		<xs:complexContent>
+			<xs:extension base="FunctievervullingType">
+				<xs:sequence>
+					<xs:element name="functie" type="EnumeratieType"/>
+					<xs:element name="bevoegdheid" type="BevoegdheidPubliekrechtelijkeFunctionarisType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--**** MaatschappelijkeActiviteit ****-->
+	<xs:complexType name="MaatschappelijkeActiviteitType">
+		<xs:complexContent>
+			<xs:extension base="BasisType">
+				<xs:sequence>
+                    <!-- Attributen -->
+					<xs:element name="kvkNummer" type="KvKNummerType"/>
+					<xs:element name="nonMailing" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="pensioenvennootschap" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="sbiActiviteit" type="SBIActiviteitType" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="incidenteelUitlenenArbeidskrachten" type="EnumeratieType" minOccurs="0"/>
+
+                    <!-- Componenten -->
+                    <!-- afgeleid gegeven binnen HR-Domein -->
+                    <xs:element name="bezoekLocatie" type="LocatieType" minOccurs="0"/>
+					<xs:element name="postLocatie" type="LocatieType" minOccurs="0"/>
+					<xs:element name="communicatiegegevens" type="CommunicatiegegevensType" minOccurs="0"/>
+                    <xs:element name="naam" type="xs:string" minOccurs="0"/>
+					<xs:element name="notitie" type="xs:string" minOccurs="0"/>
+
+					<!-- relaties -->
+					<xs:element name="manifesteertZichAls" type="OndernemingRelatieRegistratieType" minOccurs="0"/>
+					<xs:element name="wordtUitgeoefendIn" type="NietCommercieleVestigingRelatieRegistratieType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="wordtGeleidVanuit" type="VestigingRelatieType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>Deze relatie geeft de hoofdvestiging aan</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="heeftAlsEigenaar" type="PersoonRelatieRegistratieType" minOccurs="0"/>
+					<xs:element name="hadAlsEigenaar" type="PersoonRelatieRegistratieType" minOccurs="0"/>
+                    <xs:element name="berichtenbox" type="BerichtenboxType" minOccurs="0" maxOccurs="1"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--**** Onderneming ****-->
+	<xs:complexType name="OndernemingType">
+		<xs:complexContent>
+			<xs:extension base="BasisType">
+				<xs:sequence>
+					<xs:element name="kvkNummer" type="KvKNummerType" minOccurs="0"/>
+                    <xs:element name="sbiActiviteit" type="SBIActiviteitType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="voltijdWerkzamePersonen" type="xs:integer" minOccurs="0"/>
+					<xs:element name="deeltijdWerkzamePersonen" type="xs:integer" minOccurs="0"/>
+					<!-- Afgeleid gegeven binnen HR-Domein -->
+                    <xs:element name="totaalWerkzamePersonen" type="xs:integer" minOccurs="0"/>
+					<!-- relaties -->
+                    <xs:element name="handeltOnder" type="HandelsnaamRelatieRegistratieType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="wordtUitgeoefendIn" type="CommercieleVestigingRelatieRegistratieType" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="isEenManifestatieVan" type="MaatschappelijkeActiviteitRelatieType" minOccurs="0"/>
+                    <xs:element name="isOvergenomenVan" type="VoortzettingRelatieRegistratieType" minOccurs="0"/>
+                    <xs:element name="isOvergedragenNaar" type="VoortzettingRelatieRegistratieType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--**** Vestiging ****-->
+	<xs:complexType name="VestigingType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="BasisType">
+				<xs:sequence>
+				  <!-- attributen -->
+					<xs:element name="vestigingsnummer" type="VestigingsnummerType" minOccurs="0"/>
+				  <!-- componenten -->
+					<xs:element name="bezoekLocatie" type="LocatieType" minOccurs="0"/>
+					<xs:element name="postLocatie" type="LocatieType" minOccurs="0"/>
+					<xs:element name="communicatiegegevens" type="CommunicatiegegevensType" minOccurs="0"/>
+                    <!-- afgeleid gegeven binnen IP-Domein -->
+                    <xs:element name="eersteHandelsnaam" type="xs:string" minOccurs="0"/>
+					<!-- relaties -->
+					<xs:element name="isSamengevoegdMet" type="VestigingenRelatieRegistratieType" minOccurs="0"/>
+                    <xs:element name="isOvergenomenVan" type="VoortzettingRelatieRegistratieType" minOccurs="0"/>
+                    <xs:element name="isOvergedragenNaar" type="VoortzettingRelatieRegistratieType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommercieleVestigingType">
+		<xs:complexContent>
+			<xs:extension base="VestigingType">
+				<xs:sequence>
+                  <!-- attributen -->
+					<xs:element name="voltijdWerkzamePersonen" type="xs:integer" minOccurs="0"/>
+					<xs:element name="deeltijdWerkzamePersonen" type="xs:integer" minOccurs="0"/>
+					<!-- Afgeleid gegeven binnen HR-Domein -->
+                    <xs:element name="totaalWerkzamePersonen" type="xs:integer" minOccurs="0"/>
+                  <!-- componenten -->
+					<xs:element name="activiteiten" type="ActiviteitenCommercieleVestigingType" minOccurs="0"/>
+					<!-- relaties -->
+                    <xs:element name="handeltOnder" type="HandelsnaamRelatieRegistratieType" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="isEenUitoefeningVan" type="OndernemingRelatieRegistratieType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="NietCommercieleVestigingType">
+		<xs:complexContent>
+			<xs:extension base="VestigingType">
+				<xs:sequence>
+				  <!-- attributen -->
+					<xs:element name="naamgeving" type="NaamgevingType" minOccurs="0"/>
+				  <!-- componenten -->
+					<xs:element name="activiteiten" type="ActiviteitenType" minOccurs="0"/>
+					<!-- relaties -->
+                    <xs:element name="isEenUitoefeningVan" type="MaatschappelijkeActiviteitRelatieType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--**** Naamgeving ****-->
+	<xs:complexType name="NaamgevingType">
+		<xs:complexContent>
+			<xs:extension base="BasisType">
+				<xs:sequence>
+					<xs:element name="naam" type="xs:string"/>
+					<xs:element name="ookGenoemd" type="xs:string" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--**** Volmacht ****-->
+	<xs:complexType name="VolmachtType">
+		<xs:complexContent>
+			<xs:extension base="BasisType">
+				<xs:sequence>
+                    <xs:element name="typeVolmacht" type="EnumeratieType"/>
+                    <xs:element name="isStatutair" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="beperkteVolmacht" type="BeperkteVolmachtType" minOccurs="0"/>
+                    <xs:element name="heeftBetrekkingOp" type="VestigingenRelatieType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--**** Handelsnaam ****-->
+	<xs:complexType name="HandelsnaamType">
+		<xs:complexContent>
+			<xs:extension base="BasisType">
+				<xs:sequence>
+					<xs:element name="naam" type="xs:string"/>
+					<xs:element name="volgorde" type="xs:integer" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--***************************** MainTypes ZONDER Registratie *****************************-->
+	<!--**** Deponering ****-->
+    <xs:complexType name="DeponeringenType">
+		<xs:complexContent>
+			<xs:extension base="MetExtraElementenMogenlijkheidType">
+		<xs:sequence>
+                    <xs:element name="deponering" type="DeponeringRelatieType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+    <xs:complexType name="DeponeringNietNatuurlijkPersoonRelatieType">
+		<xs:complexContent>
+            <xs:extension base="RelatieType">
+                <xs:sequence>
+                    <xs:element name="rsin" type="RSINummerType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DeponeringType" abstract="true">
+		<xs:complexContent>
+            <xs:extension base="MetExtraElementenMogenlijkheidType">
+				<xs:sequence>
+                    <xs:element name="depotId" type="DepotIdType"/>
+					<xs:element name="soortDeponering" type="xs:string" minOccurs="0"/>
+                    <xs:element name="status" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="datumDeponering" type="DatumIncompleetType" minOccurs="0"/>
+                    <xs:element name="uitspraak" type="RechterlijkeUitspraakType" minOccurs="0"/>
+                    <!-- relaties -->
+                    <xs:element name="gaatOver" type="DeponeringRelatieType" minOccurs="0"/>
+                    <xs:element name="gedeponeerdBij" type="DeponeringNietNatuurlijkPersoonRelatieType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+    <xs:complexType name="DeponeringJaarstukType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="DeponeringType">
+                <xs:sequence>
+                    <xs:element name="boekjaar" type="JaarType" minOccurs="0"/>
+                </xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DeponeringAansprakelijkheidIntrekkingType">
+		<xs:complexContent>
+			<xs:extension base="DeponeringType"/>
+		</xs:complexContent>
+	</xs:complexType>
+    <xs:complexType name="DeponeringAansprakelijkheidOverblijvendType">
+		<xs:complexContent>
+            <xs:extension base="DeponeringType"/>
+		</xs:complexContent>
+	</xs:complexType>
+    <xs:complexType name="DeponeringAansprakelijkheidVerklaringType">
+		<xs:complexContent>
+            <xs:extension base="DeponeringType"/>
+		</xs:complexContent>
+	</xs:complexType>
+    <xs:complexType name="DeponeringAanvullendeMededelingType">
+		<xs:complexContent>
+			<xs:extension base="DeponeringType"/>
+		</xs:complexContent>
+	</xs:complexType>
+    <xs:complexType name="DeponeringBijzondereDeponeringType">
+		<xs:complexContent>
+			<xs:extension base="DeponeringType">
+				<xs:sequence>
+                    <xs:element name="soort" type="EnumeratieType" minOccurs="0"/>
+                    <!-- volgende wordt in mapping hier neer gezet staat in domein op andere plek -->
+                    <xs:element name="fusieSplitsingVoorstel" type="FusieSplitsingVoorstelType" minOccurs="0"/>
+                    <xs:element name="omschrijving" type="xs:string" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DeponeringJaarstukHalfjaarKwartaalcijfersType">
+		<xs:complexContent>
+			<xs:extension base="DeponeringJaarstukType"/>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DeponeringJaarstukInstemmingType">
+		<xs:complexContent>
+			<xs:extension base="DeponeringJaarstukType">
+				<xs:sequence>
+                    <xs:element name="groepsjaarrekeningHouder" type="DeponeringNietNatuurlijkPersoonRelatieType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+    <xs:complexType name="DeponeringJaarstukJaarrekeningOngewijzigdVastgesteldType">
+        <xs:complexContent>
+            <xs:extension base="DeponeringJaarstukType"/>
+        </xs:complexContent>
+    </xs:complexType>
+	<xs:complexType name="DeponeringJaarstukJaarrekeningType">
+		<xs:complexContent>
+			<xs:extension base="DeponeringJaarstukType">
+				<xs:sequence>
+					<xs:element name="datumVaststelling" type="DatumIncompleetType" minOccurs="0"/>
+					<xs:element name="vaststelling" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="grootte" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="maandEindeBoekjaar" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="plaatsDeponeringJaarverslag" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="buitenlandseJaarrekening" type="EnumeratieType" minOccurs="0"/>
+                    <xs:element name="aanvullendeMededeling" type="DeponeringAanvullendeMededelingType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DeponeringJaarstukOntheffingType">
+		<xs:complexContent>
+			<xs:extension base="DeponeringJaarstukType">
+				<xs:sequence>
+					<xs:element name="reden" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="groepsjaarrekeninghouder" type="DeponeringNietNatuurlijkPersoonRelatieType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+    <xs:complexType name="DeponeringOverigJaarstukType">
+        <xs:complexContent>
+            <xs:extension base="DeponeringJaarstukType">
+                <xs:sequence>
+                    <xs:element name="soort" type="EnumeratieType" minOccurs="0"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="BerichtenboxType">
+		<xs:complexContent>
+			<xs:extension base="MetExtraElementenMogenlijkheidType">
+				<xs:sequence>
+					<xs:element name="berichtenboxnaam" type="xs:string" />
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+    </xs:complexType>
+
+	<xs:complexType name="FusieSplitsingType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="BasisType">
+				<xs:sequence>
+					<xs:element name="uitspraak" type="RechterlijkeUitspraakType" minOccurs="0"/>
+					<xs:element name="datumAkte" type="DatumIncompleetType" minOccurs="0"/>
+					<xs:element name="status" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="rol" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="opTeRichtenVerkrijgendeRechtspersoon" type="OpTeRichtenRechtspersoonType"
+								minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="toekennendeRechtspersoon" type="NietNatuurlijkPersoonRelatieType"
+								minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FusieType">
+		<xs:complexContent>
+			<xs:extension base="FusieSplitsingType">
+				<xs:sequence>
+					<xs:element name="opTeRichtenVerdwijnendeRechtspersoon" type="OpTeRichtenRechtspersoonType"
+								minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="verkrijgendeRechtspersoon" type="NietNatuurlijkPersoonRelatieType" minOccurs="0"/>
+					<xs:element name="verdwijnendeRechtspersoon" type="NietNatuurlijkPersoonRelatieType"
+								minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SplitsingType">
+		<xs:complexContent>
+			<xs:extension base="FusieSplitsingType">
+				<xs:sequence>
+					<xs:element name="opTeRichtenSplitsendeRechtspersoon" type="OpTeRichtenRechtspersoonType"
+								minOccurs="0"/>
+					<xs:element name="splitsendeRechtspersoon" type="NietNatuurlijkPersoonRelatieType" minOccurs="0"/>
+					<xs:element name="verkrijgendeRechtspersoon" type="NietNatuurlijkPersoonRelatieType"
+								minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="zuivereSplitsing" type="EnumeratieType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:complexType name="OpTeRichtenRechtspersoonType">
+		<xs:complexContent>
+			<xs:extension base="BasisType">
+				<xs:sequence>
+					<xs:element name="rechtsvorm" type="EnumeratieType" minOccurs="0"/>
+					<xs:element name="naam" type="xs:string" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+</xs:schema>

--- a/nhr-loader/src/main/resources/wsdl/catalogus/CatalogusRelaties.xsd
+++ b/nhr-loader/src/main/resources/wsdl/catalogus/CatalogusRelaties.xsd
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		   xmlns="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02"
+		   targetNamespace="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02"
+		   elementFormDefault="qualified" attributeFormDefault="unqualified"
+		   version="schema.v3_0">
+		   
+	<xs:include schemaLocation="CatalogusMainTypes.xsd"/>
+
+	<!--************************************* RelatieTypes *************************************-->
+	<xs:complexType name="RelatieType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="MetExtraElementenMogenlijkheidType"/>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="RelatieRegistratieType" abstract="true">
+		<xs:complexContent>
+			<xs:extension base="RelatieType">
+				<xs:sequence>
+					<xs:element name="relatieRegistratie" type="RegistratieType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--**** Persoon ****-->
+	<xs:complexType name="PersoonRelatieType">
+		<xs:complexContent>
+			<xs:extension base="RelatieType">
+				<xs:choice>
+					<xs:element name="naamPersoon" type="NaamPersoonType"/>
+					<xs:element name="natuurlijkPersoon" type="NatuurlijkPersoonType"/>
+					<xs:element name="buitenlandseVennootschap" type="BuitenlandseVennootschapType"/>
+					<xs:element name="eenmanszaakMetMeerdereEigenaren" type="EenmanszaakMetMeerdereEigenarenType"/>
+					<xs:element name="rechtspersoon" type="RechtspersoonType"/>
+					<xs:element name="rechtspersoonInOprichting" type="RechtspersoonInOprichtingType"/>
+					<xs:element name="samenwerkingsverband" type="SamenwerkingsverbandType"/>
+					<xs:element name="afgeslotenMoeder" type="AfgeslotenMoederType"/>
+				</xs:choice>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PersoonRelatieRegistratieType">
+		<xs:complexContent>
+			<xs:extension base="RelatieRegistratieType">
+				<xs:choice>
+					<xs:element name="naamPersoon" type="NaamPersoonType"/>
+					<xs:element name="natuurlijkPersoon" type="NatuurlijkPersoonType"/>
+					<xs:element name="buitenlandseVennootschap" type="BuitenlandseVennootschapType"/>
+					<xs:element name="eenmanszaakMetMeerdereEigenaren" type="EenmanszaakMetMeerdereEigenarenType"/>
+					<xs:element name="rechtspersoon" type="RechtspersoonType"/>
+					<xs:element name="rechtspersoonInOprichting" type="RechtspersoonInOprichtingType"/>
+					<xs:element name="samenwerkingsverband" type="SamenwerkingsverbandType"/>
+					<xs:element name="afgeslotenMoeder" type="AfgeslotenMoederType"/>
+				</xs:choice>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="NatuurlijkPersoonRelatieType">
+		<xs:complexContent>
+			<xs:extension base="RelatieType">
+				<xs:sequence>
+					<xs:element name="natuurlijkPersoon" type="NatuurlijkPersoonType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="NietNatuurlijkPersoonRelatieType">
+		<xs:complexContent>
+			<xs:extension base="RelatieType">
+				<xs:choice>
+					<xs:element name="buitenlandseVennootschap" type="BuitenlandseVennootschapType"/>
+					<xs:element name="eenmanszaakMetMeerdereEigenaren" type="EenmanszaakMetMeerdereEigenarenType"/>
+					<xs:element name="rechtspersoon" type="RechtspersoonType"/>
+					<xs:element name="rechtspersoonInOprichting" type="RechtspersoonInOprichtingType"/>
+					<xs:element name="samenwerkingsverband" type="SamenwerkingsverbandType"/>
+					<xs:element name="afgeslotenMoeder" type="AfgeslotenMoederType"/>
+				</xs:choice>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--**** Functievervulling ****-->
+	<xs:complexType name="FunctievervullingRelatieType">
+		<xs:complexContent>
+			<xs:extension base="RelatieType">
+				<xs:choice>
+					<xs:element name="aansprakelijke" type="AansprakelijkeType"/>
+					<xs:element name="bestuursfunctie" type="BestuursfunctieType"/>
+					<xs:element name="functionarisBijzondereRechtstoestand" type="FunctionarisBijzondereRechtstoestandType"/>
+                    <xs:element name="gemachtigde" type="GemachtigdeType"/>
+					<xs:element name="overigeFunctionaris" type="OverigeFunctionarisType"/>
+					<xs:element name="publiekrechtelijkeFunctionaris" type="PubliekrechtelijkeFunctionarisType"/>
+				</xs:choice>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--**** MaatschappelijkeActiviteit ****-->
+	<xs:complexType name="MaatschappelijkeActiviteitRelatieType">
+		<xs:complexContent>
+			<xs:extension base="RelatieType">
+				<xs:sequence>
+					<xs:element name="maatschappelijkeActiviteit" type="MaatschappelijkeActiviteitType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="MaatschappelijkeActiviteitRelatieRegistratieType">
+		<xs:complexContent>
+			<xs:extension base="RelatieRegistratieType">
+				<xs:sequence>
+					<xs:element name="maatschappelijkeActiviteit" type="MaatschappelijkeActiviteitType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="VoortzettingRelatieRegistratieType">
+		<xs:complexContent>
+			<xs:extension base="MaatschappelijkeActiviteitRelatieRegistratieType">
+				<xs:sequence>
+					<xs:element name="datumVoortzetting" type="DatumIncompleetType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--**** Onderneming ****-->
+	<xs:complexType name="OndernemingRelatieRegistratieType">
+		<xs:complexContent>
+			<xs:extension base="RelatieRegistratieType">
+				<xs:sequence>
+					<xs:element name="onderneming" type="OndernemingType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="OndernemingRelatieType">
+		<xs:complexContent>
+			<xs:extension base="RelatieType">
+				<xs:sequence>
+					<xs:element name="onderneming" type="OndernemingType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--**** Vestiging ****-->
+	<xs:complexType name="VestigingRelatieType">
+		<xs:complexContent>
+			<xs:extension base="RelatieType">
+				<xs:choice>
+					<xs:element name="commercieleVestiging" type="CommercieleVestigingType"/>
+					<xs:element name="nietCommercieleVestiging" type="NietCommercieleVestigingType"/>
+				</xs:choice>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="VestigingenRelatieType">
+		<xs:complexContent>
+			<xs:extension base="RelatieType">
+				<xs:sequence>
+					<xs:element name="commercieleVestiging" type="CommercieleVestigingType" minOccurs="0"  maxOccurs="unbounded"/>
+					<xs:element name="nietCommercieleVestiging" type="NietCommercieleVestigingType" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="VestigingenRelatieRegistratieType">
+		<xs:complexContent>
+			<xs:extension base="RelatieRegistratieType">
+				<xs:sequence>
+					<xs:element name="commercieleVestiging" type="CommercieleVestigingType" minOccurs="0"  maxOccurs="unbounded"/>
+					<xs:element name="nietCommercieleVestiging" type="NietCommercieleVestigingType" minOccurs="0" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CommercieleVestigingRelatieRegistratieType">
+		<xs:complexContent>
+			<xs:extension base="RelatieRegistratieType">
+				<xs:sequence>
+					<xs:element name="commercieleVestiging" type="CommercieleVestigingType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="NietCommercieleVestigingRelatieRegistratieType">
+		<xs:complexContent>
+			<xs:extension base="RelatieRegistratieType">
+				<xs:sequence>
+					<xs:element name="nietCommercieleVestiging" type="NietCommercieleVestigingType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<!--**** Handelsnaam ****-->
+	<xs:complexType name="HandelsnaamRelatieRegistratieType">
+		<xs:complexContent>
+			<xs:extension base="RelatieRegistratieType">
+				<xs:sequence>
+					<xs:element name="handelsnaam" type="HandelsnaamType"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<xs:complexType name="AansprakelijkheidRelatieRegistratieType">
+		<xs:complexContent>
+			<xs:extension base="RelatieRegistratieType">
+				<xs:sequence>
+					<xs:element name="moeder" type="NietNatuurlijkPersoonRelatieType" minOccurs="0"/>
+					<xs:element name="datumIntrekking" type="DatumIncompleetType" minOccurs="0"/>
+					<xs:element name="verklaring" type="DeponeringRelatieType" minOccurs="0"/>
+					<xs:element name="intrekking" type="DeponeringRelatieType" minOccurs="0"/>
+					<xs:element name="overblijvende" type="DeponeringRelatieType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+	<!--**** Deponering ****-->
+	<xs:complexType name="DeponeringRelatieType">
+		<xs:complexContent>
+			<xs:extension base="RelatieType">
+                <xs:choice>
+                    <xs:element name="aansprakelijkheidVerklaring" type="DeponeringAansprakelijkheidVerklaringType"/>
+					<xs:element name="aanvullendeMededeling" type="DeponeringAanvullendeMededelingType"/>
+                    <xs:element name="bijzondereDeponering" type="DeponeringBijzondereDeponeringType"/>
+                    <xs:element name="aansprakelijkheidIntrekking" type="DeponeringAansprakelijkheidIntrekkingType"/>
+                    <xs:element name="jaarstukHalfjaarKwartaalcijfers" type="DeponeringJaarstukHalfjaarKwartaalcijfersType"/>
+                    <xs:element name="jaarstukInstemming" type="DeponeringJaarstukInstemmingType"/>
+                    <xs:element name="jaarstukJaarrekening" type="DeponeringJaarstukJaarrekeningType"/>
+                    <xs:element name="jaarstukJaarrekeningOngewijzigdVastgesteld" type="DeponeringJaarstukJaarrekeningOngewijzigdVastgesteldType"/>
+                    <xs:element name="jaarstukOntheffing" type="DeponeringJaarstukOntheffingType"/>
+                    <xs:element name="aanprakelijkheidOverblijvend" type="DeponeringAansprakelijkheidOverblijvendType"/>
+                    <xs:element name="overigJaarstuk" type="DeponeringOverigJaarstukType" />
+                </xs:choice>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+</xs:schema>

--- a/nhr-loader/src/main/resources/wsdl/catalogus/CatalogusTypes.xsd
+++ b/nhr-loader/src/main/resources/wsdl/catalogus/CatalogusTypes.xsd
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02"
+           targetNamespace="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02"
+           elementFormDefault="qualified" attributeFormDefault="unqualified"
+           version="schema.v3_0">
+
+    <xs:complexType name="EnumeratieType">
+        <xs:sequence>
+            <xs:element name="code" type="xs:string"/>
+            <xs:element name="omschrijving" type="xs:string"/>
+            <xs:element name="referentieType" type="xs:string" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!--**** Letter ****-->
+    <xs:simpleType name="Letter">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[a-zA-Z]"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!--**** Alfanumeriek ****-->
+    <xs:simpleType name="Alfanumeriek15">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[a-zA-Z0-9_\+\-]{0,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="Alfanumeriek5">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[a-zA-Z0-9_\+\-]{0,5}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!--**** Tekst ****-->
+    <xs:simpleType name="Tekst16">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="0"/>
+            <xs:maxLength value="16"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+	<xs:simpleType name="Tekst50">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="0"/>
+            <xs:maxLength value="50"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!--**** Numeriek ****-->
+    <xs:simpleType name="Numeriek23DecimaalFractie4">
+        <xs:restriction base="xs:decimal">
+            <xs:totalDigits value="23"/>
+            <xs:fractionDigits value="4"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!--**** Jaar / Datum / Tijdstip ****-->
+    <xs:simpleType name="JaarType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{4}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="DatumIncompleetType">
+        <xs:annotation>
+            <xs:documentation>Een datum heeft een vast formaat: 8 posities, met als invulling jjjjmmdd (jaar-maand-dag),
+                waarbij alleen cijfers zijn toegestaan.
+                Wanneer een gedeelte van de datum onbekend is, wordt dat gerepresenteerd door nullen. De mogelijke
+                waarden van datum zijn:
+                jjjjmmdd volledige datum
+                jjjjmm00 dag onbekend
+                jjjj0000 maand onbekend
+                00000000 datum onbekend, standaardwaarde
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{8}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="TijdstipType">
+        <xs:annotation>
+            <xs:documentation>Een tijdstip bestaat uit een complete datum (volgens de gregoriaanse kalender) en tijd.
+                Het formaat van het tijdstip is jjjjmmddhhmmssmmm, waarbij achtereenvolgens: jjjj - jaartal
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{17}"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="NoValue">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="nietOndersteund"/>
+            <xs:enumeration value="nietGeautoriseerd"/>
+            <xs:enumeration value="geenWaarde"/>
+            <xs:enumeration value="waardeOnbekend"/>
+            <xs:enumeration value="vastgesteldOnbekend"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!--**** Nummer ****-->
+    <xs:simpleType name="BSNummerType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{9}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="RSINummerType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{9}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="KvKNummerType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{8}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="VestigingsnummerType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[0-9]{12}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!--**** Id ****-->
+    <xs:simpleType name="DepotIdType">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="0"/>
+            <xs:maxLength value="36"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!--**** Postcode ****-->
+    <xs:complexType name="PostcodeType">
+        <xs:sequence>
+            <xs:element name="cijfercombinatie">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:pattern value="[0-9]{4}"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="lettercombinatie" minOccurs="0">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:pattern value="[a-zA-Z]{2}"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!--**** Geld ****-->
+    <xs:complexType name="GeldType">
+        <xs:sequence>
+            <xs:element name="waarde">
+                <xs:simpleType>
+                    <xs:restriction base="xs:decimal">
+                        <xs:totalDigits value="18"/>
+                        <xs:fractionDigits value="8"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="valuta" type="EnumeratieType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- **** BagId ****-->
+    <xs:complexType name="BagIdType">
+        <xs:sequence>
+            <xs:element name="identificatieNummeraanduiding" type="Tekst16"/>
+            <xs:element name="identificatieAdresseerbaarObject" type="Tekst16"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!--**** Registratie ****-->
+    <xs:complexType name="RegistratieType">
+        <xs:annotation>
+            <xs:documentation>Generiek registratie type met voor elke type geledende registratie gegevens
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="datumAanvang" type="DatumIncompleetType" minOccurs="0"/>
+            <xs:element name="datumEinde" type="DatumIncompleetType" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="soortMutatie" type="xs:string" use="optional"/>
+        <xs:attribute name="registratieTijdstip" type="TijdstipType" use="optional"/>
+        <xs:attribute name="registratieTijdstipNoValue" type="NoValue" use="optional"/>
+    </xs:complexType>
+
+    <!--**** Basis type voor alle (niet-relatie) types met registratie2_3 gegevens ****-->
+    <xs:complexType name="BasisType" abstract="true">
+        <xs:complexContent>
+            <xs:extension base="MetExtraElementenMogenlijkheidType">
+        <xs:sequence>
+            <xs:element name="registratie" type="RegistratieType" minOccurs="0"/>
+        </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="MetExtraElementenMogenlijkheidType" abstract="true">
+        <xs:sequence>
+            <xs:element name="extraElementen" type="ExtraElementenType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ExtraElementenType">
+        <xs:sequence>
+            <xs:element name="extraElement" nillable="true" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:simpleContent>
+                        <xs:extension base="xs:string">
+                            <xs:attribute name="naam" type="xs:string" use="required"/>
+                            <xs:attribute name="hoortBijGroep" type="xs:string"/>
+                        </xs:extension>
+                    </xs:simpleContent>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+</xs:schema>


### PR DESCRIPTION
JAX-VS doesn't properly embed the entire WSDL inside the jar, and some
locations may not have the firewall rules to allow talking to schemas.kvk.nl.
As such, embed the entire WSDL and its dependencies to allow using it anywhere.