### PR TITLE
nhr-loader: support not providing alias

### DIFF
--- a/brmo-service/src/main/java/nl/b3p/brmo/service/jobs/NHRJob.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/jobs/NHRJob.java
@@ -79,7 +79,7 @@ public class NHRJob implements Job {
             NHRCertificateOptions certOptions = new NHRCertificateOptions();
             certOptions.setKeystore((String) ctx.lookup("java:comp/env/brmo/nhr/keystorePath"));
             certOptions.setKeystorePassword((String) ctx.lookup("java:comp/env/brmo/nhr/keystorePassword"));
-            certOptions.setKeystoreAlias("key");
+            certOptions.setKeystoreAlias(null);
             certOptions.setTruststore((String) ctx.lookup("java:comp/env/brmo/nhr/truststorePath"));
             certOptions.setTruststorePassword((String) ctx.lookup("java:comp/env/brmo/nhr/truststorePassword"));
 

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/NHRActionBean.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/NHRActionBean.java
@@ -113,10 +113,11 @@ public class NHRActionBean implements ActionBean {
                     keyStore.load(keyStoreFile, ((String)InitialContext.doLookup("java:comp/env/brmo/nhr/keystorePassword")).toCharArray());
                 }
 
-                Certificate cert = keyStore.getCertificate("key");
-                if (cert == null) {
-                    statusNotification += "geen certificaat met alias \"key\" gevonden\n";
+                String alias = keyStore.aliases().nextElement();
+                if (alias == null) {
+                    statusNotification += "geen bruikbaar certificaat gevonden";
                 } else {
+                    Certificate cert = keyStore.getCertificate(alias);
                     Date now = new Date();
                     statusCertificateExpiry = ((X509Certificate) cert).getNotAfter();
                     statusDaysUntilExpiry = (statusCertificateExpiry.getTime() - now.getTime()) / (60 * 60 * 24);


### PR DESCRIPTION
In PKCS#12 keystores, aliases are assigned indexes from 0. It also does
not make sense to require the configuration to provide this anyways.