### PR TITLE
NHR: misc fixes

### DIFF
--- a/brmo-service/src/main/java/nl/b3p/brmo/service/jobs/NHRJob.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/jobs/NHRJob.java
@@ -160,12 +160,14 @@ public class NHRJob implements Job {
                     Calendar time = Calendar.getInstance();
                     process.setLaatstGeprobeerd(new Date());
                     // Wait for 30 seconds, then 1 minute, 2 minutes, 4 minutes, ...
-                    int secondsUntilNextTry = 30 * (int) Math.pow(2, process.getProbeerAantal() - 1);
+                    int secondsUntilNextTry = 30 * (int) Math.pow(2, Math.min(process.getProbeerAantal() - 1, 10));
 
                     // Make sure that fetches retry at least every two hours.
                     // (This will happen after 9 retries, or two hours in.)
                     if (secondsUntilNextTry > 7200) {
                         secondsUntilNextTry = 7200;
+                    } else if (secondsUntilNextTry < 30) {
+                        secondsUntilNextTry = 30;
                     }
 
                     time.add(Calendar.SECOND, secondsUntilNextTry);

--- a/brmo-service/src/main/webapp/scripts/nhr.js
+++ b/brmo-service/src/main/webapp/scripts/nhr.js
@@ -40,7 +40,7 @@ Ext.define('B3P.brmo.NHRNummers', {
                         text: "log",
                         dataIndex: 'kvkNummer',
                         renderer: function(value) {
-                           return Ext.String.format('<a href="#" onclick="return openLog({0});" title="Open log"><img src="images/page_text.gif"/></a>', value);
+                           return Ext.String.format('<a href="#" onclick="return openLog(\'{0}\');" title="Open log"><img src="images/page_text.gif"/></a>', value);
                         }
                    }
                 ],


### PR DESCRIPTION
Fixes for the time overflow (if too many retries happen, they start being scheduled into the past, due to float->int conversions, causing a busy loop), and JavaScript interpreting the kvk numbers with voorloopnul as .. numbers, instead of decimal strings (thanks, octal)