### PR TITLE
brmo-service: properly strip quotes around KVK dossiernummers

### DIFF
--- a/brmo-service/src/main/java/nl/b3p/brmo/service/jobs/NHREmailJob.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/jobs/NHREmailJob.java
@@ -65,7 +65,7 @@ public class NHREmailJob implements Job {
                 }
 
                 // Parse the KVK numer out of the CSV
-                line = line.split(",")[0];
+                line = line.split(",")[0].replaceAll("\"", "");
 
                 NHRInschrijving proces;
                 proces = entityManager.find(NHRInschrijving.class, line);

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/NHRActionBean.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/NHRActionBean.java
@@ -294,7 +294,7 @@ public class NHRActionBean implements ActionBean {
 
                 // Parse the first column from a CSV, and accept KVK numbers with zeroes trimmed
                 // (e.g. spreadsheet software parsing the number as a decimal)
-                line = line.split(",")[0];
+                line = line.split(",")[0].replaceAll("\"", "");
                 if (line.length() < 8) {
                     line = StringUtils.leftPad(line, 8, "0");
                 }


### PR DESCRIPTION
blijkt dat Excel stiekem de aanhalingstekens de eerste colom had weggehaald.