### PR TITLE
[BRMO-196] NHR RSGB eenmanszaak fix

### DIFF
--- a/brmo-loader/src/main/resources/xsl/nhr-to-rsgb-xml-3.0.xsl
+++ b/brmo-loader/src/main/resources/xsl/nhr-to-rsgb-xml-3.0.xsl
@@ -260,7 +260,7 @@
                 <fk_3ond_kvk_nummer><xsl:value-of select="."/></fk_3ond_kvk_nummer>
             </xsl:for-each>
             <fk_4pes_sc_identif>
-                <xsl:apply-templates select="cat:heeftAlsEigenaar/cat:rechtspersoon" mode="object_ref"/>
+                <xsl:apply-templates select="cat:heeftAlsEigenaar/*[not(local-name()='relatieRegistratie')]" mode="object_ref"/>
             </fk_4pes_sc_identif>
         </maatschapp_activiteit>
 

--- a/brmo-loader/src/main/resources/xsl/nhr-to-rsgb-xml-3.0.xsl
+++ b/brmo-loader/src/main/resources/xsl/nhr-to-rsgb-xml-3.0.xsl
@@ -90,6 +90,8 @@
                     <xsl:choose>
                         <xsl:when test="cat:geslachtsaanduiding = 'Man'">M</xsl:when>
                         <xsl:when test="cat:geslachtsaanduiding = 'Vrouw'">V</xsl:when>
+                        <xsl:when test="cat:geslachtsaanduiding/cat:code = 'm'">M</xsl:when>
+                        <xsl:when test="cat:geslachtsaanduiding/cat:code = 'v'">V</xsl:when>
                         <xsl:otherwise>O</xsl:otherwise>
                     </xsl:choose>
                 </geslachtsaand>
@@ -514,6 +516,9 @@
             <xsl:if test="cat:rechtspersoon/cat:bezoekLocatiePersoon/cat:adres/cat:binnenlandsAdres">
                 <xsl:value-of select="normalize-space(cat:rechtspersoon/cat:bezoekLocatiePersoon/cat:volledigAdres)"/>
             </xsl:if>
+            <xsl:if test="cat:woonLocatie/cat:adres/cat:binnenlandsAdres">
+                <xsl:value-of select="normalize-space(cat:woonLocatie/cat:volledigAdres)"/>
+            </xsl:if>
         </adres_binnenland>
         <adres_buitenland>
             <xsl:if test="cat:bezoekLocatie/cat:adres/cat:buitenlandsAdres">
@@ -527,6 +532,9 @@
             </xsl:if>
             <xsl:if test="cat:buitenlandseVennootschap/cat:bezoekLocatiePersoon/cat:adres/cat:buitenlandsAdres">
                 <xsl:value-of select="normalize-space(cat:buitenlandseVennootschap/cat:bezoekLocatiePersoon/cat:adres/cat:buitenlandsAdres)"/>
+            </xsl:if>
+            <xsl:if test="cat:woonLocatie/cat:adres/cat:buitenlandsAdres">
+                <xsl:value-of select="normalize-space(cat:woonLocatie/cat:volledigAdres)"/>
             </xsl:if>
         </adres_buitenland>
 

--- a/brmo-loader/src/main/resources/xsl/nhr-to-rsgb-xml-3.0.xsl
+++ b/brmo-loader/src/main/resources/xsl/nhr-to-rsgb-xml-3.0.xsl
@@ -107,6 +107,33 @@
             </ingeschr_nat_prs>
         </comfort>
     </xsl:template>
+    <xsl:template name="persoon">
+        <xsl:choose>
+            <xsl:when test="local-name() = 'natuurlijkPersoon'">
+                <xsl:call-template name="natPersoon" />
+            </xsl:when>
+
+            <xsl:when test="local-name() = 'rechtspersoon'">
+                <xsl:apply-templates select="cat:rechtspersoon"/>
+            </xsl:when>
+
+            <xsl:when test="local-name() = 'buitenlandseVennootschap'">
+                <xsl:apply-templates select="cat:buitenlandseVennootschap"/>
+            </xsl:when>
+
+            <xsl:when test="local-name() = 'samenwerkingsverband'">
+                <xsl:apply-templates select="cat:samenwerkingsverband"/>
+            </xsl:when>
+
+            <xsl:otherwise>
+                <xsl:comment>
+                    <xsl:text>namespace probleem voor node met naam: </xsl:text><xsl:value-of select="name()"/>
+                    <xsl:text> - local-name: </xsl:text><xsl:value-of select="local-name()"/>
+                    <xsl:text> - geen subject records aangemaakt</xsl:text>
+                </xsl:comment>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
 
     <xsl:template name="heeft">
         <xsl:for-each select="./*">
@@ -214,6 +241,10 @@
         <xsl:for-each select="cat:manifesteertZichAls/cat:onderneming">
             <xsl:comment>Maatschappelijke activiteit manifesteert zich als onderneming, met niet-hoofdvestigingen</xsl:comment>
             <xsl:apply-templates select="."/>
+        </xsl:for-each>
+
+        <xsl:for-each select="cat:heeftAlsEigenaar/*[not(local-name()='relatieRegistratie')]">
+            <xsl:call-template name="persoon" />
         </xsl:for-each>
 
         <maatschapp_activiteit column-dat-beg-geldh="datum_aanvang" column-datum-einde-geldh="datum_einde_geldig">

--- a/brmo-loader/src/main/resources/xsl/update-kvk-koppeling.xsl
+++ b/brmo-loader/src/main/resources/xsl/update-kvk-koppeling.xsl
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:cat="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02"
+                version="1.0"
+>
+    <xsl:import href="nhr-to-rsgb-xml-3.0.xsl" />
+    <xsl:template match="/">
+        <root>
+            <data>
+                <xsl:for-each select="cat:maatschappelijkeActiviteit">
+                    <xsl:for-each select="cat:heeftAlsEigenaar/*[not(local-name()='relatieRegistratie')]">
+                        <xsl:call-template name="persoon" />
+                    </xsl:for-each>
+
+                    <maatschapp_activiteit column-dat-beg-geldh="datum_aanvang"
+                                           column-datum-einde-geldh="datum_einde_geldig">
+                        <kvk_nummer>
+                            <xsl:value-of select="cat:kvkNummer"/>
+                        </kvk_nummer>
+
+                        <fk_4pes_sc_identif>
+                            <xsl:apply-templates select="cat:heeftAlsEigenaar/*[not(local-name()='relatieRegistratie')]" mode="object_ref"/>
+                        </fk_4pes_sc_identif>
+                    </maatschapp_activiteit>
+                </xsl:for-each>
+            </data>
+        </root>
+    </xsl:template>
+</xsl:stylesheet>

--- a/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
@@ -63,10 +63,10 @@ public class NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
                 // aantalNat_prs, hoofd vestgID, aantalVestg_activiteit, kvkNummer v MaatschAct, sbiCodes,
                 // aantalFunctionarissen},
                 // #1
-                arguments("/mantis10752/52019667.xml", 2, 1, 1,/*subj*/ 2, 1, 0, "nhr.comVestg.000021991235", 1,
+                arguments("/mantis10752/52019667.xml", 2, 1, 2,/*subj*/ 3, 1, 1, "nhr.comVestg.000021991235", 1,
                         52019667, new String[]{"86912"}, 0),
                 /* #2 Verhoef ortho*/
-                arguments("/nhr-v3/52019667.anon.xml", 2, 1, 1,/*subj*/ 2, 1, 0, "nhr.comVestg.000021991235", 1,
+                arguments("/nhr-v3/52019667.anon.xml", 2, 1, 2,/*subj*/ 3, 1, 1, "nhr.comVestg.000021991235", 1,
                         52019667, new String[]{"86912"}, 0),
                 /* #3 dactari*/
                 arguments("/nhr-v3/16029104.anon.xml", 3, 1, 2 + 6, /*subj*/ 3 + 6, 2, 0 + 6,
@@ -257,6 +257,10 @@ public class NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
         ITable vestg_activiteit = rsgb.createDataSet().getTable("vestg_activiteit");
         assertEquals(aantalVestg_activiteit, vestg_activiteit.getRowCount(),
                 "Het aantal 'vestg_activiteit' records klopt niet");
+
+        ITable maatschapp_activiteit = rsgb.createDataSet().getTable("maatschapp_activiteit");
+
+        assertNotNull(maatschapp_activiteit.getValue(0, "fk_4pes_sc_identif"), "Geen maatschappelijke activiteit -> persoon koppeling");
 
         ITable sbi_activiteit = rsgb.createDataSet().getTable("sbi_activiteit");
         ITable herkomst_metadata = rsgb.createDataSet().getTable("herkomst_metadata");

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/UpdatesActionBean.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/UpdatesActionBean.java
@@ -166,7 +166,8 @@ public class UpdatesActionBean implements ActionBean, ProgressUpdateListener {
             new UpdateProcess("Bijwerken subject adres comfort data", BrmoFramework.BR_BRK, "/xsl/update-comfort-adres.xsl"),
             new UpdateProcess("Bijwerken ingangsdatum_recht zakelijk recht", BrmoFramework.BR_BRK, "/xsl/update-zak_recht-begindatum.xsl", true),
             new UpdateProcess("Bijwerken vestiging activiteit", BrmoFramework.BR_NHR, "/xsl/update-vestg-activiteit.xsl"),
-            new UpdateProcess("Bijwerken non-mailing attribuut maatschappelijke activiteit", BrmoFramework.BR_NHR, "/xsl/update-nonmailing.xsl")
+            new UpdateProcess("Bijwerken non-mailing attribuut maatschappelijke activiteit", BrmoFramework.BR_NHR, "/xsl/update-nonmailing.xsl"),
+            new UpdateProcess("Bijwerking fk_4pes_sc_identif op maatschappelijke activiteit", BrmoFramework.BR_NHR, "/xsl/update-kvk-koppeling.xsl")
         });
     }
 


### PR DESCRIPTION
Fixt alle `heeftAlsEigenaar` die niet een `rechtspersoon` is (bijv. `natuurlijkPersoon,` `buitenlandseVennootschap`, `samenwerkingsverband`), samen met fixes voor de tests (om te controleren dat er altijd een `fk_4pes_sc_identif` aanwezig is)


resolve BRMO-196