### PR TITLE
datamodel: verleng sommige kolomlengtes

### DIFF
--- a/datamodel/generated_scripts/datamodel.xml
+++ b/datamodel/generated_scripts/datamodel.xml
@@ -821,8 +821,8 @@
                desc="AN200"/>
       <column name="publiekrechtelijke_rechtsvorm"
                fullname="Publiekrechtelijke rechtsvorm"
-               type="varchar(40)"
-               desc="AN40"/>
+               type="varchar(60)"
+               desc="AN60"/>
       <column name="rechtstoestand"
                fullname="Rechtstoestand"
                type="varchar(30)"
@@ -3450,8 +3450,8 @@
                desc="AN3"/>
       <column name="soort_bev"
                fullname="Soort Bevoegdheid"
-               type="varchar(30)"
-               desc="AN30"/>
+               type="varchar(50)"
+               desc="AN50"/>
       <column name="volledig_beperkt_volmacht"
                fullname="Volledig Beperkt volmacht"
                type="varchar(1)"

--- a/datamodel/generated_scripts/rsgb_converted_repaired.xml
+++ b/datamodel/generated_scripts/rsgb_converted_repaired.xml
@@ -21120,15 +21120,16 @@
                     typeName="AN200"
                     visibility=""
                     association=""/>
-         <Property elementType="Objecttype - Property"
+         <!--repair.xsl: Ingeschreven niet-natuurlijk persoon: vergroot ruimte publiekrechtelijke rechtsvorm-->
+         <Property type="EAJava_AN40"
+                    typeName="AN60"
+                    elementType="Objecttype - Property"
                     id="EAID_A79988B8_DFD6_49c8_9996_A22579B02F5C"
                     name="Publiekrechtelijke rechtsvorm"
                     lowerValueType="uml:LiteralInteger"
                     lowerValueValue="0"
                     upperValueType="uml:LiteralUnlimitedNatural"
                     upperValueValue="1"
-                    type="EAJava_AN40"
-                    typeName="AN40"
                     visibility=""
                     association=""/>
          <Property elementType="Objecttype - Property"
@@ -26244,7 +26245,10 @@
                  typeName="AN3"
                  visibility=""
                  association=""/>
-      <Property elementType="Objecttype/Relatieklasse - Property"
+      <!--repair.xsl: Functionaris: soort bevoegdheid: kolom vergroot naar 50-->
+      <Property type="EAnone_AN30"
+                 typeName="AN50"
+                 elementType="Objecttype/Relatieklasse - Property"
                  classId="EAID_5A14942C_4B47_46dc_B355_837ACE27B4F7"
                  className="FUNCTIONARIS"
                  isAbstract=""
@@ -26254,8 +26258,6 @@
                  lowerValueValue="0"
                  upperValueType="uml:LiteralUnlimitedNatural"
                  upperValueValue="1"
-                 type="EAnone_AN30"
-                 typeName="AN30"
                  visibility=""
                  association=""/>
       <Property elementType="Objecttype/Relatieklasse - Property"

--- a/datamodel/rsgbrepair.xsl
+++ b/datamodel/rsgbrepair.xsl
@@ -299,4 +299,24 @@
 			<xsl:apply-templates select="@*[name()!='typeName']|node()"/>
 		</xsl:copy>
 	</xsl:template>
+	<xsl:template match="*[@elementType='Objecttype - Property' and @id='EAID_A79988B8_DFD6_49c8_9996_A22579B02F5C']">
+		<xsl:comment>
+			<xsl:text>repair.xsl: Ingeschreven niet-natuurlijk persoon: vergroot ruimte publiekrechtelijke rechtsvorm</xsl:text>
+		</xsl:comment>
+		<xsl:copy>
+			<xsl:attribute name="type" select="'EAJava_AN60'"/>
+			<xsl:attribute name="typeName" select="'AN60'"/>
+			<xsl:apply-templates select="@*[name()!='typeName']|node()"/>
+		</xsl:copy>
+	</xsl:template>
+	<xsl:template match="*[@elementType='Objecttype/Relatieklasse - Property' and @id='EAID_3E00C0F2_1C7E_46d1_A04C_A43820E37FC1']">
+		<xsl:comment>
+			<xsl:text>repair.xsl: Functionaris: soort bevoegdheid: kolom vergroot naar 50</xsl:text>
+		</xsl:comment>
+		<xsl:copy>
+			<xsl:attribute name="type" select="'EANone_AN50'"/>
+			<xsl:attribute name="typeName" select="'AN50'"/>
+			<xsl:apply-templates select="@*[name()!='typeName']|node()"/>
+		</xsl:copy>
+	</xsl:template>
 </xsl:stylesheet>

--- a/datamodel/upgrade_scripts/2.3.1-2.3.2/oracle/rsgb.sql
+++ b/datamodel/upgrade_scripts/2.3.1-2.3.2/oracle/rsgb.sql
@@ -4,6 +4,8 @@
 
 WHENEVER SQLERROR EXIT SQL.SQLCODE
 
+ALTER TABLE ingeschr_niet_nat_prs MODIFY publiekrechtelijke_rechtsvorm VARCHAR2(60);
+ALTER TABLE functionaris MODIFY soort_bev VARCHAR2(50);
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.3.1_naar_2.3.2','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/2.3.1-2.3.2/postgresql/rsgb.sql
+++ b/datamodel/upgrade_scripts/2.3.1-2.3.2/postgresql/rsgb.sql
@@ -4,6 +4,8 @@
 
 set search_path = public,bag;
 
+ALTER TABLE ingeschr_niet_nat_prs MODIFY publiekrechtelijke_rechtsvorm VARCHAR2(60);
+ALTER TABLE functionaris MODIFY soort_bev VARCHAR2(50);
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_2.3.1_naar_2.3.2','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';


### PR DESCRIPTION

- Publiekrechtelijke rechtsvorm is in RSGB gedefinieerd als AN40, maar NHR stuurt langere antwoorden terug
- Idem met soort bevoegdheid

Verkorte naam (en eigenlijk alle naamsvelden) zijn correct gedefinieerd, maar worden verwerkt als `varchar`, deze telt in bytes ipv "tekens" (zoals NHR eigenlijk vereist).