### PR TITLE
Jackson 2.14.x

### DIFF
--- a/.mvn/owasp-suppression.xml
+++ b/.mvn/owasp-suppression.xml
@@ -44,12 +44,10 @@
         <vulnerabilityName>CVE-2022-24198</vulnerabilityName>
     </suppress>
     <suppress>
-        <notes><![CDATA[
-                   file name: log4j-api-2.17.2.jar
-                   see: https://github.com/jeremylong/DependencyCheck/issues/4637
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-api@.*$</packageUrl>
-        <cve>CVE-2022-33915</cve>
+       <notes><![CDATA[
+       file name: hsqldb-2.7.0.jar
+       ]]></notes>
+       <packageUrl regex="true">^pkg:maven/org\.hsqldb/hsqldb@2\.7\.0.*$</packageUrl>
+       <vulnerabilityName>CVE-2022-41853</vulnerabilityName>
     </suppress>
-
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -81,8 +81,8 @@
         <slf4j.version>2.0.3</slf4j.version>
         <jaxb.api.version>2.3.3</jaxb.api.version>
         <jaxb.impl.version>2.3.6</jaxb.impl.version>
-        <jackson.version>2.13.4</jackson.version>
-        <jackson.databind.version>2.13.4</jackson.databind.version>
+        <jackson.version>2.14.0-rc2</jackson.version>
+        <jackson.databind.version>2.14.0-rc2</jackson.databind.version>
         <javax-annotation.version>1.3.2</javax-annotation.version>
         <activation.api.version>1.2.2</activation.api.version>
         <tomcat.version>9.0.68</tomcat.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1357,11 +1357,11 @@
     </reporting>
     <profiles>
         <profile>
-            <!-- actief voor Travis-CI builds -->
+            <!-- actief voor CI builds -->
             <id>postgresql</id>
             <properties>
                 <oracle.jdbc.groupId>com.oracle.database.jdbc</oracle.jdbc.groupId>
-                <oracle.jdbc.artifactId>ojdbc8</oracle.jdbc.artifactId>
+                <oracle.jdbc.artifactId>ojdbc11</oracle.jdbc.artifactId>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
- Jackson resolved CVE-2022-42003
- negeer CVE-2022-41853; we gebruiken alleen vertrouwde input voor hsqldb