### PR TITLE
GeoTools 28.x upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <hibernate.version>5.6.14.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
-        <geotools.version>27.2</geotools.version>
-        <jdbc-util.version>12.2</jdbc-util.version>
+        <geotools.version>28-RC</geotools.version>
+        <jdbc-util.version>13.0-SNAPSHOT</jdbc-util.version>
         <jts.version>1.19.0</jts.version>
         <itextpdf.version>7.2.4</itextpdf.version>
         <postgresql.jdbc.version>42.5.0</postgresql.jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <hibernate.version>5.6.14.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
-        <geotools.version>28-RC</geotools.version>
+        <geotools.version>28.0</geotools.version>
         <jdbc-util.version>13.0-SNAPSHOT</jdbc-util.version>
         <jts.version>1.19.0</jts.version>
         <itextpdf.version>7.2.4</itextpdf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <hibernate.version>5.6.14.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
         <geotools.version>28.0</geotools.version>
-        <jdbc-util.version>13.0-SNAPSHOT</jdbc-util.version>
+        <jdbc-util.version>13.0</jdbc-util.version>
         <jts.version>1.19.0</jts.version>
         <itextpdf.version>7.2.4</itextpdf.version>
         <postgresql.jdbc.version>42.5.0</postgresql.jdbc.version>


### PR DESCRIPTION
- [x] Bump geotools.version van 27.1 naar 28-RC
- [x] Bump geotools.version van 28-RC naar 28.0
- [x] Bump jdbc-util naar 13.0

depends on https://github.com/B3Partners/jdbc-util/pull/370