### PR TITLE
Fix javadoc build voor bag2 loader

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -135,6 +135,8 @@ jobs:
           distribution: 'temurin'
           java-version: 11
           cache: 'maven'
+          # this check can be removed when GH runners update to Javan 11.0.18 or higher
+          check-latest: true
 
       - name: 'Javadoc'
         run: mvn compile javadoc:javadoc -DskipQA=true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -133,9 +133,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          # downgrade to 11 because javadoc bug https://bugs.openjdk.org/browse/JDK-8222091
-          # see https://github.com/B3Partners/brmo/pull/1602
-          java-version: '11.0.16'
+          java-version: 11
           cache: 'maven'
 
       - name: 'Javadoc'

--- a/bag2-loader/pom.xml
+++ b/bag2-loader/pom.xml
@@ -147,6 +147,7 @@ SPDX-License-Identifier: MIT
                     <generatePackage>nl.b3p.brmo.bag2.xml.leveringsdocument</generatePackage>
                     <schemaDirectory>${project.basedir}/src/main/xsd/</schemaDirectory>
                     <schemaIncludes>**/*.xsd</schemaIncludes>
+                    <markGenerated>true</markGenerated>
                 </configuration>
                 <executions>
                     <execution>

--- a/brmo-commandline/pom.xml
+++ b/brmo-commandline/pom.xml
@@ -24,8 +24,6 @@
             <artifactId>commons-cli</artifactId>
         </dependency>
         <dependency>
-            <!-- deze is eigenlijk alleen nodig voor java 11, maar
-            omdat we een runnable jar met classpath maken makkelijk om ook voor java 8 er bij te stoppen -->
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
             <version>${jaxb.api.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -992,6 +992,7 @@
                         <show>package</show>
                         <useStandardDocletOptions>true</useStandardDocletOptions>
                         <links>
+                            <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>
                             <link>https://www.slf4j.org/apidocs/</link>
                             <link>https://docs.oracle.com/javaee/7/api/</link>
                             <link>https://docs.jboss.org/hibernate/orm/5.6/javadocs/</link>
@@ -1000,11 +1001,11 @@
                             <link>https://junit.org/junit5/docs/current/api/</link>
                             <link>https://b3partners.github.io/kadaster-gds2/apidocs/</link>
                             <link>https://b3partners.github.io/jdbc-util/apidocs/</link>
+                            <link>https://jdbc.postgresql.org/documentation/publicapi/</link>
+                            <link>https://www.xmlunit.org/api/java/main/</link>
                         </links>
                         <encoding>${project.build.sourceEncoding}</encoding>
                         <packagesheader>${project.artifactId}</packagesheader>
-                        <!-- dit werkt niet voor veel projecten omdat de detected-link ${project.url}/apidocs is -->
-                        <detectLinks>false</detectLinks>
                         <tags>
                             <tag>
                                 <name>todo</name>


### PR DESCRIPTION
some attempt to workaround https://bugs.openjdk.org/browse/JDK-8295850 / https://bugs.openjdk.org/browse/JDK-8222091

see also https://github.com/corretto/corretto-11/issues/295

Should be fixed around 17 Jan 2023, jdk 11.0.18