### PR TITLE
brmo-service: Check for missing/false `nhr/active` on startup

### DIFF
--- a/brmo-service/src/main/java/nl/b3p/brmo/service/jobs/GeplandeTakenInit.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/jobs/GeplandeTakenInit.java
@@ -13,6 +13,8 @@ import javax.servlet.ServletResponse;
 import java.text.ParseException;
 import java.util.List;
 import java.util.Properties;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import javax.persistence.EntityManager;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -144,6 +146,16 @@ public class GeplandeTakenInit implements Servlet {
     }
 
     private void createNHRJob() throws SchedulerException {
+        Boolean isActive = false;
+        try {
+            isActive = (Boolean) InitialContext.doLookup("java:comp/env/brmo/nhr/active");
+        } catch (NamingException e) {
+        }
+
+        if (!isActive) {
+            return;
+        }
+
         Properties props = new Properties();
         props.put("org.quartz.scheduler.instanceName", NHR_SCHEDULER_NAME);
         props.put("org.quartz.threadPool.threadCount", "1");

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/jobs/NHRJob.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/jobs/NHRJob.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import javax.naming.Context;
 import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
@@ -71,7 +72,12 @@ public class NHRJob implements Job {
     private Dataservice getDataservice() {
         try {
             InitialContext ctx = new InitialContext();
-            Boolean isActive = (Boolean) ctx.lookup("java:comp/env/brmo/nhr/active");
+            Boolean isActive = false;
+            try {
+                isActive = (Boolean) InitialContext.doLookup("java:comp/env/brmo/nhr/active");
+            } catch (NamingException e) {
+            }
+
             if (!isActive) {
                 return null;
             }


### PR DESCRIPTION
Turns out that changing JNDI variables at runtime is not entirely a common thing to do. This disables the entire Quartz scheduler for NHR background fetches if `brmo/nhr/active` is missing/false.