### PR TITLE
[BRMO-259] fix P8 API test welke nu geboortedatum met een verzonnen timestamp aanlevert

### DIFF
--- a/datamodel/src/test/java/nl/b3p/brmo/datamodel/P8ServicesIntegrationTest.java
+++ b/datamodel/src/test/java/nl/b3p/brmo/datamodel/P8ServicesIntegrationTest.java
@@ -259,7 +259,8 @@ public class P8ServicesIntegrationTest extends P8TestFramework {
                 "\"adres\":\"van der Waalsstraat 86, 3132TN VLAARDINGEN\"}],\"offset\":\"0\",\"limit\":\"3\"," +
                 "\"total_item_count\":1000}",
                 body,
-                when(IGNORING_ARRAY_ORDER)
+                // bug in P8; verzint een tijdstip aan datums
+                whenIgnoringPaths("subjecten[*].geboorte_datum")
         );
     }
 }


### PR DESCRIPTION
Voor ieder datum element in de json "verreikt" de P8 API die met het tijdstip van opvragen; in dit geval geboortedatum.; dat is een bug die er al jaren in zit.

De geboortedatum werd tot voor kort niet teruggegeven uit de API.