### PR TITLE
[BRMO-265] Fix `isBetrokkenBij` van Recht

### DIFF
--- a/brmo-loader/src/main/resources/xsl/brk2-snapshot-to-rsgb-xml.xsl
+++ b/brmo-loader/src/main/resources/xsl/brk2-snapshot-to-rsgb-xml.xsl
@@ -854,10 +854,10 @@
             </isontstaanuit>
             <isbetrokkenbij>
                 <xsl:call-template name="domein_identificatie">
-                    <xsl:with-param name="id" select="$recht/Recht:isOntstaanUit/Recht-ref:HoofdsplitsingRef |
-                                                      $recht/Recht:isOntstaanUit/Recht-ref:OndersplitsingRef |
-                                                      $recht/Recht:isOntstaanUit/Recht-ref:SpiegelsplitsingAfkoopErfpachtRef |
-                                                      $recht/Recht:isOntstaanUit/Recht-ref:SpiegelsplitsingOndersplitsingRef"/>
+                    <xsl:with-param name="id" select="$recht/Recht:isBetrokkenBij/Recht-ref:HoofdsplitsingRef |
+                                                      $recht/Recht:isBetrokkenBij/Recht-ref:OndersplitsingRef |
+                                                      $recht/Recht:isBetrokkenBij/Recht-ref:SpiegelsplitsingAfkoopErfpachtRef |
+                                                      $recht/Recht:isBetrokkenBij/Recht-ref:SpiegelsplitsingOndersplitsingRef"/>
                 </xsl:call-template>
             </isbetrokkenbij>
             <isbestemdtot>


### PR DESCRIPTION
In plaats van `Recht:isBetrokkenBij` werd de waarde van `Recht:isOntstaanUit` gebruikt, lijkt een copy-paste fout.

close BRMO-265