### PR TITLE
[BRMO-257] Oracle BRK views

### DIFF
--- a/datamodel/brk/brk2.0_oracle_views.sql
+++ b/datamodel/brk/brk2.0_oracle_views.sql
@@ -613,7 +613,7 @@ COMMENT ON MATERIALIZED VIEW mb_zr_rechth IS
     * voorvoegsel: -
     * voornamen: -
     * aand_naamgebruik: -
-    * geslachtsaand: M/V/X
+    * geslachtsaand: -
     * naam: samengestelde naam bruikbaar voor natuurlijke en niet-natuurlijke subjecten
     * woonadres: meegeleverd adres buiten BAG koppeling om
     * geboortedatum: -
@@ -721,3 +721,396 @@ COMMENT ON MATERIALIZED VIEW mb_avg_zr_rechth IS
     * statutaire_zetel: -
     * rsin: -
     * kvk_nummer: -';
+
+
+CREATE MATERIALIZED VIEW mb_koz_rechth
+            (
+             objectid,
+             koz_identif,
+             begin_geldigheid,
+             begin_geldigheid_datum,
+             type,
+             aanduiding,
+             aanduiding2,
+             sectie,
+             perceelnummer,
+             appartementsindex,
+             gemeentecode,
+             aand_soort_grootte,
+             grootte_perceel,
+             oppervlakte_geom,
+             deelperceelnummer,
+             omschr_deelperceel,
+             verkoop_datum,
+             aard_cultuur_onbebouwd,
+             bedrag,
+             koopjaar,
+             meer_onroerendgoed,
+             valutasoort,
+             loc_omschr,
+             zr_identif,
+             ingangsdatum_recht,
+             subject_identif,
+             aandeel,
+             omschr_aard_verkregenr_recht,
+             indic_betrokken_in_splitsing,
+             soort,
+             geslachtsnaam,
+             voorvoegsel,
+             voornamen,
+             aand_naamgebruik,
+             geslachtsaand,
+             naam,
+             woonadres,
+             geboortedatum,
+             geboorteplaats,
+             overlijdensdatum,
+             bsn,
+             organisatie_naam,
+             rechtsvorm,
+             statutaire_zetel,
+             rsin,
+             kvk_nummer,
+             aantekeningen,
+             gemeente,
+             woonplaats,
+             straatnaam,
+             huisnummer,
+             huisletter,
+             huisnummer_toev,
+             postcode,
+             lon,
+             lat,
+             begrenzing_perceel
+                )
+            BUILD DEFERRED
+    REFRESH ON DEMAND
+AS
+SELECT CAST(ROWNUM AS INTEGER) AS objectid,
+       koz.koz_identif,
+       koz.begin_geldigheid,
+       koz.begin_geldigheid_datum,
+       koz.type,
+       koz.aanduiding,
+       koz.aanduiding2,
+       koz.sectie,
+       koz.perceelnummer,
+       koz.appartementsindex,
+       koz.gemeentecode,
+       koz.aand_soort_grootte,
+       koz.grootte_perceel,
+       koz.oppervlakte_geom,
+       koz.deelperceelnummer,
+       koz.omschr_deelperceel,
+       koz.verkoop_datum,
+       koz.aard_cultuur_onbebouwd,
+       koz.bedrag,
+       koz.koopjaar,
+       koz.meer_onroerendgoed,
+       koz.valutasoort,
+       koz.loc_omschr,
+       zrr.zr_identif,
+       zrr.ingangsdatum_recht,
+       zrr.subject_identif,
+       zrr.aandeel,
+       zrr.omschr_aard_verkregenr_recht,
+       zrr.indic_betrokken_in_splitsing,
+       zrr.soort,
+       zrr.geslachtsnaam,
+       zrr.voorvoegsel,
+       zrr.voornamen,
+       zrr.aand_naamgebruik,
+       zrr.geslachtsaand,
+       zrr.naam,
+       zrr.woonadres,
+       zrr.geboortedatum,
+       zrr.geboorteplaats,
+       zrr.overlijdensdatum,
+       zrr.bsn,
+       zrr.organisatie_naam,
+       zrr.rechtsvorm,
+       zrr.statutaire_zetel,
+       zrr.rsin,
+       zrr.kvk_nummer,
+       zrr.aantekeningen,
+       koz.gemeente,
+       koz.woonplaats,
+       koz.straatnaam,
+       koz.huisnummer,
+       koz.huisletter,
+       koz.huisnummer_toev,
+       koz.postcode,
+       koz.lon,
+       koz.lat,
+       koz.begrenzing_perceel
+FROM mb_zr_rechth zrr
+         RIGHT JOIN
+     mb_kad_onrrnd_zk_adres koz
+     ON
+         zrr.koz_identif = koz.koz_identif;
+
+CREATE UNIQUE INDEX mb_koz_rechth_objectid ON mb_koz_rechth (objectid ASC);
+CREATE INDEX mb_koz_rechth_identif ON mb_koz_rechth (koz_identif ASC);
+INSERT INTO user_sdo_geom_metadata
+VALUES ('MB_KOZ_RECHTH', 'BEGRENZING_PERCEEL',
+        MDSYS.SDO_DIM_ARRAY(MDSYS.SDO_DIM_ELEMENT('X', 12000, 280000, .1),
+                            MDSYS.SDO_DIM_ELEMENT('Y', 304000, 620000, .1)), 28992);
+CREATE INDEX mb_koz_rechth_begr_prcl_idx ON mb_koz_rechth (begrenzing_perceel) INDEXTYPE IS MDSYS.SPATIAL_INDEX;
+
+COMMENT ON MATERIALIZED VIEW mb_koz_rechth IS
+    'commentaar view mb_koz_rechth:
+    kadastrale percelen een appartementsrechten met rechten en rechthebbenden en objectid voor geoserver/arcgis
+    beschikbare kolommen:
+    * objectid: uniek id bruikbaar voor geoserver/arcgis,
+    * koz_identif: natuurlijke id van perceel of appartementsrecht
+    * begin_geldigheid: datum wanneer dit object geldig geworden is (ontstaat of bijgewerkt),
+    * begin_geldigheid_datum: datum wanneer dit object geldig geworden is (ontstaat of bijgewerkt),
+    * type: perceel of appartement,
+    * aanduiding: sectie perceelnummer,
+    * aanduiding2: kadgem sectie perceelnummer appartementsindex,
+    * sectie: -,
+    * perceelnummer: -,
+    * appartementsindex: -,
+    * gemeentecode: -,
+    * aand_soort_grootte: -,
+    * grootte_perceel: -,
+    * oppervlakte_geom: oppervlakte berekend uit geometrie, hoort gelijk te zijn aan grootte_perceel,
+    * deelperceelnummer: -,
+    * omschr_deelperceel: -,
+    * verkoop_datum: laatste datum gevonden akten van verkoop,
+    * aard_cultuur_onbebouwd: -,
+    * bedrag: -,
+    * koopjaar: -,
+    * meer_onroerendgoed: -,
+    * valutasoort: -,
+    * loc_omschr: adres buiten BAG om meegegeven,
+    * zr_identif: natuurlijk id van zakelijk recht,
+    * ingangsdatum_recht: - ,
+    * subject_identif: natuurlijk id van rechthebbende,
+    * aandeel: samenvoeging van teller en noemer (1/2),
+    * omschr_aard_verkregen_recht: tekstuele omschrijving aard recht,
+    * indic_betrokken_in_splitsing: -,
+    * soort: soort subject zoals natuurlijk, niet-natuurlijk enz.
+    * geslachtsnaam: -
+    * voorvoegsel: -
+    * voornamen: -
+    * aand_naamgebruik: -
+    * geslachtsaand: -
+    * naam: samengestelde naam bruikbaar voor natuurlijke en niet-natuurlijke subjecten
+    * woonadres: meegeleverd adres buiten BAG koppeling om
+    * geboortedatum: -
+    * geboorteplaats: -
+    * overlijdensdatum: -
+    * bsn: -
+    * organisatie_naam: naam niet natuurlijk subject
+    * rechtsvorm: -
+    * statutaire_zetel: -
+    * rsin: -
+    * kvk_nummer: -
+    * aantekeningen: samenvoeging van alle aantekeningen van dit recht,
+    * gemeente: -,
+    * woonplaats: -,
+    * straatnaam: -,
+    * huisnummer: -,
+    * huisletter: -,
+    * huisnummer_toev: -,
+    * postcode: -,
+    * lon: coordinaat als WSG84,
+    * lon: coordinaat als WSG84,
+    * begrenzing_perceel: perceelvlak';
+
+
+CREATE MATERIALIZED VIEW mb_avg_koz_rechth
+            (
+             objectid,
+             koz_identif,
+             begin_geldigheid,
+             begin_geldigheid_datum,
+             type,
+             aanduiding,
+             aanduiding2,
+             sectie,
+             perceelnummer,
+             appartementsindex,
+             gemeentecode,
+             aand_soort_grootte,
+             grootte_perceel,
+             oppervlakte_geom,
+             deelperceelnummer,
+             omschr_deelperceel,
+             verkoop_datum,
+             aard_cultuur_onbebouwd,
+             bedrag,
+             koopjaar,
+             meer_onroerendgoed,
+             valutasoort,
+             loc_omschr,
+             zr_identif,
+             ingangsdatum_recht,
+             subject_identif,
+             aandeel,
+             omschr_aard_verkregenr_recht,
+             indic_betrokken_in_splitsing,
+             soort,
+             geslachtsnaam,
+             voorvoegsel,
+             voornamen,
+             aand_naamgebruik,
+             geslachtsaand,
+             naam,
+             woonadres,
+             geboortedatum,
+             geboorteplaats,
+             overlijdensdatum,
+             bsn,
+             organisatie_naam,
+             rechtsvorm,
+             statutaire_zetel,
+             rsin,
+             kvk_nummer,
+             aantekeningen,
+             gemeente,
+             woonplaats,
+             straatnaam,
+             huisnummer,
+             huisletter,
+             huisnummer_toev,
+             postcode,
+             lon,
+             lat,
+             begrenzing_perceel
+                )
+            BUILD DEFERRED
+    REFRESH ON DEMAND
+AS
+SELECT CAST(ROWNUM AS INTEGER) AS objectid,
+       koz.koz_identif,
+       koz.begin_geldigheid,
+       koz.begin_geldigheid_datum,
+       koz.type,
+       koz.aanduiding,
+       koz.aanduiding2,
+       koz.sectie,
+       koz.perceelnummer,
+       koz.appartementsindex,
+       koz.gemeentecode,
+       koz.aand_soort_grootte,
+       koz.grootte_perceel,
+       koz.oppervlakte_geom,
+       koz.deelperceelnummer,
+       koz.omschr_deelperceel,
+       koz.verkoop_datum,
+       koz.aard_cultuur_onbebouwd,
+       koz.bedrag,
+       koz.koopjaar,
+       koz.meer_onroerendgoed,
+       koz.valutasoort,
+       koz.loc_omschr,
+       zrr.zr_identif,
+       zrr.ingangsdatum_recht,
+       zrr.subject_identif,
+       zrr.aandeel,
+       zrr.omschr_aard_verkregenr_recht,
+       zrr.indic_betrokken_in_splitsing,
+       zrr.soort,
+       zrr.geslachtsnaam,
+       zrr.voorvoegsel,
+       zrr.voornamen,
+       zrr.aand_naamgebruik,
+       zrr.geslachtsaand,
+       zrr.naam,
+       zrr.woonadres,
+       zrr.geboortedatum,
+       zrr.geboorteplaats,
+       zrr.overlijdensdatum,
+       zrr.bsn,
+       zrr.organisatie_naam,
+       zrr.rechtsvorm,
+       zrr.statutaire_zetel,
+       zrr.rsin,
+       zrr.kvk_nummer,
+       zrr.aantekeningen,
+       koz.gemeente,
+       koz.woonplaats,
+       koz.straatnaam,
+       koz.huisnummer,
+       koz.huisletter,
+       koz.huisnummer_toev,
+       koz.postcode,
+       koz.lon,
+       koz.lat,
+       koz.begrenzing_perceel
+FROM mb_avg_zr_rechth zrr
+         RIGHT JOIN
+     mb_kad_onrrnd_zk_adres koz
+     ON zrr.koz_identif = koz.koz_identif;
+
+CREATE UNIQUE INDEX MB_AVG_KOZ_RECHTH_OBJECTID ON MB_AVG_KOZ_RECHTH (OBJECTID ASC);
+CREATE INDEX MB_AVG_KOZ_RECHTH_IDENTIF ON MB_AVG_KOZ_RECHTH (KOZ_IDENTIF ASC);
+INSERT INTO USER_SDO_GEOM_METADATA
+VALUES ('MB_AVG_KOZ_RECHTH', 'BEGRENZING_PERCEEL', MDSYS.SDO_DIM_ARRAY(MDSYS.SDO_DIM_ELEMENT('X', 12000, 280000, .1),
+                                                                       MDSYS.SDO_DIM_ELEMENT('Y', 304000, 620000, .1)),
+        28992);
+CREATE INDEX MB_AVG_KOZ_RECHTH_BEGR_P_IDX ON MB_AVG_KOZ_RECHTH (BEGRENZING_PERCEEL) INDEXTYPE IS MDSYS.SPATIAL_INDEX;
+
+COMMENT ON MATERIALIZED VIEW mb_avg_koz_rechth IS
+    'commentaar view mb_avg_koz_rechth:
+    kadastrale percelen een appartementsrechten met rechten en rechthebbenden geschoond voor avg en objectid voor geoserver/arcgis
+    beschikbare kolommen:
+    * objectid: uniek id bruikbaar voor geoserver/arcgis,
+    * koz_identif: natuurlijke id van perceel of appartementsrecht
+    * begin_geldigheid: datum wanneer dit object geldig geworden is (ontstaat of bijgewerkt),
+    * begin_geldigheid_datum: datum wanneer dit object geldig geworden is (ontstaat of bijgewerkt),
+    * type: perceel of appartement,
+    * aanduiding: sectie perceelnummer,
+    * aanduiding2: kadgem sectie perceelnummer appartementsindex,
+    * sectie: -,
+    * perceelnummer: -,
+    * appartementsindex: -,
+    * gemeentecode: -,
+    * aand_soort_grootte: -,
+    * grootte_perceel: -,
+    * oppervlakte_geom: oppervlakte berekend uit geometrie, hoort gelijk te zijn aan grootte_perceel,
+    * deelperceelnummer: -,
+    * omschr_deelperceel: -,
+    * verkoop_datum: laatste datum gevonden akten van verkoop,
+    * aard_cultuur_onbebouwd: -,
+    * bedrag: -,
+    * koopjaar: -,
+    * meer_onroerendgoed: -,
+    * valutasoort: -,
+    * loc_omschr: adres buiten BAG om meegegeven,
+    * zr_identif: natuurlijk id van zakelijk recht,
+    * ingangsdatum_recht: - ,
+    * subject_identif: natuurlijk id van rechthebbende,
+    * aandeel: samenvoeging van teller en noemer (1/2),
+    * omschr_aard_verkregen_recht: tekstuele omschrijving aard recht,
+    * indic_betrokken_in_splitsing: -,
+    * soort: soort subject zoals natuurlijk, niet-natuurlijk enz.
+    * geslachtsnaam: NULL (avg)
+    * voorvoegsel: NULL (avg)
+    * voornamen: NULL (avg)
+    * aand_naamgebruik: NULL (avg)
+    * geslachtsaand:NULL (avg)
+    * naam: gelijk aan organisatie_naam
+    * woonadres: NULL (avg)
+    * geboortedatum: NULL (avg)
+    * geboorteplaats: NULL (avg)
+    * overlijdensdatum: NULL (avg)
+    * bsn: NULL (avg)
+    * organisatie_naam: naam niet natuurlijk subject
+    * rechtsvorm: -
+    * statutaire_zetel: -
+    * rsin: -
+    * kvk_nummer: -
+    * aantekeningen: samenvoeging van alle aantekeningen van dit recht,
+    * gemeente: -,
+    * woonplaats: -,
+    * straatnaam: -,
+    * huisnummer: -,
+    * huisletter: -,
+    * huisnummer_toev: -,
+    * postcode: -,
+    * lon: coordinaat als WSG84,
+    * lat: coordinaat als WSG84,
+    * begrenzing_perceel: perceelvlak';

--- a/datamodel/brk/brk2.0_oracle_views.sql
+++ b/datamodel/brk/brk2.0_oracle_views.sql
@@ -1,3 +1,167 @@
 ALTER SESSION SET NLS_LENGTH_SEMANTICS='CHAR';
 SET DEFINE OFF;
 WHENEVER SQLERROR EXIT sql.sqlcode;
+
+CREATE MATERIALIZED VIEW mb_subject
+            (
+             objectid,
+             subject_identif,
+             soort,
+             geslachtsnaam,
+             voorvoegsel,
+             voornamen,
+             aand_naamgebruik,
+             geslachtsaand,
+             naam,
+             woonadres,
+             geboortedatum,
+             geboorteplaats,
+             overlijdensdatum,
+             bsn,
+             organisatie_naam,
+             rechtsvorm,
+             statutaire_zetel,
+             rsin,
+             kvk_nummer
+                )
+            BUILD DEFERRED
+    REFRESH ON DEMAND
+AS
+SELECT CAST(ROWNUM AS INTEGER)                            AS objectid,
+       p.identificatie                                    AS subject_identif,
+       p.soort                                            AS soort,
+       np.geslachtsnaam                                   AS geslachtsnaam,
+       np.voorvoegselsgeslachtsnaam                       AS voorvoegsel,
+       np.voornamen                                       AS voornamen,
+       np.aanduidingnaamgebruik                           AS aand_naamgebruik,
+       np.geslacht                                        AS geslachtsaand,
+       CASE
+           WHEN (nnp.statutairenaam IS NOT NULL)
+               THEN (nnp.statutairenaam)
+           ELSE ((REPLACE(COALESCE(np.voornamen, '') || ' ' ||
+                          COALESCE(np.voorvoegselsgeslachtsnaam, '') || ' ', '  ', ' ') ||
+                  COALESCE(np.geslachtsnaam, '')))
+           END                                            AS naam,
+       REPLACE(COALESCE(a.openbareruimtenaam, '') || ' ' || COALESCE(TO_CHAR(a.huisnummer), '') ||
+               COALESCE(a.huisletter, '') || COALESCE(a.huisnummertoevoeging, '') || ' ' ||
+               COALESCE(a.woonplaatsnaam, ''), '  ', ' ') AS woonadres,
+       np.geboortedatum                                   AS geboortedatum,
+       np.geboorteplaats                                  AS geboorteplaats,
+       np.datumoverlijden                                 AS overlijdensdatum,
+       np.bsn                                             AS bsn,
+       nnp.statutairenaam                                 AS organisatie_naam,
+       nnp.rechtsvorm                                     AS rechtsvorm,
+       nnp.statutairezetel                                AS statutaire_zetel,
+       nnp.rsin                                           AS rsin,
+       nnp.kvknummer                                      AS kvk_nummer
+FROM persoon p
+         LEFT JOIN natuurlijkpersoon np on p.identificatie = np.identificatie
+         LEFT JOIN nietnatuurlijkpersoon nnp on p.identificatie = nnp.identificatie
+         LEFT JOIN adres a on p.woonlocatie = a.identificatie
+;
+
+CREATE UNIQUE INDEX mb_subject_objectid ON mb_subject (objectid ASC);
+CREATE INDEX mb_subject_identif ON mb_subject (subject_identif ASC);
+
+COMMENT ON MATERIALIZED VIEW mb_subject IS
+    'commentaar view mb_subject:
+    samenvoeging alle soorten subjecten: natuurlijk en niet-natuurlijk.
+
+    beschikbare kolommen:
+    * objectid: uniek id bruikbaar voor geoserver/arcgis,
+    * subject_identif: natuurlijke id van subject
+    * soort: soort subject zoals natuurlijk, niet-natuurlijk enz.
+    * geslachtsnaam: -
+    * voorvoegsel: -
+    * voornamen: -
+    * aand_naamgebruik: -
+    * geslachtsaand: -
+    * naam: samengestelde naam bruikbaar voor natuurlijke en niet-natuurlijke subjecten
+    * woonadres: woonlocatie meegeleverd adres buiten BAG koppeling om
+    * geboortedatum: -
+    * geboorteplaats: -
+    * overlijdensdatum: -
+    * bsn: -
+    * organisatie_naam: statutairenaam NNP
+    * rechtsvorm: -
+    * statutaire_zetel: -
+    * rsin: -
+    * kvk_nummer: -
+    ';
+
+
+CREATE MATERIALIZED VIEW mb_avg_subject
+            (
+             objectid,
+             subject_identif,
+             soort,
+             geslachtsnaam,
+             voorvoegsel,
+             voornamen,
+             aand_naamgebruik,
+             geslachtsaand,
+             naam,
+             woonadres,
+             geboortedatum,
+             geboorteplaats,
+             overlijdensdatum,
+             bsn,
+             organisatie_naam,
+             rechtsvorm,
+             statutaire_zetel,
+             rsin,
+             kvk_nummer
+                )
+            BUILD DEFERRED
+    REFRESH ON DEMAND
+AS
+SELECT s.objectid,
+       s.subject_identif                  AS subject_identif,
+       s.soort,
+       CAST(NULL AS CHARACTER VARYING(1)) AS geslachtsnaam,
+       CAST(NULL AS CHARACTER VARYING(1)) AS voorvoegsel,
+       CAST(NULL AS CHARACTER VARYING(1)) AS voornamen,
+       CAST(NULL AS CHARACTER VARYING(1)) AS aand_naamgebruik,
+       CAST(NULL AS CHARACTER VARYING(1)) AS geslachtsaand,
+       s.organisatie_naam                 AS naam,
+       CAST(NULL AS CHARACTER VARYING(1)) AS woonadres,
+       CAST(NULL AS CHARACTER VARYING(1)) AS geboortedatum,
+       CAST(NULL AS CHARACTER VARYING(1)) AS geboorteplaats,
+       CAST(NULL AS CHARACTER VARYING(1)) AS overlijdensdatum,
+       CAST(NULL AS CHARACTER VARYING(1)) AS bsn,
+       s.organisatie_naam,
+       s.rechtsvorm,
+       s.statutaire_zetel,
+       s.rsin,
+       s.kvk_nummer
+FROM mb_subject s;
+
+CREATE UNIQUE INDEX mb_avg_subject_objectid ON mb_avg_subject (objectid ASC);
+CREATE INDEX mb_avg_subject_identif ON mb_avg_subject (subject_identif ASC);
+
+COMMENT ON MATERIALIZED VIEW mb_avg_subject IS
+    'commentaar view mb_avg_subject:
+    volledig subject (natuurlijk en niet natuurlijk) geschoond voor avg
+    beschikbare kolommen:
+    * objectid: uniek id bruikbaar voor geoserver/arcgis,
+    * subject_identif: natuurlijke id van subject
+    * soort: soort subject zoals natuurlijk, niet-natuurlijk enz.
+    * geslachtsnaam: NULL (avg)
+    * voorvoegsel: NULL (avg)
+    * voornamen: NULL (avg)
+    * aand_naamgebruik: NULL (avg)
+    * geslachtsaand:NULL (avg)
+    * naam: gelijk aan organisatie_naam
+    * woonadres: NULL (avg)
+    * geboortedatum: NULL (avg)
+    * geboorteplaats: NULL (avg)
+    * overlijdensdatum: NULL (avg)
+    * bsn: NULL (avg)
+    * organisatie_naam: naam niet natuurlijk subject
+    * rechtsvorm: -
+    * statutaire_zetel: -
+    * rsin: -
+    * kvk_nummer: -
+    ';
+
+

--- a/datamodel/brk/brk2.0_oracle_views.sql
+++ b/datamodel/brk/brk2.0_oracle_views.sql
@@ -526,3 +526,198 @@ COMMENT ON TABLE vb_util_zk_recht IS
     * omschr_aard_verkregen_recht: tekstuele omschrijving aard recht,
     * fk_3avr_aand: code aard recht,
     * aantekeningen: samenvoeging van alle aantekening op dit recht';
+
+
+CREATE MATERIALIZED VIEW mb_zr_rechth
+            (
+             objectid,
+             zr_identif,
+             ingangsdatum_recht,
+             subject_identif,
+             koz_identif,
+             aandeel,
+             omschr_aard_verkregenr_recht,
+             indic_betrokken_in_splitsing,
+             aantekeningen,
+             soort,
+             geslachtsnaam,
+             voorvoegsel,
+             voornamen,
+             aand_naamgebruik,
+             geslachtsaand,
+             naam,
+             woonadres,
+             geboortedatum,
+             geboorteplaats,
+             overlijdensdatum,
+             bsn,
+             organisatie_naam,
+             rechtsvorm,
+             statutaire_zetel,
+             rsin,
+             kvk_nummer
+                )
+            BUILD DEFERRED
+    REFRESH ON DEMAND
+AS
+SELECT CAST(ROWNUM AS INTEGER) AS objectid,
+       uzr.zr_identif          as zr_identif,
+       uzr.ingangsdatum_recht,
+       uzr.subject_identif,
+       uzr.koz_identif,
+       uzr.aandeel,
+       uzr.omschr_aard_verkregenr_recht,
+       uzr.indic_betrokken_in_splitsing,
+       uzr.aantekeningen,
+       vs.soort,
+       vs.geslachtsnaam,
+       vs.voorvoegsel,
+       vs.voornamen,
+       vs.aand_naamgebruik,
+       vs.geslachtsaand,
+       vs.naam,
+       vs.woonadres,
+       vs.geboortedatum,
+       vs.geboorteplaats,
+       vs.overlijdensdatum,
+       vs.bsn,
+       vs.organisatie_naam,
+       vs.rechtsvorm,
+       vs.statutaire_zetel,
+       vs.rsin,
+       vs.kvk_nummer
+FROM vb_util_zk_recht uzr
+         JOIN
+     mb_subject vs
+     ON
+         uzr.subject_identif = vs.subject_identif;
+
+CREATE UNIQUE INDEX mb_zr_rechth_objectid ON mb_zr_rechth (objectid ASC);
+CREATE INDEX mb_zr_rechth_identif ON mb_zr_rechth (zr_identif ASC);
+
+COMMENT ON MATERIALIZED VIEW mb_zr_rechth IS
+    'commentaar view mb_zr_rechth:
+    alle zakelijke rechten met rechthebbenden en referentie naar kadastraal onroerende zaak (perceel of appartementsrecht)
+    beschikbare kolommen:
+    * objectid: uniek id bruikbaar voor geoserver/arcgis,
+    * zr_identif: natuurlijke id van zakelijk recht,
+    * ingangsdatum_recht: -
+    * subject_identif: natuurlijk id van subject (natuurlijk of niet natuurlijk) welke rechthebbende is,
+    * koz_identif: natuurlijk id van kadastrale onroerende zaak (perceel of appratementsrecht) dat gekoppeld is,
+    * aandeel: samenvoeging van teller en noemer (1/2),
+    * omschr_aard_verkregen_recht: tekstuele omschrijving aard recht,
+    * indic_betrokken_in_splitsing: -,
+    * aantekeningen: samenvoeging van alle rechten voor dit recht,
+    * soort: soort subject zoals natuurlijk, niet-natuurlijk enz.
+    * geslachtsnaam: -
+    * voorvoegsel: -
+    * voornamen: -
+    * aand_naamgebruik: -
+    * geslachtsaand: M/V/X
+    * naam: samengestelde naam bruikbaar voor natuurlijke en niet-natuurlijke subjecten
+    * woonadres: meegeleverd adres buiten BAG koppeling om
+    * geboortedatum: -
+    * geboorteplaats: -
+    * overlijdensdatum: -
+    * bsn: -
+    * organisatie_naam: naam niet natuurlijk subject
+    * rechtsvorm: -
+    * statutaire_zetel: -
+    * rsin: -
+    * kvk_nummer: -';
+
+
+CREATE MATERIALIZED VIEW mb_avg_zr_rechth
+            (
+             objectid,
+             zr_identif,
+             ingangsdatum_recht,
+             subject_identif,
+             koz_identif,
+             aandeel,
+             omschr_aard_verkregenr_recht,
+             indic_betrokken_in_splitsing,
+             aantekeningen,
+             soort,
+             geslachtsnaam,
+             voorvoegsel,
+             voornamen,
+             aand_naamgebruik,
+             geslachtsaand,
+             naam,
+             woonadres,
+             geboortedatum,
+             geboorteplaats,
+             overlijdensdatum,
+             bsn,
+             organisatie_naam,
+             rechtsvorm,
+             statutaire_zetel,
+             rsin,
+             kvk_nummer
+                )
+            BUILD DEFERRED
+    REFRESH ON DEMAND
+AS
+SELECT CAST(ROWNUM AS INTEGER) AS objectid,
+       uzr.zr_identif          AS zr_identif,
+       uzr.ingangsdatum_recht,
+       uzr.subject_identif,
+       uzr.koz_identif,
+       uzr.aandeel,
+       uzr.omschr_aard_verkregenr_recht,
+       uzr.indic_betrokken_in_splitsing,
+       uzr.aantekeningen,
+       vs.soort,
+       vs.geslachtsnaam,
+       vs.voorvoegsel,
+       vs.voornamen,
+       vs.aand_naamgebruik,
+       vs.geslachtsaand,
+       vs.naam,
+       vs.woonadres,
+       vs.geboortedatum,
+       vs.geboorteplaats,
+       vs.overlijdensdatum,
+       vs.bsn,
+       vs.organisatie_naam,
+       vs.rechtsvorm,
+       vs.statutaire_zetel,
+       vs.rsin,
+       vs.kvk_nummer
+FROM vb_util_zk_recht uzr
+         JOIN mb_avg_subject vs ON uzr.subject_identif = vs.subject_identif;
+
+CREATE UNIQUE INDEX mb_avg_zr_rechth_objectid ON mb_avg_zr_rechth (objectid ASC);
+CREATE INDEX mb_avg_zr_rechth_identif ON mb_avg_zr_rechth (zr_identif ASC);
+
+COMMENT ON MATERIALIZED VIEW mb_avg_zr_rechth IS
+    'commentaar view mb_avg_zr_rechth:
+    alle zakelijke rechten met voor avg geschoonde rechthebbenden en referentie naar kadastraal onroerende zaak (perceel of appartementsrecht)
+    beschikbare kolommen:
+    * objectid: uniek id bruikbaar voor geoserver/arcgis,
+    * zr_identif: natuurlijke id van zakelijk recht,
+    * ingangsdatum_recht: -,
+    * subject_identif: natuurlijk id van subject (natuurlijk of niet natuurlijk) welke rechthebbende is,
+    * koz_identif: natuurlijk id van kadastrale onroerende zaak (perceel of appratementsrecht) dat gekoppeld is,
+    * aandeel: samenvoeging van teller en noemer (1/2),
+    * omschr_aard_verkregen_recht: tekstuele omschrijving aard recht,
+    * indic_betrokken_in_splitsing: -,
+    * aantekeningen: samenvoeging van alle aantekeningen van dit recht
+    * soort: soort subject zoals natuurlijk, niet-natuurlijk enz.
+    * geslachtsnaam: NULL (avg)
+    * voorvoegsel: NULL (avg)
+    * voornamen: NULL (avg)
+    * aand_naamgebruik: NULL (avg)
+    * geslachtsaand:NULL (avg)
+    * naam: gelijk aan organisatie_naam
+    * woonadres: NULL (avg)
+    * geboortedatum: NULL (avg)
+    * geboorteplaats: NULL (avg)
+    * overlijdensdatum: NULL (avg)
+    * bsn: NULL (avg)
+    * organisatie_naam: naam niet natuurlijk subject
+    * rechtsvorm: -
+    * statutaire_zetel: -
+    * rsin: -
+    * kvk_nummer: -';

--- a/datamodel/brk/brk2.0_oracle_views.sql
+++ b/datamodel/brk/brk2.0_oracle_views.sql
@@ -165,3 +165,189 @@ COMMENT ON MATERIALIZED VIEW mb_avg_subject IS
     ';
 
 
+
+CREATE MATERIALIZED VIEW mb_kad_onrrnd_zk_adres
+            (
+             objectid,
+             koz_identif,
+             begin_geldigheid,
+             begin_geldigheid_datum,
+             benoemdobj_identif,
+             type,
+             aanduiding,
+             aanduiding2,
+             sectie,
+             perceelnummer,
+             appartementsindex,
+             gemeentecode,
+             aand_soort_grootte,
+             grootte_perceel,
+             oppervlakte_geom,
+             deelperceelnummer,
+             omschr_deelperceel,
+             verkoop_datum,
+             aard_cultuur_onbebouwd,
+             bedrag,
+             koopjaar,
+             meer_onroerendgoed,
+             valutasoort,
+             loc_omschr,
+             aantekeningen,
+             na_identif,
+             na_status,
+             gemeente,
+             woonplaats,
+             straatnaam,
+             huisnummer,
+             huisletter,
+             huisnummer_toev,
+             postcode,
+             gebruiksdoelen,
+             oppervlakte_obj,
+             lon,
+             lat,
+             begrenzing_perceel
+                )
+            BUILD DEFERRED
+    REFRESH ON DEMAND
+AS
+SELECT CAST(ROWNUM AS INTEGER)                                                 AS objectid,
+       qry.identificatie                                                       AS koz_identif,
+       TO_CHAR(o.begingeldigheid)                                              AS begin_geldigheid,
+       o.begingeldigheid                                                       AS begin_geldigheid_datum,
+       -- koppeling met BAG
+       CAST(NULL AS VARCHAR2(255 CHAR))                                        AS benoemdobj_identif,
+       qry.type                                                                AS type,
+       COALESCE(o.sectie, '') || ' ' || COALESCE(TO_CHAR(o.perceelnummer), '') AS aanduiding,
+       COALESCE(o.akrkadastralegemeente, '') || ' ' || COALESCE(o.sectie, '') || ' ' ||
+       COALESCE(TO_CHAR(o.perceelnummer), '') ||
+       ' ' || COALESCE(TO_CHAR(o.appartementsrechtvolgnummer), '')             AS aanduiding2,
+       o.sectie                                                                AS sectie,
+       o.perceelnummer                                                         AS perceelnummer,
+       o.appartementsrechtvolgnummer                                           AS appartementsindex,
+       o.akrkadastralegemeente                                                 AS gemeentecode,
+       qry.soortgrootte                                                        AS aand_soort_grootte,
+       qry.kadastralegrootte                                                   AS grootte_perceel,
+       SDO_GEOM.SDO_AREA(qry.begrenzing_perceel, 0.1)                          AS oppervlakte_geom,
+       -- bestaat niet
+       CAST(NULL AS VARCHAR2(4 CHAR))                                          AS deelperceelnummer,
+       -- bestaat niet
+       CAST(NULL AS VARCHAR2(1120 CHAR))                                       AS omschr_deelperceel,
+       -- TODO verkoop datum uit stukdeel via recht
+       CAST(NULL AS DATE)                                                      AS verkoop_datum,
+       o.aard_cultuur_onbebouwd                                                AS aard_cultuur_onbebouwd,
+       o.koopsom_bedrag                                                        AS bedrag,
+       o.koopsom_koopjaar                                                      AS koopjaar,
+       o.koopsom_indicatiemeerobjecten                                         AS meer_onroerendgoed,
+       o.koopsom_valuta                                                        AS valutasoort,
+       -- TODO BRK adres?
+       CAST(NULL AS VARCHAR2(255 CHAR))                                        AS loc_omschr,
+       aantekeningen.aantekeningen                                             AS aantekeningen,
+       -- koppeling met BAG
+       CAST(NULL AS VARCHAR2(4 CHAR))                                          AS na_identif,
+       -- koppeling met BAG
+       CAST(NULL AS VARCHAR2(80 CHAR))                                         AS na_status,
+       -- koppeling met BAG
+       CAST(NULL AS VARCHAR2(40 CHAR))                                         AS gemeente,
+       -- koppeling met BAG
+       CAST(NULL AS VARCHAR2(80 CHAR))                                         AS woonplaats,
+       -- koppeling met BAG
+       CAST(NULL AS VARCHAR2(80 CHAR))                                         AS straatnaam,
+       -- koppeling met BAG
+       CAST(NULL AS NUMBER(4))                                                 AS huisnummer,
+       -- koppeling met BAG
+       CAST(NULL AS VARCHAR2(1 CHAR))                                          AS huisletter,
+       -- koppeling met BAG
+       CAST(NULL AS VARCHAR2(4 CHAR))                                          AS huisnummer_toev,
+       -- koppeling met BAG
+       CAST(NULL AS VARCHAR2(6 CHAR))                                          AS postcode,
+       -- koppeling met BAG
+       CAST(NULL AS VARCHAR2(80 CHAR))                                         AS gebruiksdoelen,
+       -- koppeling met BAG
+       CAST(NULL AS NUMBER(4))                                                 AS oppervlakte_obj,
+       SDO_CS.TRANSFORM((qry.plaatscoordinaten), 4326).SDO_POINT.X             AS lon,
+       SDO_CS.TRANSFORM((qry.plaatscoordinaten), 4326).SDO_POINT.Y             AS lat,
+       qry.begrenzing_perceel                                                  AS begrenzing_perceel
+FROM (SELECT p.identificatie      AS identificatie,
+             'perceel'            AS type,
+             p.soortgrootte       AS soortgrootte,
+             p.kadastralegrootte  AS kadastralegrootte,
+             p.begrenzing_perceel AS begrenzing_perceel,
+             p.plaatscoordinaten  AS plaatscoordinaten
+      FROM perceel p
+      UNION ALL
+      SELECT a.identificatie             AS identificatie,
+             'appartement'               AS type,
+             CAST(NULL AS VARCHAR2(100)) AS soortgrootte,
+             CAST(NULL AS NUMBER)        AS kadastralegrootte,
+             CAST(NULL AS SDO_GEOMETRY)  AS begrenzing_perceel,
+             CAST(NULL AS SDO_GEOMETRY)  AS plaatscoordinaten
+      FROM appartementsrecht a) qry
+         JOIN onroerendezaak o ON qry.identificatie = o.identificatie
+         LEFT JOIN(SELECT r.aantekeningkadastraalobject,
+                          LISTAGG(
+                                      'id: ' || COALESCE(r.identificatie, '') || ', '
+                                      || 'aard: ' || COALESCE(r.aard, '') || ', '
+                                      || 'begin: ' || COALESCE(TO_CHAR(r.begingeldigheid), '') || ', '
+                                      || 'beschrijving: ' || COALESCE(r.omschrijving, '') || ', '
+                                      || 'eind: ' || COALESCE(TO_CHAR(r.einddatum), '') || ', '
+                                      || 'koz-id: ' || COALESCE(r.aantekeningkadastraalobject, '') || ', '
+                                      || 'subject-id: ' || COALESCE(r.betrokkenpersoon, '') || '; ', ' & ' ON OVERFLOW
+                                      TRUNCATE WITH COUNT)
+                                      WITHIN GROUP ( ORDER BY r.aantekeningkadastraalobject ) AS aantekeningen
+                   FROM recht r
+                   GROUP BY r.aantekeningkadastraalobject) aantekeningen
+                  ON o.identificatie = aantekeningen.aantekeningkadastraalobject
+;
+
+CREATE UNIQUE INDEX mb_kad_onrrnd_zk_adres_objidx ON mb_kad_onrrnd_zk_adres (objectid ASC);
+CREATE INDEX mb_kad_onrrnd_zk_adres_identif ON mb_kad_onrrnd_zk_adres (koz_identif ASC);
+INSERT INTO user_sdo_geom_metadata
+VALUES ('MB_KAD_ONRRND_ZK_ADRES', 'BEGRENZING_PERCEEL',
+        MDSYS.SDO_DIM_ARRAY(MDSYS.SDO_DIM_ELEMENT('X', 12000, 280000, .1),
+                            MDSYS.SDO_DIM_ELEMENT('Y', 304000, 620000, .1)), 28992);
+CREATE INDEX mb_kad_onrrnd_zk_adr_bgrgpidx ON mb_kad_onrrnd_zk_adres (begrenzing_perceel) INDEXTYPE IS MDSYS.SPATIAL_INDEX;
+
+COMMENT ON MATERIALIZED VIEW mb_kad_onrrnd_zk_adres IS
+    'commentaar view mb_kad_onrrnd_zk_adres:
+    alle kadastrale onroerende zaken (perceel en appartementsrecht) met opgezochte verkoop datum, objectid voor geoserver/arcgis en BAG adres
+    beschikbare kolommen:
+    * objectid: uniek id bruikbaar voor geoserver/arcgis,
+    * koz_identif: natuurlijke id van perceel of appartementsrecht
+    * begin_geldigheid: datum wanneer dit object geldig geworden is (ontstaat of bijgewerkt),
+    * begin_geldigheid_datum: datum wanneer dit object geldig geworden is (ontstaat of bijgewerkt),
+    * benoemdobj_identif: koppeling met BAG object,
+    * type: perceel of appartement,
+    * aanduiding: sectie perceelnummer,
+    * aanduiding2: kadgem sectie perceelnummer appartementsindex,
+    * sectie: -,
+    * perceelnummer: -,
+    * appartementsindex: -,
+    * gemeentecode: -,
+    * aand_soort_grootte: -,
+    * grootte_perceel: -,
+    * oppervlakte_geom: oppervlakte berekend uit geometrie, hoort gelijk te zijn aan grootte_perceel,
+    * deelperceelnummer: -,
+    * omschr_deelperceel: -,
+    * verkoop_datum: laatste datum gevonden akten van verkoop,
+    * aard_cultuur_onbebouwd: -,
+    * bedrag: -,
+    * koopjaar: -,
+    * meer_onroerendgoed: -,
+    * valutasoort: -,
+    * loc_omschr: adres buiten BAG om meegegeven,
+    * aantekeningen: -,
+    * na_identif: identificatie van nummeraanduiding
+    * na_status: status van nummeraanduiding
+    * gemeente: -,
+    * woonplaats: -,
+    * straatnaam: -,
+    * huisnummer: -,
+    * huisletter: -,
+    * huisnummer_toev: -,
+    * postcode: -,
+    * gebruiksdoelen: alle gebruiksdoelen gescheiden door komma
+    * oppervlakte_obj: oppervlak van gebouwd object
+    * lon: coordinaat als WSG84,
+    * lon: coordinaat als WSG84,
+    * begrenzing_perceel: perceelvlak';

--- a/datamodel/brk/brk2.0_postgresql_views.sql
+++ b/datamodel/brk/brk2.0_postgresql_views.sql
@@ -1160,7 +1160,7 @@ SELECT row_number() OVER ()                                 AS objectid,
        koza.begingeldigheid                                 AS begin_geldigheid_datum,
        koza.eindegeldigheid::text                           AS eind_geldigheid,
        koza.eindegeldigheid                                 AS eind_geldigheid_datum,
-       qry.type,
+       qry.type                                             AS type,
        COALESCE(koza.sectie, '') || ' ' ||
        COALESCE(koza.perceelnummer::text, '')               AS aanduiding,
        COALESCE(koza.akrkadastralegemeente, '') || ' ' || COALESCE(koza.sectie, '') || ' ' ||
@@ -1170,8 +1170,8 @@ SELECT row_number() OVER ()                                 AS objectid,
        koza.perceelnummer                                   AS perceelnummer,
        koza.appartementsrechtvolgnummer                     AS appartementsindex,
        koza.akrkadastralegemeente                           AS gemeentecode,
-       qry.soortgrootte,
-       qry.kadastralegrootte,
+       qry.soortgrootte                                     AS aand_soort_grootte,
+       qry.kadastralegrootte                                AS grootte_perceel,
        NULL                                                 AS deelperceelnummer,
        NULL                                                 AS omschr_deelperceel,
        koza.aard_cultuur_onbebouwd                          AS aard_cultuur_onbebouwd,
@@ -1182,7 +1182,7 @@ SELECT row_number() OVER ()                                 AS objectid,
        -- TODO BRK adres?
        NULL                                                 AS loc_omschr,
        kozhr.onroerendezaak                                 AS overgegaan_in,
-       qry.begrenzing_perceel
+       qry.begrenzing_perceel                               AS begrenzing_perceel
 FROM (SELECT p_archief.identificatie,
              'perceel'
                  AS type,

--- a/datamodel/brk/brk2.0_postgresql_views.sql
+++ b/datamodel/brk/brk2.0_postgresql_views.sql
@@ -503,16 +503,17 @@ CREATE OR REPLACE VIEW
              aantekeningen
                 )
 AS
-SELECT zakrecht.identificatie                                               AS zr_identif,
-       zakrecht.begingeldigheid AS ingangsdatum_recht,
-       COALESCE(tenaamstelling.aandeel_teller::text, '0') || '/'::text || COALESCE(tenaamstelling.aandeel_noemer::text, '0') AS aandeel,
-       tenaamstelling.aandeel_teller                                        AS ar_teller,
-       tenaamstelling.aandeel_noemer                                        AS ar_noemer,
-       tenaamstelling.tennamevan                                            AS subject_identif,
-       zakrecht.rustop                                                      AS koz_identif,
-       (zakrecht.isbetrokkenbij is not NULL)::bool                          AS indic_betrokken_in_splitsing,
-       zakrecht.aard                                                        AS omschr_aard_verkregen_recht,
-       zakrecht.aard                                                        AS fk_3avr_aand,
+SELECT zakrecht.identificatie                             AS zr_identif,
+       zakrecht.begingeldigheid                           AS ingangsdatum_recht,
+       COALESCE(tenaamstelling.aandeel_teller::text, '0') || '/'::text ||
+       COALESCE(tenaamstelling.aandeel_noemer::text, '0') AS aandeel,
+       tenaamstelling.aandeel_teller                      AS ar_teller,
+       tenaamstelling.aandeel_noemer                      AS ar_noemer,
+       tenaamstelling.tennamevan                          AS subject_identif,
+       zakrecht.rustop                                    AS koz_identif,
+       (zakrecht.isbetrokkenbij is not NULL)::bool        AS indic_betrokken_in_splitsing,
+       zakrecht.aard                                      AS omschr_aard_verkregen_recht,
+       zakrecht.aard                                      AS fk_3avr_aand,
        array_to_string(
                (SELECT array_agg(('id: ' || aantekening.identificatie || ', ' ||
                                   'aard: ' || COALESCE(aantekening.aard, '') || ', ' ||
@@ -523,7 +524,7 @@ SELECT zakrecht.identificatie                                               AS z
                                   'subject-id: ' || COALESCE(aantekening.betrokkenpersoon, '') || '; '))
                 FROM recht aantekening
                 WHERE aantekening.aantekeningkadastraalobject = zakrecht.rustop),
-               ' & ')                                                       AS aantekeningen
+               ' & ')                                     AS aantekeningen
 FROM recht zakrecht
          JOIN recht tenaamstelling ON zakrecht.identificatie = tenaamstelling.van
 WHERE zakrecht.identificatie like 'NL.IMKAD.ZakelijkRecht:%';
@@ -802,15 +803,13 @@ CREATE MATERIALIZED VIEW mb_koz_rechth
              begrenzing_perceel
                 )
 AS
-SELECT row_number() OVER ()                                                     AS objectid,
+SELECT row_number() OVER () AS objectid,
        koz.koz_identif,
        koz.begin_geldigheid,
        koz.begin_geldigheid_datum,
        koz.type,
-       COALESCE(koz.sectie, '') || ' ' || COALESCE(koz.perceelnummer::text, '') AS aanduiding,
-       COALESCE(koz.gemeentecode, '') || ' ' || COALESCE(koz.sectie, '') || ' ' ||
-       COALESCE(koz.perceelnummer::text, '') ||
-       ' ' || COALESCE(koz.appartementsindex::text, '')                         AS aanduiding2,
+       koz.aanduiding,
+       koz.aanduiding2,
        koz.sectie,
        koz.perceelnummer,
        koz.appartementsindex,
@@ -996,15 +995,13 @@ CREATE MATERIALIZED VIEW mb_avg_koz_rechth
              begrenzing_perceel
                 )
 AS
-SELECT row_number() OVER ()                                                     AS objectid,
+SELECT row_number() OVER () AS objectid,
        koz.koz_identif,
        koz.begin_geldigheid,
        koz.begin_geldigheid_datum,
        koz.type,
-       COALESCE(koz.sectie, '') || ' ' || COALESCE(koz.perceelnummer::text, '') AS aanduiding,
-       COALESCE(koz.gemeentecode, '') || ' ' || COALESCE(koz.sectie, '') || ' ' ||
-       COALESCE(koz.perceelnummer::text, '') ||
-       ' ' || COALESCE(koz.appartementsindex::text, '')                         AS aanduiding2,
+       koz.aanduiding,
+       koz.aanduiding2,
        koz.sectie,
        koz.perceelnummer,
        koz.appartementsindex,

--- a/datamodel/brk/brk2.0_postgresql_views.sql
+++ b/datamodel/brk/brk2.0_postgresql_views.sql
@@ -504,9 +504,8 @@ CREATE OR REPLACE VIEW
                 )
 AS
 SELECT zakrecht.identificatie                                               AS zr_identif,
-       zakrecht.begingeldigheid,
-       ((COALESCE((tenaamstelling.aandeel_teller)::text, ('0')::text) || ('/')::
-           text) || COALESCE((tenaamstelling.aandeel_noemer)::text, ('0'))) AS aandeel,
+       zakrecht.begingeldigheid AS ingangsdatum_recht,
+       COALESCE(tenaamstelling.aandeel_teller::text, '0') || '/'::text || COALESCE(tenaamstelling.aandeel_noemer::text, '0') AS aandeel,
        tenaamstelling.aandeel_teller                                        AS ar_teller,
        tenaamstelling.aandeel_noemer                                        AS ar_noemer,
        tenaamstelling.tennamevan                                            AS subject_identif,

--- a/datamodel/brk/brk2.0_postgresql_views.sql
+++ b/datamodel/brk/brk2.0_postgresql_views.sql
@@ -350,18 +350,43 @@ COMMENT ON MATERIALIZED VIEW mb_kad_onrrnd_zk_adres IS
 
 
 
-CREATE MATERIALIZED VIEW mb_percelenkaart AS
+CREATE MATERIALIZED VIEW mb_percelenkaart
+            (
+             objectid,
+             koz_identif,
+             begin_geldigheid,
+             begin_geldigheid_datum,
+             type,
+             aanduiding,
+             aanduiding2,
+             sectie,
+             perceelnummer,
+             gemeentecode,
+             aand_soort_grootte,
+             grootte_perceel,
+             oppervlakte_geom,
+             verkoop_datum,
+             aard_cultuur_onbebouwd,
+             bedrag,
+             koopjaar,
+             meer_onroerendgoed,
+             valutasoort,
+             aantekeningen,
+             lon,
+             lat,
+             begrenzing_perceel
+                )
+AS
 SELECT row_number() OVER ()                                                    AS objectid,
        o.identificatie                                                         AS koz_identif,
        o.begingeldigheid::text                                                 AS begin_geldigheid,
        o.begingeldigheid                                                       AS begin_geldigheid_datum,
-       qry.type,
+       qry.type                                                                AS type,
        COALESCE(o.sectie, '') || ' ' || COALESCE(o.perceelnummer::text, '')    AS aanduiding,
        COALESCE(o.akrkadastralegemeente, '') || ' ' || COALESCE(o.sectie, '') || ' ' ||
        COALESCE(o.perceelnummer::text, '')                                     AS aanduiding2,
        o.sectie                                                                AS sectie,
        o.perceelnummer                                                         AS perceelnummer,
-       o.appartementsrechtvolgnummer                                           AS appartementsindex,
        o.akrkadastralegemeente                                                 AS gemeentecode,
        qry.soortgrootte                                                        AS aand_soort_grootte,
        qry.kadastralegrootte                                                   AS grootte_perceel,
@@ -412,7 +437,7 @@ COMMENT ON MATERIALIZED VIEW mb_percelenkaart IS
     * begin_geldigheid_datum: datum wanneer dit object geldig geworden is (ontstaat of bijgewerkt),
     * type: perceel of appartement,
     * aanduiding: sectie perceelnummer,
-    * aanduiding2: kadgem sectie perceelnummer appartementsindex,
+    * aanduiding2: kadgem sectie perceelnummer,
     * sectie: -,
     * perceelnummer: -,
     * gemeentecode: -,

--- a/datamodel/src/test/java/nl/b3p/brmo/datamodel/MaterializedViewsTest.java
+++ b/datamodel/src/test/java/nl/b3p/brmo/datamodel/MaterializedViewsTest.java
@@ -90,7 +90,6 @@ public class MaterializedViewsTest {
         db = new DatabaseDataSourceConnection(ds, params.getProperty("rsgb.schema"));
 
         if (this.isOracle) {
-            // db = new DatabaseConnection(OracleConnectionUnwrapper.unwrap(db.getConnection()), params.getProperty(this.dbName + ".user").toUpperCase());
             db.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY, new Oracle10DataTypeFactory());
             db.getConfig().setProperty(DatabaseConfig.FEATURE_SKIP_ORACLE_RECYCLEBIN_TABLES, true);
         } else if (this.isPostgis) {
@@ -125,7 +124,7 @@ public class MaterializedViewsTest {
             naam = (String) metadata.getValue(i, "naam");
             LOG.debug(String.format("rsgb metadata tabel record: %d: naam: %s, waarde: %s", i, naam, waarde));
             if ("brmoversie".equalsIgnoreCase(naam)) {
-                assertEquals(currentVersion, waarde, "BRMO versinummer klopt niet");
+                assertEquals(currentVersion, waarde, "BRMO versienummer klopt niet");
                 foundVersion = true;
             }
         }
@@ -141,7 +140,6 @@ public class MaterializedViewsTest {
     public void testBasisMViews() throws SQLException {
         List<String> viewsFound = ViewUtils.listAllMaterializedViews(ds);
         assertNotNull(viewsFound, "Geen materialized views gevonden");
-
 
         List<String> views = Stream.of(
                 // bag
@@ -167,6 +165,7 @@ public class MaterializedViewsTest {
                 "mb_kad_onrrnd_zk_adres_bag",
                 "mb_koz_rechth_bag"
         ).collect(Collectors.toList());
+
         if (this.isPostgis) {
             views.addAll(Arrays.asList(
                     // brk 2 / postgres


### PR DESCRIPTION
- [x] mb_subject
- [x] mb_avg_subject
- [x] mb_kad_onrrnd_zk_adres
- [x] mb_percelenkaart
- [x] vb_util_zk_recht
- [x] mb_zr_rechth
- [x] mb_avg_zr_rechth
- [x] mb_koz_rechth
- [x] mb_avg_koz_rechth
- [x] mb_kad_onrrnd_zk_archief


Openstaande punten:

- `verkoop_datum` uit stukdeel via recht voor **mb_kad_onrrnd_zk_adres** en  **mb_percelenkaart** en mb_kad_onrrnd_zk_adres
- koppeling “BRK adres” (object locatie) voor kolom `loc_omschr` in **mb_kad_onrrnd_zk_adres** en **mb_kad_onrrnd_zk_archief**


resolve BRMO-257