### PR TITLE
[BRMO-268] Fix problems loading large BAG2/BGT stand directly from PDOK HTTPS server

### DIFF
--- a/bgt-loader/src/main/java/nl/b3p/brmo/util/http/HttpSeekableByteChannel.java
+++ b/bgt-loader/src/main/java/nl/b3p/brmo/util/http/HttpSeekableByteChannel.java
@@ -181,7 +181,7 @@ public class HttpSeekableByteChannel implements SeekableByteChannel {
             // avoid HEAD requests to a location that redirects but does not support the HEAD
             // method.
 
-            HttpResponseWrapper response = null;
+            HttpResponseWrapper response;
             try {
                 response = httpClientWrapper.request(uri, "Range", "bytes=0-0");
             } catch (InterruptedException e) {
@@ -258,7 +258,8 @@ public class HttpSeekableByteChannel implements SeekableByteChannel {
                     resumingInputStreamWrapper.apply(
                             new ResumingInputStream(
                                     new HttpStartRangeInputStreamProvider(
-                                            uri, httpClientWrapper, contentLength),
+                                                    uri, httpClientWrapper, contentLength)
+                                            .assumeAcceptsRanges(true),
                                     position));
         }
 

--- a/bgt-loader/src/test/java/nl/b3p/brmo/util/http/HttpStartRangeInputStreamProviderTest.java
+++ b/bgt-loader/src/test/java/nl/b3p/brmo/util/http/HttpStartRangeInputStreamProviderTest.java
@@ -106,7 +106,7 @@ class HttpStartRangeInputStreamProviderTest {
         provider.get(123, 0, null).read();
         mockWebServer.takeRequest();
         RecordedRequest request = mockWebServer.takeRequest();
-        Assertions.assertEquals("something", request.getHeader("If-Range"));
+        Assertions.assertEquals("\"something\"", request.getHeader("If-Range"));
     }
 
     @Test


### PR DESCRIPTION
Assume server supports range requests even without Accept-Ranges header and accept ETag without double quotes.

Technically these are problems with the PDOK HTTP server not implementing the specs fully/correctly, but these workarounds fix the problem.

