### PR TITLE
Bump nl.b3p:kadaster-gds2 van 2.7 naar 3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -393,7 +393,7 @@
             <dependency>
                 <groupId>nl.b3p</groupId>
                 <artifactId>kadaster-gds2</artifactId>
-                <version>2.7</version>
+                <version>3.0-SNAPSHOT</version>
             </dependency>
             <!-- J2EE dependencies en stripes -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -393,7 +393,7 @@
             <dependency>
                 <groupId>nl.b3p</groupId>
                 <artifactId>kadaster-gds2</artifactId>
-                <version>3.0-SNAPSHOT</version>
+                <version>3.0</version>
             </dependency>
             <!-- J2EE dependencies en stripes -->
             <dependency>


### PR DESCRIPTION
- [x] Bump nl.b3p:kadaster-gds2 van 2.7 naar 3.0-SNAPSHOT
- [x] Bump nl.b3p:kadaster-gds2 van 3.0-SNAPSHOT naar 3.0

zie ook https://github.com/B3Partners/kadaster-gds2/pull/210