### PR TITLE
[SUPPORT-13459] fix `vb_verblijfsobject_adres` voor Oracle

### DIFF
--- a/datamodel/extra_scripts/oracle/208_bag2_views.sql
+++ b/datamodel/extra_scripts/oracle/208_bag2_views.sql
@@ -221,8 +221,8 @@ from (select 'true'                                                             
              a.postcode,
              (select listagg(vbod.maaktdeeluitvan, ', ')
               from verblijfsobject_maaktdeeluitvan vbod
-              where (vbod.identificatie = vo.identificatie and vbod.voorkomenidentificatie =
-                                                             vo.voorkomenidentificatie))                             as maaktdeeluitvan,
+              where (vbod.identificatie = voa.identificatie and vbod.voorkomenidentificatie =
+                                                             voa.voorkomenidentificatie))                             as maaktdeeluitvan,
              (select listagg(vg.gebruiksdoel, ', ')
               from verblijfsobject_gebruiksdoel vg
               where (vg.identificatie = voa.identificatie and

--- a/datamodel/extra_scripts/oracle/208_bag2_views.sql
+++ b/datamodel/extra_scripts/oracle/208_bag2_views.sql
@@ -192,8 +192,8 @@ from (select 'true'                                                             
              a.huisletter,
              a.huisnummertoevoeging,
              a.postcode,
-             (select listagg(vbod.gebruiksdoel, ', ')
-              from verblijfsobject_gebruiksdoel vbod
+             (select listagg(vbod.maaktdeeluitvan, ', ')
+              from verblijfsobject_maaktdeeluitvan vbod
               where (vbod.identificatie = vo.identificatie and vbod.voorkomenidentificatie =
                                                              vo.voorkomenidentificatie))                             as maaktdeeluitvan,
              (select listagg(vg.gebruiksdoel, ', ')
@@ -219,10 +219,10 @@ from (select 'true'                                                             
              a.huisletter,
              a.huisnummertoevoeging,
              a.postcode,
-             (select listagg(vbod.gebruiksdoel, ', ')
-              from verblijfsobject_gebruiksdoel vbod
-              where (vbod.identificatie = voa.identificatie and vbod.voorkomenidentificatie =
-                                                               voa.voorkomenidentificatie))                             as maaktdeeluitvan,
+             (select listagg(vbod.maaktdeeluitvan, ', ')
+              from verblijfsobject_maaktdeeluitvan vbod
+              where (vbod.identificatie = vo.identificatie and vbod.voorkomenidentificatie =
+                                                             vo.voorkomenidentificatie))                             as maaktdeeluitvan,
              (select listagg(vg.gebruiksdoel, ', ')
               from verblijfsobject_gebruiksdoel vg
               where (vg.identificatie = voa.identificatie and


### PR DESCRIPTION
Het attribuut 'maaktdeeluitvan' bevatte ook de gebruiksdoelen waar normaal gesproken het ID van het pand wordt opgeslagen. Door het script te vergelijken met het postgresql script, heb ik deze aanpassingen verricht.  De aanleiding voor deze aanpassing was ticket SUPPORT-13459.