### PR TITLE
[BRMO-283] negeer falende P8 tests

### DIFF
--- a/datamodel/pom.xml
+++ b/datamodel/pom.xml
@@ -37,6 +37,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>nl.b3p</groupId>
             <artifactId>brmo-test-util</artifactId>
             <scope>test</scope>

--- a/datamodel/src/test/java/nl/b3p/brmo/datamodel/P8RestAPIIntegrationTest.java
+++ b/datamodel/src/test/java/nl/b3p/brmo/datamodel/P8RestAPIIntegrationTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 
 import java.io.IOException;
 
@@ -53,6 +54,7 @@ public class P8RestAPIIntegrationTest extends P8TestFramework {
   public void setup() {}
 
   @Test
+  @ExpectedToFail("P8 API geeft 404, derhalve is deze test zinloos geworden.")
   public void testVersion() throws IOException {
     // https://imkad-b3.p8.nl/web/version.json?_format=json
     HttpUriRequest request =
@@ -71,6 +73,7 @@ public class P8RestAPIIntegrationTest extends P8TestFramework {
   }
 
   @Test
+  @ExpectedToFail("P8 API geeft 404, derhalve is deze test zinloos geworden.")
   public void testEndpointstatus() throws IOException {
     // https://imkad-b3.p8.nl/web/endpointstatus.json?_format=json
     HttpUriRequest request =

--- a/datamodel/src/test/java/nl/b3p/brmo/datamodel/P8ServicesIntegrationTest.java
+++ b/datamodel/src/test/java/nl/b3p/brmo/datamodel/P8ServicesIntegrationTest.java
@@ -26,6 +26,7 @@ import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ExpectedToFail;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -82,6 +83,7 @@ public class P8ServicesIntegrationTest extends P8TestFramework {
   }
 
   @Test
+  @ExpectedToFail("P8 API geeft 404, derhalve is deze test zinloos geworden.")
   public void testPercelen() throws IOException {
     // https://imkad-b3.p8.nl/web/kadastralepercelen.json?offset=0&limit=3&_format=json
     HttpUriRequest request =
@@ -119,6 +121,7 @@ public class P8ServicesIntegrationTest extends P8TestFramework {
   }
 
   @Test
+  @ExpectedToFail("P8 API geeft 404, derhalve is deze test zinloos geworden.")
   public void testKadastraalPerceel() throws IOException {
     // https://imkad-b3.p8.nl/web/kadastraalperceel.json?kadperceelcode=VDG00B1708&geoinfo=true&_format=json
     HttpUriRequest request =
@@ -162,6 +165,7 @@ public class P8ServicesIntegrationTest extends P8TestFramework {
   }
 
   @Test
+  @ExpectedToFail("P8 API geeft 404, derhalve is deze test zinloos geworden.")
   public void testKadastralepercelenadressen() throws IOException {
     // https://imkad-b3.p8.nl/web/kadastralepercelenadressen.json?offset=0&limit=3&_format=json
     HttpUriRequest request =
@@ -196,6 +200,7 @@ public class P8ServicesIntegrationTest extends P8TestFramework {
   }
 
   @Test
+  @ExpectedToFail("P8 API geeft 404, derhalve is deze test zinloos geworden.")
   public void testKadastralesubjectpercelen() throws IOException {
     // https://imkad-b3.p8.nl/web/kadastralesubjectpercelen.json?offset=0&limit=3&_format=json&subjectid=NL.KAD.Persoon.157450463
     HttpUriRequest request =
@@ -226,6 +231,7 @@ public class P8ServicesIntegrationTest extends P8TestFramework {
   }
 
   @Test
+  @ExpectedToFail("P8 API geeft 404, derhalve is deze test zinloos geworden.")
   public void testSubject() throws IOException {
     // https://imkad-b3.p8.nl/web/subject.json?subjectid=NL.KAD.Persoon.157450463&_format=json
     HttpUriRequest request =
@@ -252,6 +258,7 @@ public class P8ServicesIntegrationTest extends P8TestFramework {
   }
 
   @Test
+  @ExpectedToFail("P8 API geeft 404, derhalve is deze test zinloos geworden.")
   public void testSubjecten() throws IOException {
     // https://imkad-b3.p8.nl/web/subjecten.json?offset=0&limit=3&_format=json
     HttpUriRequest request =

--- a/pom.xml
+++ b/pom.xml
@@ -715,6 +715,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.junit-pioneer</groupId>
+                <artifactId>junit-pioneer</artifactId>
+                <version>2.0.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.dbunit</groupId>
                 <artifactId>dbunit</artifactId>
                 <version>2.7.3</version>


### PR DESCRIPTION
negeer falende P8 tests, in ieder geval totdat de API weer in de lucht komt.

resolve BRMO-283