### PR TITLE
Bump jaxws-rt en jaxb-runtime versies 

### DIFF
--- a/.mvn/owasp-suppression.xml
+++ b/.mvn/owasp-suppression.xml
@@ -39,6 +39,7 @@
         <notes><![CDATA[
                    file name: kernel-7.2.5.jar
                    see: https://github.com/jeremylong/DependencyCheck/issues/4613
+                   DISPUTED
    ]]></notes>
         <gav regex="true">^com\.itextpdf:kernel:7\.2\.5.*$</gav>
         <vulnerabilityName>CVE-2022-24198</vulnerabilityName>
@@ -68,7 +69,7 @@
                    - alleen vertrouwde gegevens verwerken
                    - we zelf geen JXPath gebruiken
 
-                   CVE-2022-41852: rejected
+                   CVE-2022-41852: REJECTED
        ]]></notes>
         <packageUrl regex="true">^pkg:maven/commons\-jxpath/commons\-jxpath@.*$</packageUrl>
         <cve>CVE-2022-41852</cve>
@@ -84,11 +85,4 @@
         <packageUrl regex="true">^pkg:maven/org\.json/json@.*$</packageUrl>
         <vulnerabilityName>CVE-2022-45688</vulnerabilityName>
     </suppress>
-    <suppress until="2023-03-31+02:00">
-       <notes><![CDATA[
-       file name: postgresql-42.5.3.jar
-       ]]></notes>
-       <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
-       <vulnerabilityName>CVE-2022-41862</vulnerabilityName>
-    </suppress>    
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <quartz.version>2.3.2</quartz.version>
         <slf4j.version>2.0.6</slf4j.version>
         <jaxb.api.version>2.3.3</jaxb.api.version>
-        <jaxb.impl.version>2.3.7</jaxb.impl.version>
+        <jaxb.impl.version>2.3.8</jaxb.impl.version>
         <jackson.version>2.14.2</jackson.version>
         <jackson.databind.version>2.14.2</jackson.databind.version>
         <javax-annotation.version>1.3.2</javax-annotation.version>
@@ -143,21 +143,10 @@
         -->
         <dependencies>
             <dependency>
-                <!--
-                override transtive dependency van com.sun.xml.ws:jaxws-rt:jar:2.3.5:compile
-                en org.apache.cxf:cxf-core:jar:3.5.4:compile
-                CVE-2022-40152
-                -->
-                <groupId>com.fasterxml.woodstox</groupId>
-                <artifactId>woodstox-core</artifactId>
-                <version>6.5.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.gaul</groupId>
                 <artifactId>modernizer-maven-annotations</artifactId>
                 <version>${modernizer-maven-plugin.version}</version>
             </dependency>
-            <!-- logging libs -->
             <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
@@ -171,8 +160,6 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-to-slf4j</artifactId>
-                <!-- moet gelijk zijn aan de versie van log4j-api in apache poi,
-                zie ook https://github.com/B3Partners/brmo/pull/1470#issuecomment-1177499188 -->
                 <version>2.19.0</version>
             </dependency>
             <dependency>
@@ -277,7 +264,6 @@
                 <artifactId>commons-fileupload</artifactId>
                 <version>1.5</version>
             </dependency>
-            <!-- spatial -->
             <dependency>
                 <groupId>org.locationtech.jts</groupId>
                 <artifactId>jts-core</artifactId>
@@ -528,7 +514,7 @@
             <dependency>
                 <groupId>com.sun.xml.ws</groupId>
                 <artifactId>jaxws-rt</artifactId>
-                <version>2.3.5</version>
+                <version>2.3.6</version>
                 <exclusions>
                     <!-- deze komen in de Tomcat lib, moeten dus niet in de war file terecht komen -->
                     <exclusion>
@@ -858,7 +844,7 @@
                         <dependency>
                             <groupId>net.sf.saxon</groupId>
                             <artifactId>Saxon-HE</artifactId>
-                            <version>11.4</version>
+                            <version>11.5</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -1078,7 +1064,7 @@
                 <plugin>
                     <groupId>com.sun.xml.ws</groupId>
                     <artifactId>jaxws-maven-plugin</artifactId>
-                    <version>2.3.5</version>
+                    <version>2.3.6</version>
                 </plugin>
                 <plugin>
                     <groupId>org.owasp</groupId>


### PR DESCRIPTION
- jaxb-runtime: 2.3.7 ⇨ 2.3.8
- jaxws-rt: 2.3.5 ⇨ 2.3.6
- Saxon-HE: 11.4 ⇨ 11.5 (build dependency)