### PR TITLE
Voegt documentnummer toe aan views

### DIFF
--- a/datamodel/extra_scripts/oracle/208_bag2_views.sql
+++ b/datamodel/extra_scripts/oracle/208_bag2_views.sql
@@ -21,8 +21,8 @@ select na.objectid,
        null              as gemeentecode
 from v_nummeraanduiding_actueel na
          left join v_openbareruimte_actueel opr on (opr.identificatie = na.ligtaan)
-         left join v_woonplaats_actueel wp on (wp.identificatie = opr.ligtin);
-where na.status = 'Naamgeving ingetrokken'
+         left join v_woonplaats_actueel wp on (wp.identificatie = opr.ligtin)
+where na.status = 'Naamgeving ingetrokken';
 comment on table vb_adres is 'volledig actueel adres zonder locatie';
 
 

--- a/datamodel/extra_scripts/oracle/208_bag2_views.sql
+++ b/datamodel/extra_scripts/oracle/208_bag2_views.sql
@@ -22,7 +22,7 @@ select na.objectid,
 from v_nummeraanduiding_actueel na
          left join v_openbareruimte_actueel opr on (opr.identificatie = na.ligtaan)
          left join v_woonplaats_actueel wp on (wp.identificatie = opr.ligtin);
-
+where na.status = 'Naamgeving ingetrokken'
 comment on table vb_adres is 'volledig actueel adres zonder locatie';
 
 

--- a/datamodel/extra_scripts/postgresql/208_bag2_views.sql
+++ b/datamodel/extra_scripts/postgresql/208_bag2_views.sql
@@ -44,6 +44,7 @@ select qry.objectid,
        qry.huisletter,
        qry.huisnummertoevoeging,
        qry.postcode,
+       qry.documentnummer,
        qry.geometrie,
     qry.geometrie_centroide
 from (
@@ -60,6 +61,7 @@ from (
                 a.huisletter,
                 a.huisnummertoevoeging,
                 a.postcode,
+                lp.documentnummer,
                 st_centroid(lp.geometrie) as geometrie_centroide,
                 lp.geometrie
          from v_ligplaats_actueel lp
@@ -78,6 +80,7 @@ from (
                 a.huisletter,
                 a.huisnummertoevoeging,
                 a.postcode,
+                lpa.documentnummer,
                 st_centroid(lpa.geometrie) as geometrie_centroide,
                 lpa.geometrie
          from v_ligplaats_actueel lpa
@@ -105,6 +108,7 @@ select qry.objectid,
        qry.huisletter,
        qry.huisnummertoevoeging,
        qry.postcode,
+       qry.documentnummer,
        qry.geometrie,
        qry.geometrie_centroide
 from (select true                      as ishoofdadres,
@@ -120,6 +124,7 @@ from (select true                      as ishoofdadres,
              a.huisletter,
              a.huisnummertoevoeging,
              a.postcode,
+             sp.documentnummer,
              st_centroid(sp.geometrie) as geometrie_centroide,
              sp.geometrie
       from v_standplaats_actueel sp
@@ -138,6 +143,7 @@ from (select true                      as ishoofdadres,
              a.huisletter,
              a.huisnummertoevoeging,
              a.postcode,
+             spa.documentnummer,
              st_centroid(spa.geometrie) as geometrie_centroide,
              spa.geometrie
       from v_standplaats_actueel spa
@@ -257,6 +263,7 @@ select qry.objectid,
        qry.huisletter,
        qry.huisnummertoevoeging,
        qry.postcode,
+       qry.documentnummer,
        qry.soort,
        qry.maaktdeeluitvan,
        qry.gebruiksdoelen,
@@ -277,6 +284,7 @@ from (
                 vla.huisletter,
                 vla.huisnummertoevoeging,
                 vla.postcode,
+                vla.documentnummer,
                 'ligplaats'   as soort,
                 null          as maaktdeeluitvan,
                 null          as gebruiksdoelen,
@@ -298,6 +306,7 @@ from (
                 vsa.huisletter,
                 vsa.huisnummertoevoeging,
                 vsa.postcode,
+                vsa.documentnummer,
                 'standplaats' as soort,
                 null          as maaktdeeluitvan,
                 null          as gebruiksdoelen,
@@ -319,6 +328,7 @@ from (
                 vva.huisletter,
                 vva.huisnummertoevoeging,
                 vva.postcode,
+                vva.documentnummer,
                 'verblijfsobject' as soort,
                 vva.maaktdeeluitvan,
                 vva.gebruiksdoelen,

--- a/datamodel/extra_scripts/postgresql/208_bag2_views.sql
+++ b/datamodel/extra_scripts/postgresql/208_bag2_views.sql
@@ -168,6 +168,7 @@ select qry.objectid,
        qry.maaktdeeluitvan,
        qry.gebruiksdoelen,
        qry.oppervlakte,
+       qry.documentnummer,
        qry.geometrie,
        qry.geometrie_centroide
 from (select true                      as ishoofdadres,
@@ -196,6 +197,7 @@ from (select true                      as ishoofdadres,
                              vg.voorkomenidentificatie = vo.voorkomenidentificatie))
                  , ', ')               as gebruiksdoelen,
              vo.oppervlakte,
+             vo.documentnummer,
              st_centroid(vo.geometrie) as geometrie_centroide,
              vo.geometrie
       from v_verblijfsobject_actueel vo
@@ -227,6 +229,7 @@ from (select true                      as ishoofdadres,
                              vg.voorkomenidentificatie = voa.voorkomenidentificatie))
                  , ', ')                as gebruiksdoelen,
              voa.oppervlakte,
+             voa.documentnummer,
              st_centroid(voa.geometrie) as geometrie_centroide,
              voa.geometrie
       from v_verblijfsobject_actueel voa


### PR DESCRIPTION
Het documentnummer van een verblijfsobject is niet in de view vb_verblijfsobject_adres toegevoegd. Naar aanleiding van SUPPORT-13560 heb ik deze toegevoegd voor de klant. Toen kwam ik erachter dat de views voor de ligplaatsen, standplaatsen en uiteindelijk de adreseerbaar-object view geen documentnummer hebben, terwijl de 'actueel' views deze wel hebben. Andere klanten zijn mogelijk ook geïnteresseerd in deze views daarom heb ik ze toegevoegd.