### PR TITLE
Update 403_create_geotools_primarykey_metatable.sql

### DIFF
--- a/datamodel/utility_scripts/oracle/403_create_geotools_primarykey_metatable.sql
+++ b/datamodel/utility_scripts/oracle/403_create_geotools_primarykey_metatable.sql
@@ -10,7 +10,7 @@
 -- 
 CREATE TABLE gt_pk_metadata (
   table_schema VARCHAR2(32) NOT NULL,
-  table_name VARCHAR2(32) NOT NULL,
+  table_name VARCHAR2(64) NOT NULL,
   pk_column VARCHAR2(32) NOT NULL,
   pk_column_idx NUMBER(38),
   pk_policy VARCHAR2(32),


### PR DESCRIPTION
changed column size for table_name. too small for several standard view names