### PR TITLE
Revert "Bump apache.cxf.version van 3.5.6 naar 3.6.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <skip-windows />
         <javasimon.version>4.2.0</javasimon.version>
         <jakarta.mail.version>1.6.7</jakarta.mail.version>
-        <apache.cxf.version>3.6.1</apache.cxf.version>
+        <apache.cxf.version>3.5.6</apache.cxf.version>
         <apache.poi.version>5.2.3</apache.poi.version>
         <quartz.version>2.3.2</quartz.version>
         <slf4j.version>2.0.7</slf4j.version>


### PR DESCRIPTION
Reverts B3Partners/brmo#1850 welke voor SSL Handshake Exceptions zorgt: 
`Caused by: javax.net.ssl.SSLHandshakeException: SSLHandshakeException invoking https://service30.kadaster.nl/gds2/afgifte/v20170401: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target` 
vermoedelijk omdat de (private) root certificaten niet worden geladen
