### PR TITLE
Bump GeoTools naar 30.0 en jdbc-util naar 16.0

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,10 +31,11 @@ jobs:
         postgis: 
             # tot 11-2023  
             - 11-3.3-alpine
-            # - 12-3.3-alpine
-            # - 13-3.3-alpine
-            # - 14-3.3-alpine
-            - 15-3.3-alpine
+            # - 12-3.4-alpine
+            # - 13-3.4-alpine
+            # - 14-3.4-alpine
+            - 15-3.4-alpine
+            - 16-3.4-alpine
 
     steps:
       - uses: actions/checkout@v4

--- a/bag2-loader/pom.xml
+++ b/bag2-loader/pom.xml
@@ -28,10 +28,6 @@ SPDX-License-Identifier: MIT
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
-            <artifactId>gt-opengis</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.geotools</groupId>
             <artifactId>gt-metadata</artifactId>
         </dependency>
         <dependency>

--- a/bag2-loader/src/main/java/nl/b3p/brmo/bag2/loader/BAG2GMLMutatieGroepStream.java
+++ b/bag2-loader/src/main/java/nl/b3p/brmo/bag2/loader/BAG2GMLMutatieGroepStream.java
@@ -35,11 +35,11 @@ import org.apache.commons.logging.LogFactory;
 import org.codehaus.staxmate.SMInputFactory;
 import org.codehaus.staxmate.in.SMEvent;
 import org.codehaus.staxmate.in.SMInputCursor;
+import org.geotools.api.referencing.FactoryException;
 import org.geotools.gml.stream.XmlStreamGeometryReader;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.PrecisionModel;
-import org.opengis.referencing.FactoryException;
 
 public class BAG2GMLMutatieGroepStream implements Iterable<BAG2MutatieGroep> {
   private static final Log log = LogFactory.getLog(BAG2GMLMutatieGroepStream.class);

--- a/bgt-loader/src/main/java/nl/b3p/brmo/bgt/loader/BGTObjectStreamer.java
+++ b/bgt-loader/src/main/java/nl/b3p/brmo/bgt/loader/BGTObjectStreamer.java
@@ -33,9 +33,9 @@ import org.apache.commons.logging.LogFactory;
 import org.codehaus.staxmate.SMInputFactory;
 import org.codehaus.staxmate.in.SMEvent;
 import org.codehaus.staxmate.in.SMInputCursor;
+import org.geotools.api.referencing.FactoryException;
 import org.geotools.gml.stream.XmlStreamGeometryReader;
 import org.locationtech.jts.geom.Geometry;
-import org.opengis.referencing.FactoryException;
 
 public class BGTObjectStreamer implements Iterable<BGTObject> {
   private static final Log log = LogFactory.getLog(BGTObjectStreamer.class);

--- a/pom.xml
+++ b/pom.xml
@@ -271,11 +271,6 @@
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
-                <artifactId>gt-opengis</artifactId>
-                <version>${geotools.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.geotools</groupId>
                 <artifactId>gt-metadata</artifactId>
                 <version>${geotools.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,8 @@
         <maven-fluido-skin.version>2.0.0-M7</maven-fluido-skin.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
-        <geotools.version>29.2</geotools.version>
-        <jdbc-util.version>15.2</jdbc-util.version>
+        <geotools.version>30-RC</geotools.version>
+        <jdbc-util.version>16.0-SNAPSHOT</jdbc-util.version>
         <jts.version>1.19.0</jts.version>
         <itextpdf.version>8.0.1</itextpdf.version>
         <postgresql.jdbc.version>42.6.0</postgresql.jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <hibernate.version>5.6.15.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
         <geotools.version>30.0</geotools.version>
-        <jdbc-util.version>16.0-SNAPSHOT</jdbc-util.version>
+        <jdbc-util.version>16.0</jdbc-util.version>
         <jts.version>1.19.0</jts.version>
         <itextpdf.version>8.0.1</itextpdf.version>
         <postgresql.jdbc.version>42.6.0</postgresql.jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <maven-fluido-skin.version>2.0.0-M8</maven-fluido-skin.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
-        <geotools.version>30-RC</geotools.version>
+        <geotools.version>30.0</geotools.version>
         <jdbc-util.version>16.0-SNAPSHOT</jdbc-util.version>
         <jts.version>1.19.0</jts.version>
         <itextpdf.version>8.0.1</itextpdf.version>


### PR DESCRIPTION
- [x] Bump GeoTools van 29.2 naar 30-RC en jdbc-util van 15.3 naar 16.0-SNAPSHOT
- [X] Bump GeoTools van 30-RC naar 30.0 
- [x] Bump jdbc-util van 16.0-SNAPSHOT naar 16.0

zie ook https://github.com/B3Partners/jdbc-util/pull/490