### PR TITLE
Einde PostgreSQL 11 ondersteuning

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,11 +29,8 @@ jobs:
         # docker image tags from https://hub.docker.com/r/postgis/postgis/tags?page=1&ordering=last_updated
         # zie ook https://www.postgresql.org/support/versioning/
         postgis: 
-            # tot 11-2023  
-            - 11-3.3-alpine
-            # - 12-3.4-alpine
-            # - 13-3.4-alpine
-            # - 14-3.4-alpine
+            # t/m november 2024
+            - 12-3.4-alpine
             - 15-3.4-alpine
             - 16-3.4-alpine
         include:
@@ -42,7 +39,7 @@ jobs:
             postgis: 16-3.4-alpine
               
           - java: 21
-            java-dist: 'zulu'
+            java-dist: 'temurin'
             postgis: 16-3.4-alpine
 
     steps:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -34,7 +34,7 @@ jobs:
         run: mvn -U package -Dmaven.test.skip=true -Ddocker.skip=true -Dtest.onlyITs= -DskipQA=true -Dmaven.javadoc.skip=true
 
       - name: "Run Trivy vulnerability scanner on ${{ matrix.docker-image }}"
-        uses: aquasecurity/trivy-action@0.13.0
+        uses: aquasecurity/trivy-action@0.13.1
         # docker run --rm -v trivy_cache:/root/.cache/ aquasec/trivy image ghcr.io/b3partners/brmo-service:snapshot
         with:
           image-ref: "ghcr.io/b3partners/${{ matrix.docker-image }}:snapshot"

--- a/.github/workflows/upgrade-pgsql.yml
+++ b/.github/workflows/upgrade-pgsql.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        postgis: [ 11-3.3 ]
+        postgis: [ 12-3.4 ]
 
     services:
       postgres:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ${{ matrix.windows }}
     strategy:
       matrix:
-        java: [ 11 ]
-        windows: [ windows-2019, windows-2022 ]
+        java: [ 17 ]
+        windows: [ windows-2022 ]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Op 9 nov 2023 is de laatste release van PostgreSQL 11, derhalve vervalt de ondersteuning daarvoor in de eerstvolgende release.

- [x] Bump PG van 11 naar 12 voor upgrade test checks
- [x] Update PG buildmatrix