### PR TITLE
[BRMO-351] Een zakelijk recht die direct een ander zakelijk recht belast, wordt niet getoond

### DIFF
--- a/datamodel/upgrade_scripts/3.0.2-4.0.0/oracle/brk.sql
+++ b/datamodel/upgrade_scripts/3.0.2-4.0.0/oracle/brk.sql
@@ -16,6 +16,33 @@ END;
 /
 MERGE INTO brmo_metadata USING DUAL ON (naam = 'brmoversie') WHEN NOT MATCHED THEN INSERT (naam) VALUES('brmoversie');
 
+-- view vb_util_zk_recht_op_koz wordt vervangen met onderstaand SQL ten behoeve van de upgrade
+CREATE OR REPLACE VIEW vb_util_zk_recht_op_koz
+            (
+             identificatie,
+             rustop_zak_recht
+                )
+AS
+SELECT qry.identificatie,
+       qry.rustop_zak_recht
+FROM (SELECT r.identificatie,
+             r.rustop         AS rustop_zak_recht
+      FROM   recht r 
+      UNION ALL
+      -- [BRMO-336] wanneer een zakelijkrecht een eigendomsrecht belast
+      SELECT ribm.isbelastmet AS identificatie,
+             r.rustop         AS rustop_zak_recht
+      FROM recht r
+      LEFT JOIN recht_isbelastmet ribm ON r.identificatie = ribm.zakelijkrecht
+      UNION ALL
+      -- [BRMO-351] wanneer een zakelijkrecht een ander zakelijkrecht belast
+      SELECT ribm2.isbelastmet                        AS identificatie,
+             r.rustop                                AS rustop_zak_recht
+      FROM recht r
+      LEFT JOIN recht_isbelastmet ribm ON r.identificatie = ribm.zakelijkrecht
+      LEFT JOIN recht_isbelastmet ribm2 ON ribm.isbelastmet = ribm2.zakelijkrecht
+     ) qry
+WHERE SUBSTR(qry.identificatie, 1, INSTR(qry.identificatie, ':') - 1) = 'NL.IMKAD.ZakelijkRecht';
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_3.0.2_naar_4.0.0','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/3.0.2-4.0.0/postgresql/brk.sql
+++ b/datamodel/upgrade_scripts/3.0.2-4.0.0/postgresql/brk.sql
@@ -8,6 +8,35 @@ SET search_path = brk,public;
 
 SET SCHEMA 'brk';
 
+-- view vb_util_zk_recht_op_koz wordt vervangen met onderstaand SQL ten behoeve van de upgrade
+CREATE OR REPLACE VIEW 
+    vb_util_zk_recht_op_koz
+            (
+             identificatie,
+             rustop_zak_recht
+            )
+AS 
+SELECT  qry.identificatie,
+        qry.rustop_zak_recht
+FROM    ( 
+            SELECT  r.identificatie,
+                    r.rustop                               AS rustop_zak_recht
+            FROM    recht r
+            UNION ALL
+            -- [BRMO-336] wanneer een zakelijkrecht een eigendomsrecht belast
+            SELECT ribm.isbelastmet                        AS identificatie,
+                   r.rustop                                AS rustop_zak_recht
+            FROM recht r
+            LEFT JOIN recht_isbelastmet ribm ON r.identificatie = ribm.zakelijkrecht
+            UNION ALL
+             -- [BRMO-351] wanneer een zakelijkrecht een ander zakelijkrecht belast
+            SELECT ribm2.isbelastmet                        AS identificatie,
+                   r.rustop                                AS rustop_zak_recht
+            FROM recht r
+            LEFT JOIN recht_isbelastmet ribm ON r.identificatie = ribm.zakelijkrecht
+            LEFT JOIN recht_isbelastmet ribm2 ON ribm.isbelastmet = ribm2.zakelijkrecht     
+          ) qry
+  WHERE split_part( qry.identificatie, ':', 1) = 'NL.IMKAD.ZakelijkRecht';
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_3.0.2_naar_4.0.0','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';


### PR DESCRIPTION
Een zakelijk recht, zoals een erfpacht-recht, kan een eigendomsrecht belasten. Ook is het mogelijk dat een zakelijk recht een zakelijk recht als een erfpacht kan belasten. Momenteel worden deze zakelijke rechten die direct een ander zakelijk recht belasten niet getoond. 

Voor PostgreSQL en Oracle is deze fixe toegepast.

Upgrade notities: 
Voor het toepassen van deze update hoeft enkel de DDL van de view `vb_util_zk_recht_op_koz` worden toegepast zonder overige views te droppen. Wel zouden de materialized views moeten worden ververst met [dit script](https://github.com/B3Partners/brmo/blob/master/datamodel/utility_scripts/postgresql/902_refresh_brk2.0_mat_views.sql)

