### PR TITLE
[BRMO-123] Verwijder ondersteuning voor BAG 1.0

### DIFF
--- a/brmo-commandline/README.md
+++ b/brmo-commandline/README.md
@@ -40,7 +40,7 @@ Configuratie:
 ```
 De `[format]` optie is optioneel en kan de waarde "json" hebben, de default is tekst output.
 
-De `[archief-directory]` optie is optioneel en kan gebruikt worden om betsanden na laden in een archief directory te plaatsen.
+De `[archief-directory]` optie is optioneel en kan gebruikt worden om bestanden na laden in een archief directory te plaatsen.
 
 De `[error-state]` is optioneel, default is "ignore".
 
@@ -60,17 +60,17 @@ Onderstaand een aantal voorbeelden.
      output:  
      
      ```
-     staging versie: 2.0.3
-     rsgb    versie: 2.0.3
+     staging versie: 3.0.3
+     rsgb    versie: 3.0.3
      ```
      
-  - `java -jar ./bin/brmo-commandline.jar -db conf/commandline-example.properties --load /home/mark/dev/projects/brmo/brmo-loader/src/test/resources/GH-275/OPR-1884300000000464.xml bag`
+  - `java -jar ./bin/brmo-commandline.jar -db conf/commandline-example.properties --load ./MUT01.xml brk`
   - `java -jar ./bin/brmo-commandline.jar --dbprops conf/commandline-example.properties --list json`
   
      output:  
      `{"aantalprocessen":0}`  
      of:
-     `{"aantalprocessen":1,"processen":[{"id":86,"bestand_naam":"/home/mark/dev/projects/brmo/brmo-loader/src/test/resources/GH-275/OPR-1884300000000464.xml","bestand_datum":"2016-04-08","soort":"bag","status":"STAGING_OK","contact":"null"}]}`
+     `{"aantalprocessen":1,"processen":[{"id":86,"bestand_naam":"./MUT01.xml","bestand_datum":"2016-04-08","soort":"brk","status":"STAGING_OK","contact":"null"}]}`
 
   - `java -jar ./bin/brmo-commandline.jar --dbprops conf/brmo-db.properties --torsgb`
   - `java -jar ./bin/brmo-commandline.jar --dbprops ./conf/brmo-db.properties -s`
@@ -83,7 +83,6 @@ Onderstaand een aantal voorbeelden.
      STAGING_NOK,0  
      RSGB_OK,0  
      RSGB_NOK,1
-     RSGB_BAG_NOK,123
      RSGB_OUTDATED,0  
      ARCHIVE,0  
 

--- a/brmo-commandline/src/main/java/nl/b3p/brmo/commandline/Main.java
+++ b/brmo-commandline/src/main/java/nl/b3p/brmo/commandline/Main.java
@@ -475,21 +475,19 @@ public class Main {
     long staging_nok = brmo.getCountBerichten(null, Bericht.STATUS.STAGING_NOK.name());
     long rsgb_ok = brmo.getCountBerichten(null, Bericht.STATUS.RSGB_OK.name());
     long rsgb_nok = brmo.getCountBerichten(null, Bericht.STATUS.RSGB_NOK.name());
-    long rsgb_bag_nok = brmo.getCountBerichten(null, Bericht.STATUS.RSGB_BAG_NOK.name());
     long rsgb_outdated = brmo.getCountBerichten(null, Bericht.STATUS.RSGB_OUTDATED.name());
     long archive = brmo.getCountBerichten(null, Bericht.STATUS.ARCHIVE.name());
 
     if (format.equalsIgnoreCase("json")) {
       System.out.printf(
-          "{\"status\":[{\"STAGING_OK\":%s},{\"STAGING_NOK\":%s},{\"RSGB_OK\":%s},{\"RSGB_NOK\":%s},{\"RSGB_BAG_NOK\":%s},{\"RSGB_OUTDATED\":%s},{\"ARCHIVE\":%s}]}\n",
-          staging_ok, staging_nok, rsgb_ok, rsgb_nok, rsgb_bag_nok, rsgb_outdated, archive);
+          "{\"status\":[{\"STAGING_OK\":%s},{\"STAGING_NOK\":%s},{\"RSGB_OK\":%s},{\"RSGB_NOK\":%s},{\"RSGB_OUTDATED\":%s},{\"ARCHIVE\":%s}]}\n",
+          staging_ok, staging_nok, rsgb_ok, rsgb_nok,  rsgb_outdated, archive);
     } else {
       System.out.println("status, aantal");
       System.out.printf("STAGING_OK,%s\n", staging_ok);
       System.out.printf("STAGING_NOK,%s\n", staging_nok);
       System.out.printf("RSGB_OK,%s\n", rsgb_ok);
       System.out.printf("RSGB_NOK,%s\n", rsgb_nok);
-      System.out.printf("RSGB_BAG_NOK,%s\n", rsgb_bag_nok);
       System.out.printf("RSGB_OUTDATED,%s\n", rsgb_outdated);
       System.out.printf("ARCHIVE,%s\n", archive);
     }

--- a/brmo-commandline/src/test/java/nl/b3p/brmo/commandline/MainIntegrationTest.java
+++ b/brmo-commandline/src/test/java/nl/b3p/brmo/commandline/MainIntegrationTest.java
@@ -69,8 +69,6 @@ public class MainIntegrationTest {
       staging.getConfig().setProperty(DatabaseConfig.FEATURE_SKIP_ORACLE_RECYCLEBIN_TABLES, true);
     }
     CleanUtil.cleanSTAGING(staging, false);
-    // omdat de insert van het bag object mislukt vanwege referentie check hoeft er niet
-    // opgeruimd in rsgb
     staging.close();
     dsStaging.close();
   }
@@ -92,7 +90,6 @@ public class MainIntegrationTest {
       strings = {
         "--versieinfo",
         "--versieinfo json",
-        "--load ../../../brmo-loader/src/test/resources/GH-275/OPR-1884300000000464.xml bag",
         "-l",
         "--list json",
         "-s",


### PR DESCRIPTION
BAG 1 is al een tijd niet meer beschikbaar.

- [x] Verwijder BAG referenties uit brmo-commandline
