### PR TITLE
Bump GeoTools van 30.2 naar 31.0 en jdbc-util van 16.2 naar 17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,8 @@
         <maven-fluido-skin.version>2.0.0-M8</maven-fluido-skin.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
-        <geotools.version>30.2</geotools.version>
-        <jdbc-util.version>16.2</jdbc-util.version>
+        <geotools.version>31-RC</geotools.version>
+        <jdbc-util.version>17.0-SNAPSHOT</jdbc-util.version>
         <jts.version>1.19.0</jts.version>
         <itextpdf.version>8.0.3</itextpdf.version>
         <postgresql.jdbc.version>42.7.3</postgresql.jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <maven-fluido-skin.version>2.0.0-M8</maven-fluido-skin.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
-        <geotools.version>31-RC</geotools.version>
+        <geotools.version>31.0</geotools.version>
         <jdbc-util.version>17.0-SNAPSHOT</jdbc-util.version>
         <jts.version>1.19.0</jts.version>
         <itextpdf.version>8.0.3</itextpdf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <hibernate.version>5.6.15.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
         <geotools.version>31.0</geotools.version>
-        <jdbc-util.version>17.0-SNAPSHOT</jdbc-util.version>
+        <jdbc-util.version>17.0</jdbc-util.version>
         <jts.version>1.19.0</jts.version>
         <itextpdf.version>8.0.3</itextpdf.version>
         <postgresql.jdbc.version>42.7.3</postgresql.jdbc.version>


### PR DESCRIPTION
- [x] Bump GeoTools van 30.2 naar [31-RC](https://github.com/geotools/geotools/releases/tag/31-RC) en jdbc-util van 16.2 naar 17.0-SNAPSHOT
- [x] Bump GeoTools van 31-RC naar [31.0](https://github.com/geotools/geotools/releases/tag/31.0)
- [x] Bump jdbc-util van 17.0-SNAPSHOT naar [17.0](https://github.com/B3Partners/jdbc-util/releases/tag/jdbc-util-17.0)

requires https://github.com/B3Partners/jdbc-util/pull/560