### PR TITLE
[BRMO-352] - Toevoegen van nHr-views

### DIFF
--- a/brmo-dist/assembly.xml
+++ b/brmo-dist/assembly.xml
@@ -142,6 +142,7 @@
             <includes>
                 <include>**/209_*.sql</include>
                 <include>**/210_*.sql</include>
+                <include>**/211_*.sql</include>
             </includes>
         </fileSet>
         <fileSet>

--- a/datamodel/extra_scripts/oracle/211_nhr_views.sql
+++ b/datamodel/extra_scripts/oracle/211_nhr_views.sql
@@ -14,7 +14,7 @@ group by s.naam, coalesce(v.fk_15ond_kvk_nummer, v.fk_17mac_kvk_nummer);
 -- koppel subject en vestg tabel met het adresseerbaarobject
 create materialized view mb_kvk_adres as 
 select  
-        cast(rownum as integer)    as objectid,
+        row_number() OVER ()::integer AS objectid,
         v.sc_identif,
         -- fk_15ond_kvk_nummer = kvknummer voor onderneming
         -- fk_17mac_kvk_nummer = kvknummer voor maatschappelijke activiteit (niet commercieel)

--- a/datamodel/extra_scripts/oracle/211_nhr_views.sql
+++ b/datamodel/extra_scripts/oracle/211_nhr_views.sql
@@ -1,0 +1,11 @@
+create or replace view v_kvk_hoofd_nevenvestiging as 
+select      s.naam as hoofdvestigingnaam,
+            coalesce(v.fk_15ond_kvk_nummer, v.fk_17mac_kvk_nummer)                                 as kvknummer,
+            listagg(distinct s2.naam, ' | ' on overflow truncate) within group ( order by s2.naam) as nevenvestigingen,
+            count(v2.sc_identif)                                                                   as aantal_nevenvestigingen
+from vestg v
+join subject s on v.sc_identif = s.identif
+join vestg v2 on coalesce(v.fk_15ond_kvk_nummer, v.fk_17mac_kvk_nummer) = coalesce(v2.fk_15ond_kvk_nummer, v2.fk_17mac_kvk_nummer)
+join subject s2 on v2.sc_identif = s2.identif
+where v.hoofdvestiging = 'Ja' and v2.hoofdvestiging = 'Nee'
+group by s.naam, coalesce(v.fk_15ond_kvk_nummer, v.fk_17mac_kvk_nummer);

--- a/datamodel/extra_scripts/oracle/211_nhr_views.sql
+++ b/datamodel/extra_scripts/oracle/211_nhr_views.sql
@@ -26,8 +26,7 @@ select
         --https://www.kvk.nl/over-het-handelsregister/overzicht-standaard-bedrijfsindeling-sbi-codes-voor-activiteiten/
         case 
                 when v.fk_sa_sbi_activiteit_sbi_code between '01%' and '04%' then 'Landbouw, bosbouw en visserij'
-				-- regex selectie tussen 06* en 09*
-                when regexp_like(v.fk_sa_sbi_activiteit_sbi_code, '^0[6-9]\d+') then 'Winning van delftstoffen'
+                when v.fk_sa_sbi_activiteit_sbi_code between '06%' and '09%' then 'Winning van delftstoffen'
 				when v.fk_sa_sbi_activiteit_sbi_code between '10%' and '34%' then 'Industrie'
 				when v.fk_sa_sbi_activiteit_sbi_code between '35%' and '36%' then 'Productie en distributie van en handel in elektriciteit, aardgas, stoom en gekoelde lucht '
 				when v.fk_sa_sbi_activiteit_sbi_code between '36%' and '41%' then 'Winning en distributie van water; afval- en afvalwaterbeheer en sanering'
@@ -39,8 +38,8 @@ select
 				when v.fk_sa_sbi_activiteit_sbi_code between '64%' and '68%' then 'Financiële instellingen'
 				when v.fk_sa_sbi_activiteit_sbi_code between '68%' and '69%' then 'Verhuur van en handel in onroerend goed'	
 				when v.fk_sa_sbi_activiteit_sbi_code between '69%' and '77%' then 'Advisering, onderzoek en overige specialistische zakelijke dienstverlening'	
-				when v.fk_sa_sbi_activiteit_sbi_code between '69%' and '77%' then 'Verhuur en lease van autos, consumentenartikelen, machines en overige roerende goederen'	
-				when v.fk_sa_sbi_activiteit_sbi_code between '77%' and '85%' then 'Openbaar bestuur, overheidsdiensten en verplichte sociale verzekeringen'	
+				when v.fk_sa_sbi_activiteit_sbi_code between '77%' and '84%' then 'Verhuur van roerende goederen en overige zakelijke dienstverlening'
+				when v.fk_sa_sbi_activiteit_sbi_code between '84%' and '85%' then 'Openbaar bestuur, overheidsdiensten en verplichte sociale verzekeringen'
 				when v.fk_sa_sbi_activiteit_sbi_code between '85%' and '86%' then 'Onderwijs'
 				when v.fk_sa_sbi_activiteit_sbi_code between '86%' and '90%' then 'Gezondheids- en welzijnszorg'
 				when v.fk_sa_sbi_activiteit_sbi_code between '90%' and '94%' then 'Cultuur, sport en recreatie'

--- a/datamodel/extra_scripts/oracle/211_nhr_views.sql
+++ b/datamodel/extra_scripts/oracle/211_nhr_views.sql
@@ -9,3 +9,183 @@ join vestg v2 on coalesce(v.fk_15ond_kvk_nummer, v.fk_17mac_kvk_nummer) = coales
 join subject s2 on v2.sc_identif = s2.identif
 where v.hoofdvestiging = 'Ja' and v2.hoofdvestiging = 'Nee'
 group by s.naam, coalesce(v.fk_15ond_kvk_nummer, v.fk_17mac_kvk_nummer);
+
+create materialized view mb_kvk_adres as 
+select  
+        cast(rownum as integer)    as objectid,
+        v.sc_identif,
+        -- fk_15ond_kvk_nummer = kvknummer voor onderneming
+        -- fk_17mac_kvk_nummer = kvknummer voor maatschappelijke activiteit (niet commercieel)
+        to_char(coalesce(v.fk_15ond_kvk_nummer,v.fk_17mac_kvk_nummer))  as kvknummer,
+        s.naam,
+        v.hoofdvestiging,
+        vhn.hoofdvestigingnaam,
+        -- de sbi codes zijn gebruikt om de bedrijfsactiviteit te generaliseren
+        --https://www.kvk.nl/over-het-handelsregister/overzicht-standaard-bedrijfsindeling-sbi-codes-voor-activiteiten/
+        case 
+                when v.fk_sa_sbi_activiteit_sbi_code between '01%' and '04%' then 'Landbouw, bosbouw en visserij'
+				-- regex selectie tussen 06* en 09*
+                when regexp_like(v.fk_sa_sbi_activiteit_sbi_code, '^0[6-9]\d+') then 'Winning van delftstoffen'
+				when v.fk_sa_sbi_activiteit_sbi_code between '10%' and '34%' then 'Industrie'
+				when v.fk_sa_sbi_activiteit_sbi_code between '35%' and '36%' then 'Productie en distributie van en handel in elektriciteit, aardgas, stoom en gekoelde lucht '
+				when v.fk_sa_sbi_activiteit_sbi_code between '36%' and '41%' then 'Winning en distributie van water; afval- en afvalwaterbeheer en sanering'
+				when v.fk_sa_sbi_activiteit_sbi_code between '41%' and '45%' then 'Bouwnijverheid'
+				when v.fk_sa_sbi_activiteit_sbi_code between '45%' and '49%' then 'Groot- en detailhandel; reparatie van auto'
+				when v.fk_sa_sbi_activiteit_sbi_code between '49%' and '55%' then 'Vervoer en opslag'
+				when v.fk_sa_sbi_activiteit_sbi_code between '55%' and '58%' then 'Logies-, maaltijd- en drankverstrekking'
+				when v.fk_sa_sbi_activiteit_sbi_code between '58%' and '64%' then 'Informatie en communicatie'
+				when v.fk_sa_sbi_activiteit_sbi_code between '64%' and '68%' then 'Financiële instellingen'
+				when v.fk_sa_sbi_activiteit_sbi_code between '68%' and '69%' then 'Verhuur van en handel in onroerend goed'	
+				when v.fk_sa_sbi_activiteit_sbi_code between '69%' and '77%' then 'Advisering, onderzoek en overige specialistische zakelijke dienstverlening'	
+				when v.fk_sa_sbi_activiteit_sbi_code between '69%' and '77%' then 'Verhuur en lease van autos, consumentenartikelen, machines en overige roerende goederen'	
+				when v.fk_sa_sbi_activiteit_sbi_code between '77%' and '85%' then 'Openbaar bestuur, overheidsdiensten en verplichte sociale verzekeringen'	
+				when v.fk_sa_sbi_activiteit_sbi_code between '85%' and '86%' then 'Onderwijs'
+				when v.fk_sa_sbi_activiteit_sbi_code between '86%' and '90%' then 'Gezondheids- en welzijnszorg'
+				when v.fk_sa_sbi_activiteit_sbi_code between '90%' and '94%' then 'Cultuur, sport en recreatie'
+				when v.fk_sa_sbi_activiteit_sbi_code between '94%' and '97%' then 'Overige dienstverlening'
+				when v.fk_sa_sbi_activiteit_sbi_code between '97%' and '99%' then 'Huishoudens als werkgever; niet-gedifferentieerde productie van goederen en diensten door huishoudens voor eigen gebruik'
+				when v.fk_sa_sbi_activiteit_sbi_code like '99%' then 'Extraterritoriale organisaties en lichamen'
+                else 'Geen specifiek activiteit'
+        end as activiteit,
+        v.fk_sa_sbi_activiteit_sbi_code as sbi_code,
+        sa.omschr,
+        v.activiteit_omschr 	   as omschr_detail,
+        v.typering,
+        -- datum bedrijf
+        v.datum_aanvang,
+        v.datum_beeindiging,
+        -- werknemer(s)
+        v.fulltime_werkzame_mannen + v.parttime_werkzame_mannen as aantal_werknemers,
+        v.fulltime_werkzame_mannen as aantal_fulltime_werknemers,
+        v.parttime_werkzame_mannen as parttime_werknemers,
+        -- adresgegevens
+        coalesce(s.adres_binnenland, s.adres_buitenland) as adres,
+        -- correspondentieadres
+        replace(coalesce(coa.straatnaam, '') || ' ' || coalesce(to_char(coa.huisnummer), '') || coalesce(coa.huisletter, '') || coalesce(coa.huisnummertoevoeging, '') || 
+        ' ' || coalesce(coa.postcode, '') || ' ' || coalesce(coa.woonplaats, ''), ' ', ' ') as correspondentieadres,
+        -- contactgegevens
+        s.emailadres,
+        s.fax_nummer,
+        s.telefoonnummer,
+        s.website_url,
+        -- adresseerbaarobjectidentificaties
+        v.fk_20aoa_identif 		   as adresseerbaarobjectid,
+        s.fk_15aoa_identif 		   as correspondentie_aoi,
+        a.maaktdeeluitvan,
+        a.geometrie_centroide      as geometrie
+from vestg v 
+-- Een vestiging kan meerdere activiteiten bevatten, deze staat in de vestg_activiteit tabel. 
+left join sbi_activiteit sa on v.fk_sa_sbi_activiteit_sbi_code = sa.sbi_code
+-- soms staat de naam niet in de vestg_naam tabel. Daarom is het noodzakelijk om de naam van 
+-- de subject tabel ook te raadplegen
+left join subject s on v.sc_identif = s.identif
+-- koppeling met geometrie
+left join mb_adresseerbaar_object_geometrie_bag a on v.fk_20aoa_identif = a.identificatie
+-- koppeling met correspondentie adresgegevens en geometrie
+left join mb_adresseerbaar_object_geometrie_bag coa on s.fk_15aoa_identif = coa.identificatie
+-- voeg hoofdvestiging naam toe
+left join v_kvk_hoofd_nevenvestiging vhn on coalesce(v.fk_15ond_kvk_nummer,v.fk_17mac_kvk_nummer) = vhn.kvknummer;
+
+delete
+from user_sdo_geom_metadata
+where table_name = 'MB_KVK_ADRES';
+insert into user_sdo_geom_metadata
+values ('mb_kvk_adres', 'geometrie',
+        MDSYS.SDO_DIM_ARRAY(MDSYS.SDO_DIM_ELEMENT('X', 12000, 280000, .1),
+                            MDSYS.SDO_DIM_ELEMENT('Y', 304000, 620000, .1)), 28992);
+
+CREATE INDEX mb_kvk_adres_geometrie_idx ON mb_kvk_adres (geometrie) INDEXTYPE IS MDSYS.SPATIAL_INDEX;
+CREATE UNIQUE INDEX mb_kvk_adres_objectid ON mb_kvk_adres (objectid);
+
+create materialized view mb_kvk_pand as 
+select  
+        cast(rownum as integer)    as objectid,
+        kvk.sc_identif,
+		kvk.kvknummer,
+		kvk.naam,
+		kvk.hoofdvestiging,
+		kvk.hoofdvestigingnaam,
+		kvk.activiteit,
+		kvk.sbi_code,
+		kvk.omschr,
+		kvk.omschr_detail,
+		kvk.typering,
+		kvk.datum_aanvang,
+		kvk.datum_beeindiging,
+		kvk.aantal_werknemers,
+		kvk.aantal_fulltime_werknemers,
+		kvk.parttime_werknemers,
+		kvk.adres,
+		kvk.correspondentieadres,
+		kvk.emailadres,
+		kvk.fax_nummer,
+		kvk.telefoonnummer,
+		kvk.website_url,
+		kvk.adresseerbaarobjectid,
+		kvk.correspondentie_aoi,
+		kvk.maaktdeeluitvan,
+		-- pandgeometrie
+		vp.geometrie
+from mb_kvk_adres kvk
+-- koppel pand geometrie
+join brmo_bag.v_pand_actueel vp on kvk.maaktdeeluitvan = vp.identificatie;
+
+delete
+from user_sdo_geom_metadata
+where table_name = 'MB_KVK_PAND';
+insert into user_sdo_geom_metadata
+values ('mb_kvk_pand', 'geometrie',
+        MDSYS.SDO_DIM_ARRAY(MDSYS.SDO_DIM_ELEMENT('X', 12000, 280000, .1),
+                            MDSYS.SDO_DIM_ELEMENT('Y', 304000, 620000, .1)), 28992);
+
+CREATE INDEX mb_kvk_pand_geometrie_idx ON mb_kvk_pand (geometrie) INDEXTYPE IS MDSYS.SPATIAL_INDEX;
+CREATE UNIQUE INDEX mb_kvk_pand_objectid ON mb_kvk_pand (objectid);
+
+-- koppel kvk-gegevens met bag-gegevens met BRK-geometriëen
+create materialized view mb_kvk_perceel as 
+select  
+		cast(rownum as integer)    as objectid,
+		kvk.sc_identif,
+		kvk.kvknummer,
+		kvk.naam,
+		kvk.hoofdvestiging,
+		kvk.hoofdvestigingnaam,
+		kvk.activiteit,
+		kvk.sbi_code,
+		kvk.omschr,
+		kvk.omschr_detail,
+		kvk.typering,
+		kvk.datum_aanvang,
+		kvk.datum_beeindiging,
+		kvk.aantal_werknemers,
+		kvk.aantal_fulltime_werknemers,
+		kvk.parttime_werknemers,
+		kvk.adres,
+		kvk.correspondentieadres,
+		kvk.emailadres,
+		kvk.fax_nummer,
+		kvk.telefoonnummer,
+		kvk.website_url,
+		kvk.adresseerbaarobjectid,
+		kvk.correspondentie_aoi,
+		-- BRK gegevens
+		p.identificatie as perceelsidentificatie, 
+		zrr.soort,
+		zrr.kvk_nummer as kvk_eigenaar, 
+		p.begrenzing_perceel as geometrie
+from mb_kvk_adres kvk
+-- koppel BRK gegevens
+join brmo_brk.perceel p on SDO_RELATE(kvk.geometrie, p.begrenzing_perceel, 'mask=INSIDE querytype=window')='TRUE'
+join brmo_brk.mb_zr_rechth zrr on p.identificatie = zrr.koz_identif;
+
+delete
+from user_sdo_geom_metadata
+where table_name = 'MB_KVK_PERCEEL';
+insert into user_sdo_geom_metadata
+values ('mb_kvk_perceel', 'geometrie',
+        MDSYS.SDO_DIM_ARRAY(MDSYS.SDO_DIM_ELEMENT('X', 12000, 280000, .1),
+                            MDSYS.SDO_DIM_ELEMENT('Y', 304000, 620000, .1)), 28992);
+
+CREATE INDEX mb_kvk_perceel_geometrie_idx ON mb_kvk_perceel (geometrie) INDEXTYPE IS MDSYS.SPATIAL_INDEX;
+CREATE UNIQUE INDEX mb_kvk_perceel_objectid ON mb_kvk_perceel (objectid);
+CREATE INDEX mb_kvk_perceel_perceelsidentificatie ON mb_kvk_perceel (perceelsidentificatie);

--- a/datamodel/extra_scripts/oracle/211_nhr_views.sql
+++ b/datamodel/extra_scripts/oracle/211_nhr_views.sql
@@ -1,3 +1,4 @@
+--- koppel nevenvestigingen met hoofdvestiging
 create or replace view v_kvk_hoofd_nevenvestiging as 
 select      s.naam as hoofdvestigingnaam,
             coalesce(v.fk_15ond_kvk_nummer, v.fk_17mac_kvk_nummer)                                 as kvknummer,
@@ -10,6 +11,7 @@ join subject s2 on v2.sc_identif = s2.identif
 where v.hoofdvestiging = 'Ja' and v2.hoofdvestiging = 'Nee'
 group by s.naam, coalesce(v.fk_15ond_kvk_nummer, v.fk_17mac_kvk_nummer);
 
+-- koppel subject en vestg tabel met het adresseerbaarobject
 create materialized view mb_kvk_adres as 
 select  
         cast(rownum as integer)    as objectid,
@@ -97,6 +99,7 @@ values ('mb_kvk_adres', 'geometrie',
 CREATE INDEX mb_kvk_adres_geometrie_idx ON mb_kvk_adres (geometrie) INDEXTYPE IS MDSYS.SPATIAL_INDEX;
 CREATE UNIQUE INDEX mb_kvk_adres_objectid ON mb_kvk_adres (objectid);
 
+-- koppel pandgeometrieën aan de nHr-gegevens
 create materialized view mb_kvk_pand as 
 select  
         cast(rownum as integer)    as objectid,
@@ -141,7 +144,7 @@ values ('mb_kvk_pand', 'geometrie',
 CREATE INDEX mb_kvk_pand_geometrie_idx ON mb_kvk_pand (geometrie) INDEXTYPE IS MDSYS.SPATIAL_INDEX;
 CREATE UNIQUE INDEX mb_kvk_pand_objectid ON mb_kvk_pand (objectid);
 
--- koppel kvk-gegevens met bag-gegevens met BRK-geometriëen
+-- koppel BRK-gegevens en perceelgrenzen aan de nHr-gegevens
 create materialized view mb_kvk_perceel as 
 select  
 		cast(rownum as integer)    as objectid,

--- a/datamodel/extra_scripts/postgresql/211_nhr_views.sql
+++ b/datamodel/extra_scripts/postgresql/211_nhr_views.sql
@@ -26,10 +26,10 @@ select
 			-- de sbi codes zijn gebruikt om de bedrijfsactiviteit te generaliseren
 			--https://www.kvk.nl/over-het-handelsregister/overzicht-standaard-bedrijfsindeling-sbi-codes-voor-activiteiten/
 			case 
-				when v.fk_sa_sbi_activiteit_sbi_code between '01%' and '03%' then 'Landbouw, bosbouw en visserij'
-				-- hier naar kijken
-				when v.fk_sa_sbi_activiteit_sbi_code between '%6%' and '10%' then 'Winning van delfstoffen'
-				when v.fk_sa_sbi_activiteit_sbi_code between '10%' and '35%' then 'Industrie'
+				when v.fk_sa_sbi_activiteit_sbi_code between '01%' and '04%' then 'Landbouw, bosbouw en visserij'
+				-- regex selectie tussen 06* en 09*
+				when v.fk_sa_sbi_activiteit_sbi_code ~ '^0[6-9]\d+' then 'Winning van delfstoffen'
+				when v.fk_sa_sbi_activiteit_sbi_code between '10%' and '34%' then 'Industrie'
 				when v.fk_sa_sbi_activiteit_sbi_code between '35%' and '36%' then 'Productie en distributie van en handel in elektriciteit, aardgas, stoom en gekoelde lucht '
 				when v.fk_sa_sbi_activiteit_sbi_code between '36%' and '41%' then 'Winning en distributie van water; afval- en afvalwaterbeheer en sanering'
 				when v.fk_sa_sbi_activiteit_sbi_code between '41%' and '45%' then 'Bouwnijverheid'

--- a/datamodel/extra_scripts/postgresql/211_nhr_views.sql
+++ b/datamodel/extra_scripts/postgresql/211_nhr_views.sql
@@ -1,5 +1,5 @@
 --- koppel nevenvestigingen met hoofdvestiging
-create or replace view v_kvk_hoofd_nevenvestiging as 
+create or replace view v_kvk_hoofd_nevenvestiging as
 select 			s.naam as hoofdvestigingnaam,
 				coalesce(v.fk_15ond_kvk_nummer::text, v.fk_17mac_kvk_nummer::text) as kvknummer,
 				count(v2.sc_identif)  								 		       as aantal_nevenvestigingen,
@@ -90,8 +90,10 @@ CREATE INDEX mb_kvk_adres_geometrie_idx ON public.mb_kvk_adres USING gist (geome
 CREATE UNIQUE INDEX mb_kvk_adres_objectid ON public.mb_kvk_adres USING btree (objectid);
 
 -- koppel kvk-gegevens met bag-gegevens met BAG-geometriëen
-create materialized view mb_kvk_pand
-select  kvk.sc_identif,
+create materialized view mb_kvk_pand as 
+select  
+		row_number() over ()     		 as objectid,
+		kvk.sc_identif,
 		kvk.kvknummer,
 		kvk.naam,
 		kvk.hoofdvestiging,
@@ -125,7 +127,9 @@ CREATE UNIQUE INDEX mb_kvk_pand_objectid ON public.mb_kvk_pand USING btree (obje
 
 -- koppel kvk-gegevens met bag-gegevens met BRK-geometriëen
 create materialized view mb_kvk_perceel as 
-select  kvk.sc_identif,
+select  
+		row_number() over ()     		 as objectid,
+		kvk.sc_identif,
 		kvk.kvknummer,
 		kvk.naam,
 		kvk.hoofdvestiging,
@@ -149,7 +153,7 @@ select  kvk.sc_identif,
 		kvk.adresseerbaarobjectid,
 		kvk.correspondentie_aoi,
 		-- BRK gegevens
-		p.identificatie as koz_identif, 
+		p.identificatie as perceelsidentificatie, 
 		zrr.soort,
 		zrr.kvk_nummer as kvk_eigenaar, 
 		p.begrenzing_perceel as geometrie

--- a/datamodel/extra_scripts/postgresql/211_nhr_views.sql
+++ b/datamodel/extra_scripts/postgresql/211_nhr_views.sql
@@ -1,0 +1,12 @@
+--- koppel nevenvestigingen met hoofdvestiging
+create or replace view v_kvk_hoofd_nevenvestiging as 
+select 			s.naam as hoofdvestigingnaam,
+				coalesce(v.fk_15ond_kvk_nummer::text, v.fk_17mac_kvk_nummer::text) as kvknummer,
+				array_to_string(array_agg(distinct s2.naam), ' | ')    as nevenvestigingen,
+				count(v2.*)  								 		   as aantal_nevenvestigingen
+from vestg v
+join subject s on v.sc_identif = s.identif
+join vestg v2 on coalesce(v.fk_15ond_kvk_nummer, v.fk_17mac_kvk_nummer) = coalesce(v2.fk_15ond_kvk_nummer, v2.fk_17mac_kvk_nummer)
+join subject s2 on v2.sc_identif = s2.identif 
+where v.hoofdvestiging = 'Ja' and v2.hoofdvestiging = 'Nee'
+group by hoofdvestigingnaam, coalesce(v.fk_15ond_kvk_nummer::text, v.fk_17mac_kvk_nummer::text);

--- a/datamodel/extra_scripts/postgresql/211_nhr_views.sql
+++ b/datamodel/extra_scripts/postgresql/211_nhr_views.sql
@@ -26,8 +26,7 @@ select
 			--https://www.kvk.nl/over-het-handelsregister/overzicht-standaard-bedrijfsindeling-sbi-codes-voor-activiteiten/
 			case 
 				when v.fk_sa_sbi_activiteit_sbi_code between '01%' and '04%' then 'Landbouw, bosbouw en visserij'
-				-- regex selectie tussen 06* en 09*
-				when v.fk_sa_sbi_activiteit_sbi_code ~ '^0[6-9]\d+' then 'Winning van delfstoffen'
+				when v.fk_sa_sbi_activiteit_sbi_code between '06%' and '09%' then 'Winning van delfstoffen'
 				when v.fk_sa_sbi_activiteit_sbi_code between '10%' and '34%' then 'Industrie'
 				when v.fk_sa_sbi_activiteit_sbi_code between '35%' and '36%' then 'Productie en distributie van en handel in elektriciteit, aardgas, stoom en gekoelde lucht '
 				when v.fk_sa_sbi_activiteit_sbi_code between '36%' and '41%' then 'Winning en distributie van water; afval- en afvalwaterbeheer en sanering'
@@ -39,8 +38,8 @@ select
 				when v.fk_sa_sbi_activiteit_sbi_code between '64%' and '68%' then 'Financiële instellingen'
 				when v.fk_sa_sbi_activiteit_sbi_code between '68%' and '69%' then 'Verhuur van en handel in onroerend goed'	
 				when v.fk_sa_sbi_activiteit_sbi_code between '69%' and '77%' then 'Advisering, onderzoek en overige specialistische zakelijke dienstverlening'	
-				when v.fk_sa_sbi_activiteit_sbi_code between '69%' and '77%' then 'Verhuur en lease van autos, consumentenartikelen, machines en overige roerende goederen'	
-				when v.fk_sa_sbi_activiteit_sbi_code between '77%' and '85%' then 'Openbaar bestuur, overheidsdiensten en verplichte sociale verzekeringen'	
+				when v.fk_sa_sbi_activiteit_sbi_code between '77%' and '84%' then 'Verhuur van roerende goederen en overige zakelijke dienstverlening'
+				when v.fk_sa_sbi_activiteit_sbi_code between '84%' and '85%' then 'Openbaar bestuur, overheidsdiensten en verplichte sociale verzekeringen'
 				when v.fk_sa_sbi_activiteit_sbi_code between '85%' and '86%' then 'Onderwijs'
 				when v.fk_sa_sbi_activiteit_sbi_code between '86%' and '90%' then 'Gezondheids- en welzijnszorg'
 				when v.fk_sa_sbi_activiteit_sbi_code between '90%' and '94%' then 'Cultuur, sport en recreatie'

--- a/datamodel/extra_scripts/postgresql/211_nhr_views.sql
+++ b/datamodel/extra_scripts/postgresql/211_nhr_views.sql
@@ -10,3 +10,95 @@ join vestg v2 on coalesce(v.fk_15ond_kvk_nummer, v.fk_17mac_kvk_nummer) = coales
 join subject s2 on v2.sc_identif = s2.identif 
 where v.hoofdvestiging = 'Ja' and v2.hoofdvestiging = 'Nee'
 group by hoofdvestigingnaam, coalesce(v.fk_15ond_kvk_nummer::text, v.fk_17mac_kvk_nummer::text);
+
+-- koppel kvk-gegevens met bag-gegevens en perceelidentificatie
+create materialized view mb_kvk_pand_perceel as 
+select 		
+			row_number() over ()     		 as objectid,
+			v.sc_identif,
+			p.identificatie as perceelsidentificatie,
+			s.naam,
+			-- fk_15ond_kvk_nummer = kvknummer voor onderneming
+			-- fk_17mac_kvk_nummer = kvknummer voor maatschappelijke activiteit (niet commercieel)
+			coalesce(v.fk_15ond_kvk_nummer::text,v.fk_17mac_kvk_nummer::text)  as kvknummer,
+			zrr.soort,
+			zrr.kvk_nummer as kvknummer_eigenaar,
+			-- de sbi codes zijn gebruikt om de bedrijfsactiviteit te generaliseren
+			--https://www.kvk.nl/over-het-handelsregister/overzicht-standaard-bedrijfsindeling-sbi-codes-voor-activiteiten/
+			case 
+				when v.fk_sa_sbi_activiteit_sbi_code between '01%' and '03%' then 'Landbouw, bosbouw en visserij'
+				-- hier naar kijken
+				when v.fk_sa_sbi_activiteit_sbi_code between '%6%' and '10%' then 'Winning van delfstoffen'
+				when v.fk_sa_sbi_activiteit_sbi_code between '10%' and '35%' then 'Industrie'
+				when v.fk_sa_sbi_activiteit_sbi_code between '35%' and '36%' then 'Productie en distributie van en handel in elektriciteit, aardgas, stoom en gekoelde lucht '
+				when v.fk_sa_sbi_activiteit_sbi_code between '36%' and '41%' then 'Winning en distributie van water; afval- en afvalwaterbeheer en sanering'
+				when v.fk_sa_sbi_activiteit_sbi_code between '41%' and '45%' then 'Bouwnijverheid'
+				when v.fk_sa_sbi_activiteit_sbi_code between '45%' and '49%' then 'Groot- en detailhandel; reparatie van auto'
+				when v.fk_sa_sbi_activiteit_sbi_code between '49%' and '55%' then 'Vervoer en opslag'
+				when v.fk_sa_sbi_activiteit_sbi_code between '55%' and '58%' then 'Logies-, maaltijd- en drankverstrekking'
+				when v.fk_sa_sbi_activiteit_sbi_code between '58%' and '64%' then 'Informatie en communicatie'
+				when v.fk_sa_sbi_activiteit_sbi_code between '64%' and '68%' then 'Financiële instellingen'
+				when v.fk_sa_sbi_activiteit_sbi_code between '68%' and '69%' then 'Verhuur van en handel in onroerend goed'	
+				when v.fk_sa_sbi_activiteit_sbi_code between '69%' and '77%' then 'Advisering, onderzoek en overige specialistische zakelijke dienstverlening'	
+				when v.fk_sa_sbi_activiteit_sbi_code between '69%' and '77%' then 'Verhuur en lease van autos, consumentenartikelen, machines en overige roerende goederen'	
+				when v.fk_sa_sbi_activiteit_sbi_code between '77%' and '85%' then 'Openbaar bestuur, overheidsdiensten en verplichte sociale verzekeringen'	
+				when v.fk_sa_sbi_activiteit_sbi_code between '85%' and '86%' then 'Onderwijs'
+				when v.fk_sa_sbi_activiteit_sbi_code between '86%' and '90%' then 'Gezondheids- en welzijnszorg'
+				when v.fk_sa_sbi_activiteit_sbi_code between '90%' and '94%' then 'Cultuur, sport en recreatie'
+				when v.fk_sa_sbi_activiteit_sbi_code between '94%' and '97%' then 'Overige dienstverlening'
+				when v.fk_sa_sbi_activiteit_sbi_code between '97%' and '99%' then 'Huishoudens als werkgever; niet-gedifferentieerde productie van goederen en diensten door huishoudens voor eigen gebruik'
+				when v.fk_sa_sbi_activiteit_sbi_code like '99%' then 'Extraterritoriale organisaties en lichamen'
+				else 'Geen specifiek activiteit'
+			end as activiteit,
+			v.fk_sa_sbi_activiteit_sbi_code as sbi_code,
+			sa.omschr,
+			v.activiteit_omschr 	   as omschr_detail,
+			v.hoofdvestiging,
+			vhn.hoofdvestigingnaam,
+			v.typering,
+			-- datum bedrijf
+			v.datum_aanvang,
+			v.datum_beeindiging,
+			-- werknemer(s)
+			v.fulltime_werkzame_mannen + v.parttime_werkzame_mannen as aantal_werknemers,
+			v.fulltime_werkzame_mannen as aantal_fulltime_werknemers,
+			v.parttime_werkzame_mannen as parttime_werknemers,
+			-- adresgegevens
+			coalesce(s.adres_binnenland, s.adres_buitenland) as adres,
+			replace((((((((COALESCE(coa.straatnaam, ''::character varying)::text || ' '::text) || COALESCE(coa.huisnummer::text, ''::text)) || COALESCE(coa.huisletter, ''::character varying)::text) || COALESCE(coa.huisnummertoevoeging, ''::character varying)::text) || ' '::text) || COALESCE(coa.postcode, ''::character varying)::text) || ' '::text) || COALESCE(coa.woonplaats, ''::character varying)::text, '  '::text, ' '::text) AS correspondentieadres,
+			-- contactgegevens
+			s.emailadres,
+			s.fax_nummer,
+			s.telefoonnummer,
+			s.website_url,
+			-- adresseerbaarobjectidentificaties
+			v.fk_20aoa_identif 		   as adresseerbaarobjectid,
+			s.fk_15aoa_identif 		   as correspondentie_aoi,
+			-- geometrie
+			a.geometrie_centroide 	   as adresgeometrie,
+			vp.geometrie 			   as pandgeometrie,
+			p.begrenzing_perceel	   as perceelgeometrie
+from vestg v
+-- koppeling met de hoofdactiviteit van een vestiging. 
+-- Een vestiging kan meerdere activiteiten bevatten, deze staat in de vestg_activiteit tabel. 
+left join sbi_activiteit sa on v.fk_sa_sbi_activiteit_sbi_code = sa.sbi_code
+-- soms staat de naam niet in de vestg_naam tabel. Daarom is het noodzakelijk om de naam van 
+-- de subject tabel ook te raadplegen
+left join subject s on v.sc_identif = s.identif
+-- koppeling met geometrie
+left join mb_adresseerbaar_object_geometrie_bag a on v.fk_20aoa_identif = a.identificatie
+-- koppeling met correspondentie adresgegevens en geometrie
+left join mb_adresseerbaar_object_geometrie_bag coa on s.fk_15aoa_identif = coa.identificatie
+-- koppel pand geometrie
+left join bag.v_pand_actueel vp on a.maaktdeeluitvan = vp.identificatie 
+-- voeg hoofdvestiging naam toe
+left join v_kvk_hoofd_nevenvestiging vhn on coalesce(v.fk_15ond_kvk_nummer::text,v.fk_17mac_kvk_nummer::text) = vhn.kvknummer
+-- koppel BRK gegevens
+left join brk.perceel p on st_contains(p.begrenzing_perceel, a.geometrie)
+left join brk.mb_zr_rechth zrr on p.identificatie = zrr.koz_identif;
+
+CREATE INDEX mb_kvk_pand_perceel_adresgeometrie_idx ON public.mb_kvk_pand_perceel USING gist (adresgeometrie);
+CREATE INDEX mb_kvk_pand_perceel_pandgeometrie_idx on public.mb_kvk_pand_perceel USING gist (perceelgeometrie);
+CREATE INDEX mb_kvk_pand_perceel_perceelgeometrie_idx ON public.mb_kvk_pand_perceel USING gist (perceelgeometrie);
+CREATE INDEX mb_kvk_pand_perceel_identif ON public.mb_kvk_pand_perceel USING btree (perceelsidentificatie);
+CREATE UNIQUE INDEX mb_kvk_pand_perceel_objectid ON public.mb_kvk_pand_perceel USING btree (objectid);

--- a/docker/src/main/docker/Dockerfile
+++ b/docker/src/main/docker/Dockerfile
@@ -41,6 +41,7 @@ COPY bin_unzipped/drivers/pgsql/*.jar /usr/local/tomcat/lib/
 COPY ["bin_unzipped/db/rsgb/datamodel_postgresql.sql", \
       "bin_unzipped/db/rsgb/postgresql/209_bag2_rsgb_views.sql", \
       "bin_unzipped/db/rsgb/postgresql/210_bag2_brk2.0_mat_views.sql", \
+      "bin_unzipped/db/rsgb/postgresql/211_nhr_views.sql", \
       "bin_unzipped/db/brk/brk2.0_postgresql.sql", \
       "bin_unzipped/db/brk/brk2.0_postgresql_views.sql", \
       "bin_unzipped/db/brk/brk2.0_commentaar.sql", \


### PR DESCRIPTION
Deze views kunnen ervoor zorgen dat de data van het Handelsregister kan worden gebruikt als kaartlagen in een GIS-viewer. Door de tabellen `subject` en `vestg` met elkaar te koppelen en te koppelen aan het adresseerbaar object, is het mogelijk om de nHr-informatie op de kaart te tonen. Aan de hand van het adresseerbaar object is een administratieve koppeling te realiseren met de BAG. De BRK is gekoppeled met een spatial join.

Het is mogelijk om op drie verschillende manieren de kaartlaag te visualiseren aangezien er drie verschillende geometriëen aanwezig zijn. Om die reden zijn er drie materialized views gemaakt, namelijk: 
1. `mb_kvk_adres`: koppelt het adresseerbaarobject met de nHr-gegevens (punt-geometrie).
2. `mb_kvk_pand`: koppelt via de `maaktdeeluitvan` attribuut bovenstaande materialized view zodat een pand-geometrie kan worden getoond (vlak-geometrie).
4. `mb_kvk_perceel`: koppelt `mb_kvk_adres` met een spatial join  (`ST_CONTAINS`) zodat een perceel-geometrie en overige BRK-gegevens kan worden getoond (vlak-geometrie).

Na het inladen van nHr-data kunnen deze views worden aangemaakt. 