### PR TITLE
[BRMO-365] Gebruik sslSocketFactory voor nieuwe PKIOverheid certificaten. 

### DIFF
--- a/nhr-loader/src/main/java/nl/b3p/brmo/nhr/loader/cli/NHRLoadUtils.java
+++ b/nhr-loader/src/main/java/nl/b3p/brmo/nhr/loader/cli/NHRLoadUtils.java
@@ -108,8 +108,7 @@ public class NHRLoadUtils {
     context.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);
 
     TLSClientParameters tlsClientParameters = new TLSClientParameters();
-    tlsClientParameters.setKeyManagers(keyManagerFactory.getKeyManagers());
-    tlsClientParameters.setSslContext(context);
+    tlsClientParameters.setSSLSocketFactory(context.getSocketFactory());
     http.setTlsClientParameters(tlsClientParameters);
 
     Map<String, Object> props = new HashMap<>();


### PR DESCRIPTION
Na de upgrade van apache.cxf van 3.5.6 -> 3.6.X werkt de keymanager niet meer voor (nieuwe) PKIOverheid certificaten
Zie ook: https://github.com/B3Partners/brmo/pull/2007/