### PR TITLE
Verduidelijk begingeldigheid/eindegeldigheid datum

### DIFF
--- a/datamodel/brk/brk2.0_commentaar.sql
+++ b/datamodel/brk/brk2.0_commentaar.sql
@@ -26,8 +26,8 @@ COMMENT ON COLUMN stukdeel.deelvan IS 'Referentie naar het stuk waarvan dit deel
 
 COMMENT ON TABLE onroerendezaak IS 'Een onroerende zaak is de grond, de niet gewonnen delfstoffen, de met de grond verenigde beplantingen, alsmede de gebouwen en werken die duurzaam met de grond zijn verenigd, hetzij rechtstreeks, hetzij door vereniging met andere gebouwen of werken.';
 COMMENT ON COLUMN onroerendezaak.identificatie IS 'Identificatie is een door het Kadaster toegekend landelijk uniek nummer aan een object binnen de kadastrale registratie.';
-COMMENT ON COLUMN onroerendezaak.begingeldigheid IS 'BRMO: metadata tbv archivering, datum van bericht.';
-COMMENT ON COLUMN onroerendezaak.eindegeldigheid IS 'BRMO: metadata tbv archivering, datum van opvolgend bericht.';
+COMMENT ON COLUMN onroerendezaak.begingeldigheid IS 'BRMO: metadata tbv archivering, de toestandsdatum van het bericht.';
+COMMENT ON COLUMN onroerendezaak.eindegeldigheid IS 'BRMO: metadata tbv archivering, de toestandsdatum van het opvolgende bericht.';
 COMMENT ON COLUMN onroerendezaak.akrkadastralegemeentecode IS 'De kadastrale gemeente, deel van de kadastrale aanduiding van de onroerende zaak.';
 COMMENT ON COLUMN onroerendezaak.akrkadastralegemeente IS 'De kadastrale gemeente, deel van de kadastrale aanduiding van de onroerende zaak.';
 COMMENT ON COLUMN onroerendezaak.kadastralegemeentecode IS 'De kadastrale gemeente, deel van de kadastrale aanduiding van de onroerende zaak.';
@@ -190,7 +190,7 @@ COMMENT ON COLUMN recht.einddatum IS 'Einddatum is de datum waarop de geldigheid
 COMMENT ON COLUMN recht.betreftgedeeltevanperceel IS 'BetreftGedeelteVanPerceel is een aanduiding of de aantekening het gehele perceel (nee of niet gevuld) betreft of slechts een gedeelte (ja).';
 COMMENT ON COLUMN recht.aantekeningkadastraalobject IS 'Relatie van aantekening naar onroerende zaak.';
 COMMENT ON COLUMN recht.betrokkenpersoon IS 'Relatie van aantekening naar persoon';
-COMMENT ON COLUMN recht.begingeldigheid IS 'BRMO: metadata tbv archivering, datum van bericht.';
+COMMENT ON COLUMN recht.begingeldigheid IS 'BRMO: metadata tbv archivering, de toestandsdatum van het bericht.';
 
 
 COMMENT ON TABLE recht_aantekeningrecht IS 'Koppeltabel voor aantekeningen bij een tenaamstelling van een recht.';

--- a/datamodel/upgrade_scripts/3.0.2-4.0.0/oracle/brk.sql
+++ b/datamodel/upgrade_scripts/3.0.2-4.0.0/oracle/brk.sql
@@ -44,6 +44,10 @@ FROM (SELECT r.identificatie,
      ) qry
 WHERE SUBSTR(qry.identificatie, 1, INSTR(qry.identificatie, ':') - 1) = 'NL.IMKAD.ZakelijkRecht';
 
+COMMENT ON COLUMN onroerendezaak.begingeldigheid IS 'BRMO: metadata tbv archivering, de toestandsdatum van het bericht.';
+COMMENT ON COLUMN onroerendezaak.eindegeldigheid IS 'BRMO: metadata tbv archivering, de toestandsdatum van het opvolgende bericht.';
+COMMENT ON COLUMN recht.begingeldigheid IS 'BRMO: metadata tbv archivering, de toestandsdatum van het bericht.';
+
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_3.0.2_naar_4.0.0','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';
 -- versienummer update

--- a/datamodel/upgrade_scripts/3.0.2-4.0.0/postgresql/brk.sql
+++ b/datamodel/upgrade_scripts/3.0.2-4.0.0/postgresql/brk.sql
@@ -38,6 +38,10 @@ FROM    (
           ) qry
   WHERE split_part( qry.identificatie, ':', 1) = 'NL.IMKAD.ZakelijkRecht';
 
+COMMENT ON COLUMN onroerendezaak.begingeldigheid IS 'BRMO: metadata tbv archivering, de toestandsdatum van het bericht.';
+COMMENT ON COLUMN onroerendezaak.eindegeldigheid IS 'BRMO: metadata tbv archivering, de toestandsdatum van het opvolgende bericht.';
+COMMENT ON COLUMN recht.begingeldigheid IS 'BRMO: metadata tbv archivering, de toestandsdatum van het bericht.';
+
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_3.0.2_naar_4.0.0','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';
 -- versienummer update


### PR DESCRIPTION
Maak duidelijk dat begingeldigheid/eindegeldigheid een toestandsdatum zijn en per definitie niet het begin/einde van de levenscyclus van een onroerende zaak of recht (al kan dat wel dezelfde datum zijn).