### PR TITLE
[BRMO-369] Verwijder ondersteuning voor PostgreSQL 12

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Release      | Datum        | Ondersteund/supported  | valid database versions (fully patched/mainstream support)                                      | runtime (fully patched)                 |
 |--------------|--------------|------------------------|-------------------------------------------------------------------------------------------------|-----------------------------------------|
-| 4.x-SNAPSHOT |              | ❌ (development)        | Current PostgreSQL 12 - 17 + PostGIS 3.4 - 3.5, Oracle 19c/21c/23ai + Spatial, 21 XE, 23ai Free | Java 17, Java 21, Tomcat 9, Docker 27   |
+| 4.x-SNAPSHOT |              | ❌ (development)        | Current PostgreSQL 1 - 17 + PostGIS 3.4 - 3.5, Oracle 19c/21c/23ai + Spatial, 21 XE, 23ai Free | Java 17, Java 21, Tomcat 9, Docker 27   |
 | 3.0.2        | 7-feb-2024   | ✔️                     | PostgreSQL 12 - 16 + PostGIS 3.4, Oracle 19c/21c + Spatial                                      | Java 11, Tomcat 9, Docker 25            |
 | 3.0.1        | 13-jul-2023  | :warning: (deprecated) | PostgreSQL 11 - 15 + PostGIS 3.3, Oracle 19c/21c + Spatial                                      | Java 11, Tomcat 9, Docker 24            |
 | 3.0.0        | 6-feb-2023   | ❌ (superceded)         | PostgreSQL 11 - 15 + PostGIS 3.3, Oracle 19c/21c + Spatial                                      | Java 11, Tomcat 9, Docker 23            |
@@ -23,7 +23,7 @@ van de kwetsbaarheid; gebruik https://github.com/B3Partners/brmo/security/adviso
 Wees verantwoordelijk in uw openbaarmaking en probeer te voorkomen dat het probleem wordt onthuld via Github-issues
 of commit-berichten.
 
-Uw e-mail moet binnen 1 werkdag (maandag-vrijdag) worden bevstigd door het ondersteuningsteam en/of een ontwikkelaar.
+Uw e-mail moet binnen 1 werkdag (maandag-vrijdag) worden bevestigd door het ondersteuningsteam en/of een ontwikkelaar.
 
 ## Reporting a Vulnerability
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,7 @@
 
 | Release      | Datum        | Ondersteund/supported  | valid database versions (fully patched/mainstream support)                                      | runtime (fully patched)                 |
 |--------------|--------------|------------------------|-------------------------------------------------------------------------------------------------|-----------------------------------------|
-| 4.x-SNAPSHOT |              | ❌ (development)        | Current PostgreSQL 1 - 17 + PostGIS 3.4 - 3.5, Oracle 19c/21c/23ai + Spatial, 21 XE, 23ai Free | Java 17, Java 21, Tomcat 9, Docker 27   |
+| 4.x-SNAPSHOT |              | ❌ (development)        | Current PostgreSQL 13 - 17 + PostGIS 3.4 - 3.5, Oracle 19c/21c/23ai + Spatial, 21 XE, 23ai Free | Java 17, Java 21, Tomcat 9, Docker 27   |
 | 3.0.2        | 7-feb-2024   | ✔️                     | PostgreSQL 12 - 16 + PostGIS 3.4, Oracle 19c/21c + Spatial                                      | Java 11, Tomcat 9, Docker 25            |
 | 3.0.1        | 13-jul-2023  | :warning: (deprecated) | PostgreSQL 11 - 15 + PostGIS 3.3, Oracle 19c/21c + Spatial                                      | Java 11, Tomcat 9, Docker 24            |
 | 3.0.0        | 6-feb-2023   | ❌ (superceded)         | PostgreSQL 11 - 15 + PostGIS 3.3, Oracle 19c/21c + Spatial                                      | Java 11, Tomcat 9, Docker 23            |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,7 +35,7 @@ jobs:
             # t/m november 2027
             - 15-3.4-alpine
             # t/m november 2028
-            - 16-3.4-alpine
+            - 16-3.5-alpine
             # t/m november 2029
             - 17-3.5-alpine
         include:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,11 +29,13 @@ jobs:
         java-dist: [ 'temurin' ]
         # docker image tags from https://hub.docker.com/r/postgis/postgis/tags?page=1&ordering=last_updated
         # zie ook https://www.postgresql.org/support/versioning/
-        postgis:
-          # t/m november 2024
-          - 12-3.4-alpine
-          - 15-3.4-alpine
-          - 16-3.4-alpine
+        postgis: 
+            # t/m november 2025
+            - 13-3.4-alpine
+            # t/m november 2027
+            - 15-3.4-alpine
+            # t/m november 2028
+            - 16-3.4-alpine
         include:
           - java: 21
             java-dist: 'temurin'

--- a/.github/workflows/upgrade-pgsql.yml
+++ b/.github/workflows/upgrade-pgsql.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        postgis: [ 12-3.4 ]
+        postgis: [ 13-3.4 ]
 
     services:
       postgres:


### PR DESCRIPTION
- [x] Merge medio november 2024 / voor versie 4.0.0

resolves BRMO-369