### PR TITLE
[BRMO-371] Upgrade GeoTools van 31.3 naar 32.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,8 @@
         <maven-fluido-skin.version>2.0.0-M10</maven-fluido-skin.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
-        <geotools.version>31.3</geotools.version>
-        <jdbc-util.version>17.3</jdbc-util.version>
+        <geotools.version>32-SNAPSHOT</geotools.version>
+        <jdbc-util.version>18.0-SNAPSHOT</jdbc-util.version>
         <jts.version>1.20.0</jts.version>
         <itextpdf.version>8.0.5</itextpdf.version>
         <postgresql.jdbc.version>42.7.4</postgresql.jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <hibernate.version>5.6.15.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
         <geotools.version>32.0</geotools.version>
-        <jdbc-util.version>18.0-SNAPSHOT</jdbc-util.version>
+        <jdbc-util.version>18.0</jdbc-util.version>
         <jts.version>1.20.0</jts.version>
         <itextpdf.version>8.0.5</itextpdf.version>
         <postgresql.jdbc.version>42.7.4</postgresql.jdbc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <maven-fluido-skin.version>2.0.0-M10</maven-fluido-skin.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
-        <geotools.version>32-SNAPSHOT</geotools.version>
+        <geotools.version>32.0</geotools.version>
         <jdbc-util.version>18.0-SNAPSHOT</jdbc-util.version>
         <jts.version>1.20.0</jts.version>
         <itextpdf.version>8.0.5</itextpdf.version>


### PR DESCRIPTION
- [x] Bump GeoTools van 31.3 naar 32-SNAPSHOT 
- [x] Bump jdbc-util van 17.3 naar 18-SNAPSHOT
- [x] Bump GeoTools van 32-SNAPSHOT naar 32.0
- [x] Bump jdbc-util van 18-SNAPSHOT naar 18.0

depends: https://github.com/B3Partners/jdbc-util/pull/649
zie: https://github.com/geoserver/geoserver/wiki/Release-Schedule#volunteer-coordination
