### PR TITLE
Revert "build(deps): bump org.apache.maven.plugins:maven-scm-publish-plugin from 3.2.1 to 3.3.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1098,7 +1098,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-scm-publish-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>io.fabric8</groupId>


### PR DESCRIPTION
Reverts B3Partners/brmo#2158

see https://github.com/B3Partners/jdbc-util/pull/630