### PR TITLE
Update schemaspy-maven-plugin van 5.2.1 naar 5.3.0

### DIFF
--- a/datamodel/pom.xml
+++ b/datamodel/pom.xml
@@ -121,7 +121,6 @@
                         <file>${project.basedir}/src/test/resources/pgsql.properties</file>
                         <file>${project.basedir}/src/test/resources/local.pgsql.properties</file>
                     </files>
-                    <quiet>true</quiet>
                 </configuration>
                 <executions>
                     <execution>
@@ -297,6 +296,7 @@
                     <allowHtmlInComments>false</allowHtmlInComments>
                     <schemaDescription>SchemaSpy rapport BRMO schemas v${project.version}</schemaDescription>
                     <highQuality>true</highQuality>
+                    <vizjs>false</vizjs>
                 </configuration>
             </plugin>
         </plugins>

--- a/datamodel/src/test/resources/pgsql.properties
+++ b/datamodel/src/test/resources/pgsql.properties
@@ -1,4 +1,4 @@
-rsgb.dbtype=pgsql
+rsgb.dbtype=pgsql11
 rsgb.host=127.0.0.1
 rsgb.port=5432
 rsgb.username=rsgb

--- a/pom.xml
+++ b/pom.xml
@@ -1093,7 +1093,7 @@
                 <plugin>
                     <groupId>nl.geodienstencentrum.maven</groupId>
                     <artifactId>schemaspy-maven-plugin</artifactId>
-                    <version>5.3.0-RC2</version>
+                    <version>5.3.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-scm-publish-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1093,7 +1093,7 @@
                 <plugin>
                     <groupId>nl.geodienstencentrum.maven</groupId>
                     <artifactId>schemaspy-maven-plugin</artifactId>
-                    <version>5.3.0-RC1</version>
+                    <version>5.3.0-RC2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-scm-publish-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -987,11 +987,10 @@
                     <configuration>
                         <notimestamp>true</notimestamp>
                         <quiet>true</quiet>
-                        <stylesheet>java</stylesheet>
                         <show>package</show>
                         <useStandardDocletOptions>true</useStandardDocletOptions>
                         <links>
-                            <link>https://docs.oracle.com/en/java/javase/11/docs/api/</link>
+                            <link>https://docs.oracle.com/en/java/javase/17/docs/api/</link>
                             <link>https://www.slf4j.org/apidocs/</link>
                             <link>https://docs.oracle.com/javaee/7/api/</link>
                             <link>https://docs.jboss.org/hibernate/orm/5.6/javadocs/</link>
@@ -1094,7 +1093,7 @@
                 <plugin>
                     <groupId>nl.geodienstencentrum.maven</groupId>
                     <artifactId>schemaspy-maven-plugin</artifactId>
-                    <version>5.2.1</version>
+                    <version>5.3.0-RC1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-scm-publish-plugin</artifactId>


### PR DESCRIPTION
- [x] Update`nl.geodienstencentrum.maven:schemaspy-maven-plugin` van 5.2.1 naar 5.3.0-RC1 en test
- [x] Update`nl.geodienstencentrum.maven:schemaspy-maven-plugin` van 5.3.0-RC1 naar 5.3.0-RC2 en test
- [x] Update`nl.geodienstencentrum.maven:schemaspy-maven-plugin` van 5.3.0-RC2 naar 5.3.0