### PR TITLE
[BRMO-377] Upgrade PostGIS van 16-3.4 naar 17-3.5 [ ** BREAKING ** ]

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,15 +2,15 @@
 
 ## Ondersteund / Supported
 
-| Release      | Datum        | Ondersteund/supported  | valid database versions (fully patched/mainstream support)    | runtime (fully patched)                 |
-|--------------|--------------|------------------------|---------------------------------------------------------------|-----------------------------------------|
-| 4.x-SNAPSHOT |              | ❌ (development)        | Current PostgreSQL + PostGIS, Oracle 19c/21c/23ai + Spatial, 21 XE, 23ai Free | Java 17, Java 21, Tomcat 9, Docker 27   |
-| 3.0.2        | 7-feb-2024   | ✔️                     | PostgreSQL 12 - 16 + PostGIS 3.4, Oracle 19c/21c + Spatial    | Java 11, Tomcat 9, Docker 25            |
-| 3.0.1        | 13-jul-2023  | :warning: (deprecated) | PostgreSQL 11 - 15 + PostGIS 3.3, Oracle 19c/21c + Spatial    | Java 11, Tomcat 9, Docker 24            |
-| 3.0.0        | 6-feb-2023   | ❌ (superceded)         | PostgreSQL 11 - 15 + PostGIS 3.3, Oracle 19c/21c + Spatial    | Java 11, Tomcat 9, Docker 23            |
-| 3.0.0-rc1    | 13-jan-2023  | ❌ (superceded)         | PostgreSQL 11 - 15 + PostGIS 3.3, Oracle 19c/21c + Spatial    | Java 11, Tomcat 9, Docker 23            |
-| 2.3.3        | 29-nov-2022  | ❌                      | PostgreSQL 11 - 15 + PostGIS 3.3, Oracle 19c/21c + Spatial    | Java 11, Tomcat 8.5/9, Docker 20        |
-| =< 2.3.2     | 29-sept-2022 | ❌                      | PostgreSQL 10 - 14 + PostGIS 3.2, Oracle 19c/21c + Spatial    | Java 11, Tomcat 8.5                     |
+| Release      | Datum        | Ondersteund/supported  | valid database versions (fully patched/mainstream support)                                      | runtime (fully patched)                 |
+|--------------|--------------|------------------------|-------------------------------------------------------------------------------------------------|-----------------------------------------|
+| 4.x-SNAPSHOT |              | ❌ (development)        | Current PostgreSQL 12 - 17 + PostGIS 3.4 - 3.5, Oracle 19c/21c/23ai + Spatial, 21 XE, 23ai Free | Java 17, Java 21, Tomcat 9, Docker 27   |
+| 3.0.2        | 7-feb-2024   | ✔️                     | PostgreSQL 12 - 16 + PostGIS 3.4, Oracle 19c/21c + Spatial                                      | Java 11, Tomcat 9, Docker 25            |
+| 3.0.1        | 13-jul-2023  | :warning: (deprecated) | PostgreSQL 11 - 15 + PostGIS 3.3, Oracle 19c/21c + Spatial                                      | Java 11, Tomcat 9, Docker 24            |
+| 3.0.0        | 6-feb-2023   | ❌ (superceded)         | PostgreSQL 11 - 15 + PostGIS 3.3, Oracle 19c/21c + Spatial                                      | Java 11, Tomcat 9, Docker 23            |
+| 3.0.0-rc1    | 13-jan-2023  | ❌ (superceded)         | PostgreSQL 11 - 15 + PostGIS 3.3, Oracle 19c/21c + Spatial                                      | Java 11, Tomcat 9, Docker 23            |
+| 2.3.3        | 29-nov-2022  | ❌                      | PostgreSQL 11 - 15 + PostGIS 3.3, Oracle 19c/21c + Spatial                                      | Java 11, Tomcat 8.5/9, Docker 20        |
+| =< 2.3.2     | 29-sept-2022 | ❌                      | PostgreSQL 10 - 14 + PostGIS 3.2, Oracle 19c/21c + Spatial                                      | Java 11, Tomcat 8.5                     |
 
 _zie ook/see also: https://github.com/B3Partners/brmo/wiki/Systeemeisen_
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   build:
     name: "Java ${{ matrix.java }} / PostGIS ${{ matrix.postgis }}"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -201,7 +201,7 @@ jobs:
     name: 'Deploy docker images'
     if: ${{ github.repository == 'B3Partners/brmo' && github.ref == 'refs/heads/master' && github.event_name == 'push' }}
     needs: [ build, qacheck ]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest 
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,7 +32,7 @@ jobs:
         postgis:
           # t/m november 2024
           - 12-3.4-alpine
-          - 15-3.5-alpine
+          - 15-3.4-alpine
           - 16-3.5-alpine
           - 17-3.5-alpine
         include:
@@ -201,7 +201,7 @@ jobs:
     name: 'Deploy docker images'
     if: ${{ github.repository == 'B3Partners/brmo' && github.ref == 'refs/heads/master' && github.event_name == 'push' }}
     needs: [ build, qacheck ]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   build:
     name: "Java ${{ matrix.java }} / PostGIS ${{ matrix.postgis }}"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -32,12 +32,13 @@ jobs:
         postgis:
           # t/m november 2024
           - 12-3.4-alpine
-          - 15-3.4-alpine
-          - 16-3.4-alpine
+          - 15-3.5-alpine
+          - 16-3.5-alpine
+          - 17-3.5-alpine
         include:
           - java: 21
             java-dist: 'temurin'
-            postgis: 16-3.4-alpine
+            postgis: 17-3.5-alpine
 
     steps:
       - uses: actions/checkout@v4

--- a/docker/src/main/docker/pg_conf/Dockerfile
+++ b/docker/src/main/docker/pg_conf/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgis/postgis:16-3.4-alpine
+FROM postgis/postgis:17-3.5-alpine
 
 ARG TZ="Europe/Amsterdam"
 ARG BRMO_VERSION="snapshot"


### PR DESCRIPTION
Let op: er is een dump-restore cyclus nodig voor upgrade van de (docker) database van 16 naar 17. 
**Voor docker deployments zijn PG 16 en eerder nu deprecated.**

- [x] update "required" builds