### PR TITLE
[BRMO-383] voeg kolommen `tijdstipaanbieding_stuk` en `tijdstipaanbieding2` toe aan views 

### DIFF
--- a/datamodel/extra_scripts/oracle/210_bag2_brk2.0_mat_views.sql
+++ b/datamodel/extra_scripts/oracle/210_bag2_brk2.0_mat_views.sql
@@ -208,9 +208,16 @@ SELECT CAST(ROWNUM AS INTEGER)            AS objectid,
        koz.postcode,
        koz.lon,
        koz.lat,
-       koz.begrenzing_perceel
+       koz.begrenzing_perceel,
+       st1.tijdstipaanbieding as tijdstipaanbieding_stuk,
+       st2.tijdstipaanbieding as tijdstipaanbieding_stuk2
 FROM BRMO_BRK.mb_zr_rechth zrr
-         RIGHT JOIN mb_kadastraleonroerendezakenmetadres koz ON (zrr.koz_identif = koz.identificatie);
+         RIGHT JOIN mb_kadastraleonroerendezakenmetadres koz ON (zrr.koz_identif = koz.identificatie)
+         JOIN BRMO_BRK.recht r on  zrr.zr_identif = r.van
+         LEFT JOIN BRMO_BRK.stukdeel sd1 ON sd1.identificatie = r.isgebaseerdop
+         LEFT JOIN BRMO_BRK.stukdeel sd2 ON sd2.identificatie = r.isgebaseerdop2
+         LEFT JOIN BRMO_BRK.stuk st1 ON sd1.deelvan = st1.identificatie
+         LEFT JOIN BRMO_BRK.stuk st2 ON sd2.deelvan = st2.identificatie;
 
 COMMENT ON MATERIALIZED VIEW mb_onroerendezakenmetrechthebbenden
     IS 'commentaar view mb_onroerendezakenmetrechthebbenden:
@@ -273,7 +280,9 @@ COMMENT ON MATERIALIZED VIEW mb_onroerendezakenmetrechthebbenden
     * postcode: -,
     * lon: coordinaat als WSG84,
     * lon: coordinaat als WSG84,
-    * begrenzing_perceel: perceelvlak';
+    * begrenzing_perceel: perceelvlak,
+    * tijdstipaanbieding_stuk: tijdstip van aanbieding van stuk,
+    * tijdstipaanbieding_stuk2: tijdstip van aanbieding van 2e stuk';
 
 delete
 from user_sdo_geom_metadata
@@ -346,9 +355,16 @@ SELECT CAST(ROWNUM AS INTEGER)            AS objectid,
        koz.postcode,
        koz.lon,
        koz.lat,
-       koz.begrenzing_perceel
+       koz.begrenzing_perceel,
+       st1.tijdstipaanbieding as tijdstipaanbieding_stuk,
+       st2.tijdstipaanbieding as tijdstipaanbieding_stuk2
 FROM BRMO_BRK.mb_avg_zr_rechth zrr
-         RIGHT JOIN mb_kadastraleonroerendezakenmetadres koz ON (zrr.koz_identif = koz.identificatie);
+         RIGHT JOIN mb_kadastraleonroerendezakenmetadres koz ON (zrr.koz_identif = koz.identificatie)
+         JOIN BRMO_BRK.recht r on  zrr.zr_identif = r.van
+         LEFT JOIN BRMO_BRK.stukdeel sd1 ON sd1.identificatie = r.isgebaseerdop
+         LEFT JOIN BRMO_BRK.stukdeel sd2 ON sd2.identificatie = r.isgebaseerdop2
+         LEFT JOIN BRMO_BRK.stuk st1 ON sd1.deelvan = st1.identificatie
+         LEFT JOIN BRMO_BRK.stuk st2 ON sd2.deelvan = st2.identificatie;
 
 COMMENT ON MATERIALIZED VIEW mb_avg_onroerendezakenmetrechthebbenden
     IS 'commentaar view mb_avg_onroerendezakenmetrechthebbenden:
@@ -411,7 +427,9 @@ COMMENT ON MATERIALIZED VIEW mb_avg_onroerendezakenmetrechthebbenden
     * postcode: -,
     * lon: coordinaat als WSG84,
     * lon: coordinaat als WSG84,
-    * begrenzing_perceel: perceelvlak';
+    * begrenzing_perceel: perceelvlak,
+    * tijdstipaanbieding_stuk: tijdstip van aanbieding van stuk,
+    * tijdstipaanbieding_stuk2: tijdstip van aanbieding van 2e stuk';
 
 delete
 from user_sdo_geom_metadata

--- a/datamodel/extra_scripts/postgresql/210_bag2_brk2.0_mat_views.sql
+++ b/datamodel/extra_scripts/postgresql/210_bag2_brk2.0_mat_views.sql
@@ -94,6 +94,8 @@ SELECT row_number() OVER ()                                                     
        st_x(st_transform(qry.plaatscoordinaten, 4326))                                                 AS lon,
        st_y(st_transform(qry.plaatscoordinaten, 4326))                                                 AS lat,
        qry.begrenzing_perceel
+--        ,st1.tijdstipaanbieding,
+--        st2.tijdstipaanbieding as tijdstipaanbieding2
 FROM (SELECT p.identificatie,
              'perceel' AS type,
              p.soortgrootte,
@@ -241,7 +243,9 @@ CREATE MATERIALIZED VIEW public.mb_onroerendezakenmetrechthebbenden
              postcode,
              lon,
              lat,
-             begrenzing_perceel
+             begrenzing_perceel,
+             tijdstipaanbieding_stuk,
+             tijdstipaanbieding_stuk2
                 )
 AS
 SELECT row_number() OVER ()             AS objectid,
@@ -301,9 +305,16 @@ SELECT row_number() OVER ()             AS objectid,
        koz.postcode,
        koz.lon,
        koz.lat,
-       koz.begrenzing_perceel
+       koz.begrenzing_perceel,
+       st1.tijdstipaanbieding as tijdstipaanbieding_stuk,
+       st2.tijdstipaanbieding as tijdstipaanbieding_stuk2
 FROM brk.mb_zr_rechth zrr
          RIGHT JOIN mb_kadastraleonroerendezakenmetadres koz ON zrr.koz_identif = koz.identificatie
+         JOIN brk.recht r on  zrr.zr_identif = r.van
+         LEFT JOIN brk.stukdeel sd1 ON sd1.identificatie = r.isgebaseerdop
+         LEFT JOIN brk.stukdeel sd2 ON sd2.identificatie = r.isgebaseerdop2
+         LEFT JOIN brk.stuk st1 ON sd1.deelvan = st1.identificatie
+         LEFT JOIN brk.stuk st2 ON sd2.deelvan = st2.identificatie
 WITH NO DATA;
 -- View indexes:
 CREATE INDEX mb_onroerendezakenmetrechthebbenden_begrenzing_perceel_idx ON public.mb_onroerendezakenmetrechthebbenden USING gist (begrenzing_perceel);
@@ -371,7 +382,9 @@ COMMENT ON MATERIALIZED VIEW public.mb_onroerendezakenmetrechthebbenden IS 'comm
     * postcode: -,
     * lon: coordinaat als WSG84,
     * lon: coordinaat als WSG84,
-    * begrenzing_perceel: perceelvlak';
+    * begrenzing_perceel: perceelvlak,
+    * tijdstipaanbieding_stuk: tijdstip van aanbieding van stuk,
+    * tijdstipaanbieding_stuk2: tijdstip van aanbieding van 2e stuk';
 
 
 -- materialized view zonder gegevens van natuurlijke personen
@@ -434,7 +447,9 @@ CREATE MATERIALIZED VIEW public.mb_avg_onroerendezakenmetrechthebbenden
              postcode,
              lon,
              lat,
-             begrenzing_perceel
+             begrenzing_perceel,
+             tijdstipaanbieding_stuk,
+             tijdstipaanbieding_stuk2
                 )
 AS
 SELECT row_number() OVER ()             AS objectid,
@@ -494,9 +509,16 @@ SELECT row_number() OVER ()             AS objectid,
        koz.postcode,
        koz.lon,
        koz.lat,
-       koz.begrenzing_perceel
+       koz.begrenzing_perceel,
+       st1.tijdstipaanbieding as tijdstipaanbieding_stuk,
+       st2.tijdstipaanbieding as tijdstipaanbieding_stuk2
 FROM brk.mb_avg_zr_rechth zrr
          RIGHT JOIN mb_kadastraleonroerendezakenmetadres koz ON zrr.koz_identif = koz.identificatie
+         JOIN brk.recht r on  zrr.zr_identif = r.van
+         LEFT JOIN brk.stukdeel sd1 ON sd1.identificatie = r.isgebaseerdop
+         LEFT JOIN brk.stukdeel sd2 ON sd2.identificatie = r.isgebaseerdop2
+         LEFT JOIN brk.stuk st1 ON sd1.deelvan = st1.identificatie
+         LEFT JOIN brk.stuk st2 ON sd2.deelvan = st2.identificatie
 WITH NO DATA;
 -- View indexes:
 CREATE INDEX mb_avg_onroerendezakenmetrechthebbenden_begrenzing_perceel_idx ON public.mb_avg_onroerendezakenmetrechthebbenden USING gist (begrenzing_perceel);
@@ -564,4 +586,6 @@ COMMENT ON MATERIALIZED VIEW public.mb_avg_onroerendezakenmetrechthebbenden IS '
     * postcode: -,
     * lon: coordinaat als WSG84,
     * lon: coordinaat als WSG84,
-    * begrenzing_perceel: perceelvlak';
+    * begrenzing_perceel: perceelvlak,
+    * tijdstipaanbieding_stuk: tijdstip van aanbieding van stuk,
+    * tijdstipaanbieding_stuk2: tijdstip van aanbieding van 2e stuk';

--- a/datamodel/upgrade_scripts/3.0.2-4.0.0/oracle/rsgb.sql
+++ b/datamodel/upgrade_scripts/3.0.2-4.0.0/oracle/rsgb.sql
@@ -10,10 +10,12 @@ INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('2
 INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('25', 'Huur afhankelijk opstal (recht van)');
 INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('26', 'Pachtafhankelijk opstal (recht van)');
 
---ihkv https://b3partners.atlassian.net/browse/BRMO-381 zouden onderstaande materialized views verwijderd kunnen worden. ivm potentiële afhankelijkheid wordt dit niet automatisch gedaan
--- drop materialized view mb_kad_onrrnd_zk_adres_bag;
--- drop materialized view mb_koz_rechth_bag;
--- drop materialized view mb_avg_koz_rechth_bag;
+-- Onderstaande materialized views kunnen verwijderd worden en worden niet langer ondersteund.
+-- ivm potentiële afhankelijkheid wordt dit niet automatisch gedaan
+-- zie https://b3partners.atlassian.net/browse/BRMO-381
+-- DROP MATERIALIZED VIEW mb_kad_onrrnd_zk_adres_bag;
+-- DROP MATERIALIZED VIEW mb_koz_rechth_bag;
+-- DROP MATERIALIZED VIEW mb_avg_koz_rechth_bag;
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_3.0.2_naar_4.0.0','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';

--- a/datamodel/upgrade_scripts/3.0.2-4.0.0/postgresql/rsgb.sql
+++ b/datamodel/upgrade_scripts/3.0.2-4.0.0/postgresql/rsgb.sql
@@ -10,10 +10,16 @@ INSERT INTO aard_verkregen_recht (aand, omschr_aard_verkregenr_recht) VALUES ('2
 INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('25', 'Huur afhankelijk opstal (recht van)');
 INSERT INTO aard_recht_verkort (aand, omschr) VALUES ('26', 'Pachtafhankelijk opstal (recht van)');
 
---ihkv https://b3partners.atlassian.net/browse/BRMO-381 zouden onderstaande materialized views verwijderd kunnen worden. ivm potentiële afhankelijkheid wordt dit niet automatisch gedaan
--- drop materialized view mb_kad_onrrnd_zk_adres_bag;
--- drop materialized view mb_koz_rechth_bag;
--- drop materialized view mb_avg_koz_rechth_bag;
+-- Onderstaande materialized views kunnen verwijderd worden en worden niet langer ondersteund.
+-- ivm potentiële afhankelijkheid wordt dit niet automatisch gedaan
+-- zie https://b3partners.atlassian.net/browse/BRMO-381
+-- DROP MATERIALIZED VIEW mb_kad_onrrnd_zk_adres_bag;
+-- DROP MATERIALIZED VIEW mb_koz_rechth_bag;
+-- DROP MATERIALIZED VIEW mb_avg_koz_rechth_bag;
+
+-- https://b3partners.atlassian.net/browse/BRMO-383
+DROP MATERIALIZED VIEW IF EXISTS mb_onroerendezakenmetrechthebbenden;
+DROP MATERIALIZED VIEW IF EXISTS mb_avg_onroerendezakenmetrechthebbenden;
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_3.0.2_naar_4.0.0','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';


### PR DESCRIPTION
Voegt de kolommen `tijdstipaanbieding_stuk` en `tijdstipaanbieding_stuk2` toe aan views:

- [x] mb_onroerendezakenmetrechthebbenden
- [x] mb_avg_onroerendezakenmetrechthebbenden
- [x] upgrade procedures Postgis / Oracle (zie hieronder )

resolve BRMO-383

## uitleg
Er zijn 2 kolommen voor tijdstip aanbieding aangezien er meerdere gebaseerd op relaties kunnen zijn.

Meerdere ‘is gebaseerd op’ bij een zakelijk recht is een valide situatie. 
Dit komt voor als het zakelijk recht eerst ontstaat onder opschortende voorwaarden (ontstaat dan nog niet in de BRK) en er later een stuk komt waarin deze opschortende voorwaarden in vervulling gaan. 
Bij het 2e stuk ontstaat dan het zakelijk recht in de BRK, maar beide stukken worden dan als ‘is gebaseerd op’ geregistreerd.
Daarnaast lijken er gevallen te zijn met meerdere gebaseerd op stukdelen die te maken hebben met fouten uit de conversie van AKR naar Koers en/of met verkeerd herstel. Dit zal worden gecorrigeerd

Onder andere in de volgende gevallen kan een tenaamstelling gebaseerd zijn op meerdere stukdelen:
* In sommige stukdelen worden de ‘gebaseerd op’ relaties meegenomen van de oude tenaamstellingen naar de nieuwe tenaamstellingen, omdat de oude titels nog relevant zijn. Bv. Verklaring van erfrecht.
* Bij vermengen van tenaamstellingen kunnen meerdere ‘gebaseerd op’ relaties ontstaan. Bv. 1/2 verkregen obv stuk1 en 1/2 verkregen obv stuk2
* Bij verenigen van percelen kunnen meerdere ‘gebaseerd op’ relaties ontstaan. Bv. perceel1 verkregen obv stuk1 en perceel2 verkregen obv stuk2
* Bij beëindigen van een beperkt recht krijgen de tenaamstellingen van het onderliggend recht het te verwerken stuk als extra ‘is gebaseerd op’, omdat dit ook een vorm van verkrijging is. Bv. Afstand beperkt recht.

Voor een exact antwoord is contact met het Kadaster nodig. 

## upgrade procedure

Er is geen scripted upgrade procedure voor de aanpassingen in de materialized views `mb_onroerendezakenmetrechthebbenden` en `mb_avg_onroerendezakenmetrechthebbenden` [BRMO-383](https://b3partners.atlassian.net/browse/BRMO-383).
Deze "extra" views zijn afhankelijk van "extra" views in het BAG schema dat mogelijk nog niet is aangemaakt en zijn mogelijk helemaal niet aanwezing het RSGB schema. Hieronder de stappen vermeld voor de upgrade indien alle "extra" (oa. uit `209_bag2_rsgb_views.sql`) views zijn aangemaakt:

Drop de betreffende materialized views uit het RSGB schema met onderstaande statements

```sql
DROP MATERIALIZED VIEW mb_onroerendezakenmetrechthebbenden;
DROP MATERIALIZED VIEW mb_avg_onroerendezakenmetrechthebbenden;
```

Maak daarna de materialized views en commentaar opnieuw aan met de database specifieke code uit `db/rsgb/oracle/210_bag2_brk2.0_mat_views.sql#187-591` dan wel `db/rsgb/postgresql/210_bag2_brk2.0_mat_views.sql#152-444` (let op er zijn meerdere views in het bestand gedefinieerd).


[BRMO-383]: https://b3partners.atlassian.net/browse/BRMO-383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ