### PR TITLE
[BRMO-384] Fix Resolving XML external entity in user-controlled data

### DIFF
--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/BRPXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/BRPXMLReader.java
@@ -73,6 +73,9 @@ public class BRPXMLReader extends BrmoXMLReader {
     soort = BrmoFramework.BR_BRP;
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     factory.setNamespaceAware(true);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
     DocumentBuilder builder = factory.newDocumentBuilder();
     Document doc = builder.parse(in);
 

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/Brk2SnapshotXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/Brk2SnapshotXMLReader.java
@@ -31,7 +31,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class Brk2SnapshotXMLReader extends BrmoXMLReader {
   private static final Log log = LogFactory.getLog(Brk2SnapshotXMLReader.class);
-  private final XMLInputFactory factory = XMLInputFactory.newInstance();
+  private final XMLInputFactory factory;
   private final XMLStreamReader streamReader;
   private final Transformer transformer;
   private static final String KAD_OBJ_SNAP = "KadastraalObjectSnapshot";
@@ -59,6 +59,9 @@ public class Brk2SnapshotXMLReader extends BrmoXMLReader {
   public Brk2SnapshotXMLReader(InputStream in)
       throws XMLStreamException, TransformerConfigurationException {
 
+    factory = XMLInputFactory.newInstance();
+    factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+    factory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
     streamReader = factory.createXMLStreamReader(in);
     TransformerFactory tf = TransformerFactory.newInstance();
     transformer = tf.newTransformer();

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/BrkSnapshotXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/BrkSnapshotXMLReader.java
@@ -27,7 +27,7 @@ public class BrkSnapshotXMLReader extends BrmoXMLReader {
 
   private static final Log log = LogFactory.getLog(BrkSnapshotXMLReader.class);
 
-  private final XMLInputFactory factory = XMLInputFactory.newInstance();
+  private final XMLInputFactory factory;
   private final XMLStreamReader streamReader;
   private final Transformer transformer;
 
@@ -56,6 +56,9 @@ public class BrkSnapshotXMLReader extends BrmoXMLReader {
   public BrkSnapshotXMLReader(InputStream in)
       throws XMLStreamException, TransformerConfigurationException {
 
+    factory = XMLInputFactory.newInstance();
+    factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+    factory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
     streamReader = factory.createXMLStreamReader(in);
     TransformerFactory tf = TransformerFactory.newInstance();
     transformer = tf.newTransformer();

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/GbavXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/GbavXMLReader.java
@@ -43,7 +43,7 @@ public class GbavXMLReader extends BrmoXMLReader {
   private static final Log log = LogFactory.getLog(GbavXMLReader.class);
   private static final String PERSOON = "persoon";
   public static final String PREFIX = "NL.BRP.Persoon.";
-  private final XMLInputFactory factory = XMLInputFactory.newInstance();
+  private final XMLInputFactory factory;
   private final XMLStreamReader streamReader;
   private final Transformer transformer;
   private final XMLOutputFactory xmlof;
@@ -52,6 +52,9 @@ public class GbavXMLReader extends BrmoXMLReader {
 
   public GbavXMLReader(InputStream in)
       throws XMLStreamException, TransformerConfigurationException {
+    factory = XMLInputFactory.newInstance();
+    factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+    factory.setProperty("javax.xml.stream.isSupportingExternalEntities", false);
     streamReader = factory.createXMLStreamReader(in);
     TransformerFactory tf = TransformerFactory.newInstance();
     transformer = tf.newTransformer();

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
@@ -1,4 +1,5 @@
 package nl.b3p.brmo.loader.xml;
+import javax.xml.XMLConstants;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -58,9 +59,20 @@ public class NhrXMLReader extends BrmoXMLReader {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     in = new TeeInputStream(in, bos, true);
 
+    // Configure DocumentBuilderFactory to prevent XXE
+    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
+    // Configure TransformerFactory to prevent XXE
+    TransformerFactory tf = TransformerFactory.newInstance();
+    tf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
     // Split input naar multiple berichten
     DOMResult r = new DOMResult();
-    splitTemplates.newTransformer().transform(new StreamSource(in), r);
+    tf.newTransformer().transform(new StreamSource(in), r);
 
     JAXBContext jc = JAXBContext.newInstance(NhrBerichten.class, NhrBericht.class, Bericht.class);
     Unmarshaller unmarshaller = jc.createUnmarshaller();

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
@@ -1,11 +1,11 @@
 package nl.b3p.brmo.loader.xml;
-import javax.xml.XMLConstants;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.parsers.DocumentBuilder;
@@ -59,20 +59,13 @@ public class NhrXMLReader extends BrmoXMLReader {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     in = new TeeInputStream(in, bos, true);
 
-    // Configure DocumentBuilderFactory to prevent XXE
-    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-    dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-    dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-    dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-    dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-
-    // Configure TransformerFactory to prevent XXE
-    TransformerFactory tf = TransformerFactory.newInstance();
-    tf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-
     // Split input naar multiple berichten
     DOMResult r = new DOMResult();
-    tf.newTransformer().transform(new StreamSource(in), r);
+    Transformer transformer=splitTemplates.newTransformer();
+    StreamSource source = new StreamSource(in);
+    // Prevent external entity resolution
+    source.setSystemId("");
+    transformer.transform(source, r);
 
     JAXBContext jc = JAXBContext.newInstance(NhrBerichten.class, NhrBericht.class, Bericht.class);
     Unmarshaller unmarshaller = jc.createUnmarshaller();

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/WozXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/WozXMLReader.java
@@ -71,6 +71,9 @@ public class WozXMLReader extends BrmoXMLReader {
 
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     factory.setNamespaceAware(true);
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
     DocumentBuilder builder = factory.newDocumentBuilder();
     Document doc = builder.parse(in);
 


### PR DESCRIPTION
Fixes:
- https://github.com/B3Partners/brmo/security/code-scanning/1431
- https://github.com/B3Partners/brmo/security/code-scanning/1430
- https://github.com/B3Partners/brmo/security/code-scanning/1429
- https://github.com/B3Partners/brmo/security/code-scanning/1428
- https://github.com/B3Partners/brmo/security/code-scanning/1426
- https://github.com/B3Partners/brmo/security/code-scanning/1425

To fix the problem, we need to configure the `DocumentBuilderFactory` to disable the parsing of external entities and DTDs. This can be done by setting specific features on the `DocumentBuilderFactory` instance. The changes should be made in the `WozXMLReader` class where the `DocumentBuilderFactory` is instantiated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
