### PR TITLE
[BRMO-391] Maak het mogelijk om database naam te specificeren voor de brmo-service docker container

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -61,7 +61,7 @@ Gebruik de procedure op https://github.com/B3Partners/brmo/wiki/update-wachtwoor
 /usr/local/tomcat/bin/digest.sh -a PBKDF2WithHmacSHA512 -i 100000 -s 16 -k 256 -h "org.apache.catalina.realm.SecretKeyCredentialHandler" <STERK WACHTWOORD>
 ```
 
-Update in de database container
+Update het wachtwoord in de database container
 
 ```shell
 # login staging db

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -50,6 +50,10 @@ services:
       DB_PASS_STAGING: ${DB_PASS_STAGING:-staging}
       DB_PASS_RSGBBGT: ${DB_PASS_RSGBBGT:-rsgbbgt}
       DB_PASS_TOPNL: ${DB_PASS_TOPNL:-topnl}
+      DB_NAME_RSGB: ${DB_NAME_RSGB:-rsgb}
+      DB_NAME_STAGING: ${DB_NAME_STAGING:-staging}
+      DB_NAME_RSGBBGT: ${DB_NAME_RSGBBGT:-rsgbbgt}
+      DB_NAME_TOPNL: ${DB_NAME_TOPNL:-topnl}
       CATALINA_OPTS: -DMAIL_FROM=${MAIL_FROM:-brmo-no-reply@b3partners.nl}
         -DMAIL_HOST=${MAIL_HOST:-mail.b3partners.nl}
         -DPG_PORT=${PG_PORT:-5432}
@@ -67,6 +71,10 @@ services:
         -DHR_IMAP_USER=${HR_IMAP_USER:-changeme}
         -DHR_IMAP_PASS=${HR_IMAP_PASS:-changeme}
         -DHR_IMAP_HOST=${HR_IMAP_HOST:-mail.b3partners.nl}
+        -DDB_NAME_RSGB=${DB_NAME_RSGB}
+        -DDB_NAME_STAGING=${DB_NAME_STAGING}
+        -DDB_NAME_RSGBBGT=${DB_NAME_RSGBBGT}
+        -DDB_NAME_TOPNL=${DB_NAME_TOPNL}
     depends_on:
       - db
     restart: unless-stopped

--- a/docker/localhost.env
+++ b/docker/localhost.env
@@ -13,3 +13,10 @@ DB_PASS_RSGBBGT=rsgbbgt
 DB_PASS_TOPNL=topnl
 HR_ACTIVE=false
 HR_IMAP_RESOURCE=dummy
+# NB als onderstaande waarden worden aangepast,
+# dan zal de brmo-service niet langer met de scripted/automatisch aangemaakt database schema's werken
+# dit is dus alleen voor situaties waar de brmo-service stand-alone wordt gebruikt met een externe database
+DB_NAME_RSGB:rsgb
+DB_NAME_STAGING: staging
+DB_NAME_RSGBBGT: rsgbbgt
+DB_NAME_TOPNL: topnl

--- a/docker/src/main/docker/tomcat_conf/server.xml
+++ b/docker/src/main/docker/tomcat_conf/server.xml
@@ -9,37 +9,37 @@
         <Resource auth="Container" driverClassName="org.postgresql.Driver" maxTotal="40" initialSize="2"
                   minEvictableIdleTimeMillis="5000" name="jdbc/brmo/staging" password="${DB_PASS_STAGING}"
                   timeBetweenEvictionRunsMillis="30000" type="javax.sql.DataSource"
-                  url="jdbc:postgresql://${PG_HOST}:${PG_PORT}/staging?sslmode=allow&amp;ApplicationName=brmo-service"
+                  url="jdbc:postgresql://${PG_HOST}:${PG_PORT}/${DB_NAME_STAGING}?sslmode=allow&amp;ApplicationName=brmo-service"
                   username="staging"
                   validationQuery="select 1"/>
         <Resource auth="Container" driverClassName="org.postgresql.Driver" maxTotal="40" initialSize="0"
                   minEvictableIdleTimeMillis="5000" name="jdbc/brmo/rsgb" password="${DB_PASS_RSGB}"
                   timeBetweenEvictionRunsMillis="30000" type="javax.sql.DataSource"
-                  url="jdbc:postgresql://${PG_HOST}:${PG_PORT}/rsgb?sslmode=allow&amp;ApplicationName=brmo-service"
+                  url="jdbc:postgresql://${PG_HOST}:${PG_PORT}/${DB_NAME_RSGB}?sslmode=allow&amp;ApplicationName=brmo-service"
                   username="rsgb"
                   validationQuery="select 1"/>
         <Resource auth="Container" driverClassName="org.postgresql.Driver" maxTotal="40" initialSize="0"
                   minEvictableIdleTimeMillis="5000" name="jdbc/brmo/rsgbbrk" password="${DB_PASS_RSGB}"
                   timeBetweenEvictionRunsMillis="30000" type="javax.sql.DataSource"
-                  url="jdbc:postgresql://${PG_HOST}:${PG_PORT}/rsgb?currentSchema=brk&amp;sslmode=allow&amp;ApplicationName=brmo-service"
+                  url="jdbc:postgresql://${PG_HOST}:${PG_PORT}/${DB_NAME_RSGB}?currentSchema=brk&amp;sslmode=allow&amp;ApplicationName=brmo-service"
                   username="rsgb"
                   validationQuery="select 1"/>
         <Resource auth="Container" driverClassName="org.postgresql.Driver" maxTotal="40" initialSize="0"
                   minEvictableIdleTimeMillis="5000" name="jdbc/brmo/rsgbbag" password="${DB_PASS_RSGB}"
                   timeBetweenEvictionRunsMillis="30000" type="javax.sql.DataSource"
-                  url="jdbc:postgresql://${PG_HOST}:${PG_PORT}/rsgb?sslmode=allow&amp;reWriteBatchedInserts=true&amp;ApplicationName=brmo-service"
+                  url="jdbc:postgresql://${PG_HOST}:${PG_PORT}/${DB_NAME_RSGB}?sslmode=allow&amp;reWriteBatchedInserts=true&amp;ApplicationName=brmo-service"
                   username="rsgb"
                   validationQuery="select 1"/>
         <Resource auth="Container" driverClassName="org.postgresql.Driver" maxTotal="40" initialSize="0"
                   minEvictableIdleTimeMillis="5000" name="jdbc/brmo/rsgbbgt" password="${DB_PASS_RSGBBGT}"
                   timeBetweenEvictionRunsMillis="30000" type="javax.sql.DataSource"
-                  url="jdbc:postgresql://${PG_HOST}:${PG_PORT}/rsgbbgt?sslmode=allow&amp;reWriteBatchedInserts=true&amp;ApplicationName=brmo-service"
+                  url="jdbc:postgresql://${PG_HOST}:${PG_PORT}/${DB_NAME_RSGBBGT}?sslmode=allow&amp;reWriteBatchedInserts=true&amp;ApplicationName=brmo-service"
                   username="rsgbbgt"
                   validationQuery="select 1"/>
         <Resource auth="Container" driverClassName="org.postgresql.Driver" maxTotal="40" initialSize="0"
                   minEvictableIdleTimeMillis="5000" name="jdbc/brmo/rsgbtopnl" password="${DB_PASS_TOPNL}"
                   timeBetweenEvictionRunsMillis="30000" type="javax.sql.DataSource"
-                  url="jdbc:postgresql://${PG_HOST}:${PG_PORT}/topnl?sslmode=allow&amp;reWriteBatchedInserts=true&amp;ApplicationName=brmo-service"
+                  url="jdbc:postgresql://${PG_HOST}:${PG_PORT}/${DB_NAME_TOPNL}?sslmode=allow&amp;reWriteBatchedInserts=true&amp;ApplicationName=brmo-service"
                   username="topnl"
                   validationQuery="select 1"/>
         <Environment type="java.lang.Boolean" name="brmo/nhr/active" value="${HR_ACTIVE}"/>


### PR DESCRIPTION
Voor deployments waar alleen de brmo-service als docker container draait, bijv. na upgrade van een bestaande omgeving met andere namen voor de databases dan ingebouwd, is het handig als daar ondersteuning in de docker image voor is.

**NB** _als ook de brmo-service-db wordt gebruikt zal dit niet werken, de database schema's zijn daar ingebouwd_