### PR TITLE
fixes for code scanning alerts no. 1637, 1638: Log Injection

### DIFF
--- a/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/BasisregistratieServiceActionBean.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/BasisregistratieServiceActionBean.java
@@ -93,7 +93,8 @@ public class BasisregistratieServiceActionBean implements ActionBean {
         ZipInputStream zip = new ZipInputStream(in);
         ZipEntry entry = zip.getNextEntry();
         while (entry != null && !entry.getName().toLowerCase().endsWith(".xml")) {
-          log.warn("Overslaan zip entry geen XML: " + entry.getName());
+          String sanitizedEntryName = entry.getName().replace("\n", "").replace("\r", "");
+          log.warn("Overslaan zip entry geen XML: " + sanitizedEntryName);
           entry = zip.getNextEntry();
         }
         if (entry == null) {

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/BasisregistratieServiceActionBean.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/BasisregistratieServiceActionBean.java
@@ -92,15 +92,16 @@ public class BasisregistratieServiceActionBean implements ActionBean {
         // uniek)
         ZipInputStream zip = new ZipInputStream(in);
         ZipEntry entry = zip.getNextEntry();
+        String sanitizedEntryName;
         while (entry != null && !entry.getName().toLowerCase().endsWith(".xml")) {
-          String sanitizedEntryName = entry.getName().replace("\n", "").replace("\r", "");
+          sanitizedEntryName = entry.getName().replace('\n', ' ').replace('\r', ' ');
           log.warn("Overslaan zip entry geen XML: " + sanitizedEntryName);
           entry = zip.getNextEntry();
         }
         if (entry == null) {
           throw new BrmoException("Geen geschikt XML bestand gevonden in zip bestand ");
         }
-        String sanitizedEntryName = entry.getName().replace('\n', ' ').replace('\r', ' ');
+        sanitizedEntryName = entry.getName().replace('\n', ' ').replace('\r', ' ');
         log.debug("Lezen XML bestand uit zip: " + sanitizedEntryName);
         unzippedFile = entry.getName();
         brmo.loadFromStream(basisregistratie, zip, getUniqueFilename(brmo), (Long) null);

--- a/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/BasisregistratieServiceActionBean.java
+++ b/brmo-service/src/main/java/nl/b3p/brmo/service/stripes/BasisregistratieServiceActionBean.java
@@ -99,7 +99,8 @@ public class BasisregistratieServiceActionBean implements ActionBean {
         if (entry == null) {
           throw new BrmoException("Geen geschikt XML bestand gevonden in zip bestand ");
         }
-        log.debug("Lezen XML bestand uit zip: " + entry.getName());
+        String sanitizedEntryName = entry.getName().replace('\n', ' ').replace('\r', ' ');
+        log.debug("Lezen XML bestand uit zip: " + sanitizedEntryName);
         unzippedFile = entry.getName();
         brmo.loadFromStream(basisregistratie, zip, getUniqueFilename(brmo), (Long) null);
 


### PR DESCRIPTION
Potential fix for [https://github.com/B3Partners/brmo/security/code-scanning/1638](https://github.com/B3Partners/brmo/security/code-scanning/1638)

To fix the log injection issue, we need to sanitize the user-provided input before logging it. Specifically, we should remove any newline characters from the ZIP entry name to prevent log forgery. Additionally, we can use a more secure logging method that clearly marks user input.

The best way to fix this problem is to replace newline characters in the ZIP entry name with a safe character (e.g., a space) before logging it. This can be done using the `String.replace` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
