### PR TITLE
[BRMO-393] Verwijder foreign key van appartementsrecht_archief.hoofdsplitsing naar recht.identificatie

### DIFF
--- a/datamodel/brk/brk2.0_oracle.sql
+++ b/datamodel/brk/brk2.0_oracle.sql
@@ -384,7 +384,8 @@ CREATE TABLE appartementsrecht_archief
 (
     identificatie   VARCHAR2(255) NOT NULL,
     begingeldigheid DATE          NOT NULL,
-    hoofdsplitsing  VARCHAR2(255) NOT NULL REFERENCES recht (identificatie),
+    -- REFERENCES recht (identificatie)
+    hoofdsplitsing  VARCHAR2(255) NOT NULL,
     PRIMARY KEY (identificatie, begingeldigheid)
 );
 

--- a/datamodel/upgrade_scripts/5.0.1-5.0.2/oracle/brk.sql
+++ b/datamodel/upgrade_scripts/5.0.1-5.0.2/oracle/brk.sql
@@ -16,6 +16,23 @@ END;
 /
 MERGE INTO brmo_metadata USING DUAL ON (naam = 'brmoversie') WHEN NOT MATCHED THEN INSERT (naam) VALUES('brmoversie');
 
+DECLARE
+    v_constraint_name VARCHAR2(255);
+BEGIN
+    SELECT c.constraint_name
+    INTO v_constraint_name
+    FROM all_cons_columns col
+             JOIN all_constraints c
+                  ON col.constraint_name = c.constraint_name
+    WHERE col.table_name = 'APPARTEMENTSRECHT_ARCHIEF'
+      AND col.column_name = 'HOOFDSPLITSING'
+      AND c.constraint_type = 'R';
+    EXECUTE IMMEDIATE 'ALTER TABLE APPARTEMENTSRECHT_ARCHIEF DROP CONSTRAINT ' || v_constraint_name;
+EXCEPTION
+    WHEN NO_DATA_FOUND THEN
+        DBMS_OUTPUT.PUT_LINE('Geen constraint gevonden voor appartementsrecht_archief.hoofdsplitsing');
+END;
+/
 
 -- onderstaande dienen als laatste stappen van een upgrade uitgevoerd
 INSERT INTO brmo_metadata (naam,waarde) SELECT 'upgrade_5.0.1_naar_5.0.2','vorige versie was ' || waarde FROM brmo_metadata WHERE naam='brmoversie';


### PR DESCRIPTION
Alleen van toepassing op Oracle BRK schema