### PR TITLE
[BRMO-397] Update GeoTools van 33.0 naar 33.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,8 @@
         <maven-fluido-skin.version>2.1.0</maven-fluido-skin.version>
         <hibernate.version>5.6.15.Final</hibernate.version>
         <!-- ook jdbc-util updaten bij geotools update -->
-        <geotools.version>33.0</geotools.version>
-        <jdbc-util.version>19.0</jdbc-util.version>
+        <geotools.version>33.1</geotools.version>
+        <jdbc-util.version>19.1</jdbc-util.version>
         <jts.version>1.20.0</jts.version>
         <itextpdf.version>9.1.0</itextpdf.version>
         <postgresql.jdbc.version>42.7.5</postgresql.jdbc.version>


### PR DESCRIPTION
en jdbc-util van 19.0 naar 19.1
vanwege security updates in GeoTools

afhankelijk van https://github.com/B3Partners/jdbc-util/pull/710