### PR TITLE
Dependency updates

### DIFF
--- a/docker/src/main/docker/Dockerfile
+++ b/docker/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9.0.105-jre17-temurin
+FROM tomcat:9.0.106-jre17-temurin
 
 ARG TZ="Europe/Amsterdam"
 ARG DEBIAN_FRONTEND="noninteractive"

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <jdbc-util.version>19.1</jdbc-util.version>
         <jts.version>1.20.0</jts.version>
         <itextpdf.version>9.2.0</itextpdf.version>
-        <postgresql.jdbc.version>42.7.5</postgresql.jdbc.version>
+        <postgresql.jdbc.version>42.7.6</postgresql.jdbc.version>
         <postgresql.postgis-jdbc.version>2024.1.0</postgresql.postgis-jdbc.version>
         <oracle.jdbc.version>23.8.0.25.04</oracle.jdbc.version>
         <oracle.jdbc.artifact>ojdbc11</oracle.jdbc.artifact>
@@ -782,6 +782,14 @@
         </dependency>
     </dependencies>
     <repositories>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <name>Maven Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
         <repository>
             <snapshots>
                 <enabled>true</enabled>

--- a/pom.xml
+++ b/pom.xml
@@ -754,7 +754,7 @@
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>mockwebserver3-junit5</artifactId>
-                <version>5.0.0-alpha.14</version>
+                <version>5.0.0-alpha.16</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <jackson.databind.version>2.19.0</jackson.databind.version>
         <javax-annotation.version>1.3.2</javax-annotation.version>
         <activation.api.version>1.2.2</activation.api.version>
-        <tomcat.version>9.0.105</tomcat.version>
+        <tomcat.version>9.0.106</tomcat.version>
         <tomcat.http.port>9091</tomcat.http.port>
         <tomcat.localDatasource>false</tomcat.localDatasource>
         <javaee-endorsed-api.version>7.0</javaee-endorsed-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <jts.version>1.20.0</jts.version>
         <itextpdf.version>9.2.0</itextpdf.version>
         <postgresql.jdbc.version>42.7.6</postgresql.jdbc.version>
-        <postgresql.postgis-jdbc.version>2024.1.0</postgresql.postgis-jdbc.version>
+        <postgresql.postgis-jdbc.version>2025.1.0</postgresql.postgis-jdbc.version>
         <oracle.jdbc.version>23.8.0.25.04</oracle.jdbc.version>
         <oracle.jdbc.artifact>ojdbc11</oracle.jdbc.artifact>
         <skip-windows />

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <test.persistence.unit>brmo.persistence.hsqldb</test.persistence.unit>
         <test.hsqldb.version>2.7.4</test.hsqldb.version>
         <test.onlyITs>false</test.onlyITs>
-        <test.junit-jupiter.version>5.12.2</test.junit-jupiter.version>
+        <test.junit-jupiter.version>5.13.1</test.junit-jupiter.version>
         <maven.surefire.version>3.5.3</maven.surefire.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
         <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
             <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
-                <version>1.5</version>
+                <version>1.6.0</version>
             </dependency>
             <dependency>
                 <groupId>org.locationtech.jts</groupId>


### PR DESCRIPTION
- Bump tomcat van 9.0.105 naar 9.0.106
- Bump postgresql.jdbc van 42.7.5 naar 42.7.6
- Bump postgis-jdbc van 2024.1.0 naar 2025.1.0
- Bump junit-jupiter van 5.12.2 naar 5.13.1
- Bump commons-fileupload:commons-fileupload from 1.5 to 1.6.0
- Bump com.squareup.okhttp3:mockwebserver3-junit5 van 5.0.0-alpha.14 naar 5.0.0-alpha.16