### PR TITLE
[BRMO-419] speciale tekens in attribuutwaarden van KVK/NHR bericht (@, +, ",?) niet ondersteund in staging proces

### DIFF
--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
@@ -190,7 +190,8 @@ public class NhrXMLReader extends BrmoXMLReader {
                   .replace(")", "")
                   // komt in bedrijfsnaam voor '& Co'
                   .replace("&", "")
-                  // komt in bedijfsnaam voor 'Radley + Co. Limited'
+                  // komt in bedijfsnaam voor 'Radley + Co. Limited' of 'Jan Wilhelm Arntz GmbH +
+                  // Co.KG'
                   .replace("+", "")
                   // komt in bedijfsnaam voor 'UAB "MANTINGA GROUP"'
                   .replace("\"", "");

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
@@ -189,7 +189,9 @@ public class NhrXMLReader extends BrmoXMLReader {
                   .replace("(", "")
                   .replace(")", "")
                   // komt in bedrijfsnaam voor '& Co'
-                  .replace("&", "");
+                  .replace("&", "")
+                  // komt in bedijfsnaam voor 'Radley + Co. Limited'
+                  .replace("+", "");
           bsnHashes.put(_cleanName, getHash(_cleanName));
         }
       }

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
@@ -194,7 +194,10 @@ public class NhrXMLReader extends BrmoXMLReader {
                   // Co.KG'
                   .replace("+", "")
                   // komt in bedijfsnaam voor 'UAB "MANTINGA GROUP"'
-                  .replace("\"", "");
+                  .replace("\"", "")
+                  //  U+0218 LATIN CAPITAL LETTER S WITH COMMA BELOW, bijv. in 'KESER Makina İmalat
+                  // Montaj Sanayi ve Ticaret Limited Șirketi'
+                  .replace("Ș", "S");
           ;
           bsnHashes.put(_cleanName, getHash(_cleanName));
         }

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
@@ -190,15 +190,17 @@ public class NhrXMLReader extends BrmoXMLReader {
                   .replace(")", "")
                   // komt in bedrijfsnaam voor '& Co'
                   .replace("&", "")
-                  // komt in bedijfsnaam voor 'Radley + Co. Limited' of 'Jan Wilhelm Arntz GmbH +
+                  // komt in bedrijfsnaam voor 'Radley + Co. Limited' of 'Jan Wilhelm Arntz GmbH +
                   // Co.KG'
                   .replace("+", "")
-                  // komt in bedijfsnaam voor 'UAB "MANTINGA GROUP"'
+                  // komt in bedrijfsnaam voor 'UAB "MANTINGA GROUP"'
                   .replace("\"", "")
                   //  U+0218 LATIN CAPITAL LETTER S WITH COMMA BELOW, bijv. in 'KESER Makina İmalat
                   // Montaj Sanayi ve Ticaret Limited Șirketi'
-                  .replace("Ș", "S");
-          ;
+                  .replace("Ș", "S")
+                  // komt voor in bedrijfsnaam 'OMG@Mathews Ltd'
+                  .replace("@", "")
+                  .replace("?", "");
           bsnHashes.put(_cleanName, getHash(_cleanName));
         }
       }

--- a/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
+++ b/brmo-loader/src/main/java/nl/b3p/brmo/loader/xml/NhrXMLReader.java
@@ -191,7 +191,10 @@ public class NhrXMLReader extends BrmoXMLReader {
                   // komt in bedrijfsnaam voor '& Co'
                   .replace("&", "")
                   // komt in bedijfsnaam voor 'Radley + Co. Limited'
-                  .replace("+", "");
+                  .replace("+", "")
+                  // komt in bedijfsnaam voor 'UAB "MANTINGA GROUP"'
+                  .replace("\"", "");
+          ;
           bsnHashes.put(_cleanName, getHash(_cleanName));
         }
       }

--- a/brmo-loader/src/main/resources/xsl/nhr-object-ref-3.0.xsl
+++ b/brmo-loader/src/main/resources/xsl/nhr-object-ref-3.0.xsl
@@ -83,6 +83,8 @@
                                       translate(
                                       translate(
                                       translate(
+                                      translate(
+                                      translate(
                                         cat:volledigeNaam,' ','')
                                                          ,$APOS,'')
                                                          ,'.','')
@@ -93,6 +95,8 @@
                                                          ,'&amp;', '')
                                                          ,'+','')
                                                          ,$QUOTE,'')
+                                                         ,'@','')
+                                                         ,'?','')
                                                          ,'Ș','S')"
                 />
                 <xsl:variable name="hashsoort" select="'naam.'"/>

--- a/brmo-loader/src/main/resources/xsl/nhr-object-ref-3.0.xsl
+++ b/brmo-loader/src/main/resources/xsl/nhr-object-ref-3.0.xsl
@@ -70,8 +70,10 @@
                 <!-- verwijder ongeldige chars zoals spatie, apostrof, haakjes, ampersand
                 zie ook: nl.b3p.brmo.loader.xml.NhrXMLReader#extractBSN() -->
                 <xsl:variable name="APOS">'</xsl:variable>
+                <xsl:variable name="QUOTE">"</xsl:variable>
                 <xsl:variable name="lookfor"
                               select="translate(
+                                      translate(
                                       translate(
                                       translate(
                                       translate(
@@ -88,7 +90,8 @@
                                                          ,'(','')
                                                          ,')','')
                                                          ,'&amp;', '')
-                                                         ,'+','')"
+                                                         ,'+','')
+                                                         ,$QUOTE,'')"
                 />
                 <xsl:variable name="hashsoort" select="'naam.'"/>
 

--- a/brmo-loader/src/main/resources/xsl/nhr-object-ref-3.0.xsl
+++ b/brmo-loader/src/main/resources/xsl/nhr-object-ref-3.0.xsl
@@ -79,6 +79,7 @@
                                       translate(
                                       translate(
                                       translate(
+                                      translate(
                                         cat:volledigeNaam,' ','')
                                                          ,$APOS,'')
                                                          ,'.','')
@@ -86,7 +87,8 @@
                                                          ,'/','')
                                                          ,'(','')
                                                          ,')','')
-                                                         ,'&amp;', '')"
+                                                         ,'&amp;', '')
+                                                         ,'+','')"
                 />
                 <xsl:variable name="hashsoort" select="'naam.'"/>
 

--- a/brmo-loader/src/main/resources/xsl/nhr-object-ref-3.0.xsl
+++ b/brmo-loader/src/main/resources/xsl/nhr-object-ref-3.0.xsl
@@ -82,6 +82,7 @@
                                       translate(
                                       translate(
                                       translate(
+                                      translate(
                                         cat:volledigeNaam,' ','')
                                                          ,$APOS,'')
                                                          ,'.','')
@@ -91,7 +92,8 @@
                                                          ,')','')
                                                          ,'&amp;', '')
                                                          ,'+','')
-                                                         ,$QUOTE,'')"
+                                                         ,$QUOTE,'')
+                                                         ,'Ș','S')"
                 />
                 <xsl:variable name="hashsoort" select="'naam.'"/>
 

--- a/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
@@ -356,8 +356,8 @@ public class NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
             // aantalFunctionarissen
             2),
         arguments(
-            "/nhr-v3/BRMO-419/origineel/289544.xml",
-            //                    "/nhr-v3/289544.anon.xml",
+            // heeft een buitenlandse persoon met Ș in de naam
+            "/nhr-v3/289544.anon.xml",
             // aantalBerichten
             3,
             // aantalProcessen
@@ -379,7 +379,31 @@ public class NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
             // sbiCodes,
             new String[] {"7112", "4120", "2511"},
             // aantalFunctionarissen
-            4)
+            4),
+        arguments(
+            "/nhr-v3/289547.anon.xml",
+            // aantalBerichten
+            3,
+            // aantalProcessen
+            1,
+            // aantalPrs
+            2,
+            // aantalSubj
+            3,
+            // aantalNiet_nat_prs
+            2,
+            // aantalNat_prs
+            0,
+            // hoofd vestgID
+            "nhr.comVestg.000062377655",
+            // aantalVestg_activiteit
+            1,
+            // kvkNummer v MaatschAct
+            97113131,
+            // sbiCodes,
+            new String[] {"4637"},
+            // aantalFunctionarissen
+            0)
         // </editor-fold>
         );
   }

--- a/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
@@ -205,7 +205,7 @@ public class NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
               "8010", "4652", "85592", "6202", "4321"
             },
             10),
-        // EO-78 gevallen
+        //  <editor-fold defaultstate="collapsed" desc="testcases voor EO-78">
         arguments(
             "/nhr-v3/maatschact_br_origineel.anon.xml",
             // aantalBerichten
@@ -278,6 +278,7 @@ public class NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
             new String[] {"86221"},
             // aantalFunctionarissen
             2),
+        // </editor-fold>
         //  <editor-fold defaultstate="collapsed" desc="testcases voor BRMO-419">
         arguments(
             // heeft een buitenlandse persoon met een + in de naam
@@ -303,7 +304,32 @@ public class NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
             // sbiCodes,
             new String[] {"47919", "46499", "47722", "47712", "47721"},
             // aantalFunctionarissen
-            1)
+            1),
+        arguments(
+            // heeft een buitenlandse persoon met " in de naam
+            "/nhr-v3/289538.anon.xml",
+            // aantalBerichten
+            3,
+            // aantalProcessen
+            1,
+            // aantalPrs
+            4,
+            // aantalSubj
+            5,
+            // aantalNiet_nat_prs
+            3,
+            // aantalNat_prs
+            1,
+            // hoofd vestgID
+            "nhr.comVestg.000032230524",
+            // aantalVestg_activiteit
+            1,
+            // kvkNummer v MaatschAct
+            63300486,
+            // sbiCodes,
+            new String[] {"46384"},
+            // aantalFunctionarissen
+            2)
         // </editor-fold>
         );
   }

--- a/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
@@ -329,6 +329,31 @@ public class NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
             // sbiCodes,
             new String[] {"46384"},
             // aantalFunctionarissen
+            2),
+        arguments(
+            // heeft een buitenlandse persoon met + in de naam
+            "/nhr-v3/289541.anon.xml",
+            // aantalBerichten
+            3,
+            // aantalProcessen
+            1,
+            // aantalPrs
+            4,
+            // aantalSubj
+            5,
+            // aantalNiet_nat_prs
+            3,
+            // aantalNat_prs
+            1,
+            // hoofd vestgID
+            "nhr.comVestg.000018129943",
+            // aantalVestg_activiteit
+            1,
+            // kvkNummer v MaatschAct
+            39052953,
+            // sbiCodes,
+            new String[] {"4662"},
+            // aantalFunctionarissen
             2)
         // </editor-fold>
         );

--- a/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
@@ -354,7 +354,32 @@ public class NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
             // sbiCodes,
             new String[] {"4662"},
             // aantalFunctionarissen
-            2)
+            2),
+        arguments(
+            "/nhr-v3/BRMO-419/origineel/289544.xml",
+            //                    "/nhr-v3/289544.anon.xml",
+            // aantalBerichten
+            3,
+            // aantalProcessen
+            1,
+            // aantalPrs
+            6,
+            // aantalSubj
+            7,
+            // aantalNiet_nat_prs
+            3,
+            // aantalNat_prs
+            3,
+            // hoofd vestgID
+            "nhr.comVestg.000058716262",
+            // aantalVestg_activiteit
+            3,
+            // kvkNummer v MaatschAct
+            93152825,
+            // sbiCodes,
+            new String[] {"7112", "4120", "2511"},
+            // aantalFunctionarissen
+            4)
         // </editor-fold>
         );
   }

--- a/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
+++ b/brmo-loader/src/test/java/nl/b3p/NhrToStagingToRsgbIntegrationTest.java
@@ -277,7 +277,35 @@ public class NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
             // sbiCodes,
             new String[] {"86221"},
             // aantalFunctionarissen
-            2));
+            2),
+        //  <editor-fold defaultstate="collapsed" desc="testcases voor BRMO-419">
+        arguments(
+            // heeft een buitenlandse persoon met een + in de naam
+            "/nhr-v3/289535.anon.xml",
+            // aantalBerichten
+            3,
+            // aantalProcessen
+            1,
+            // aantalPrs
+            3,
+            // aantalSubj
+            4,
+            // aantalNiet_nat_prs
+            3,
+            // aantalNat_prs
+            0,
+            // hoofd vestgID
+            "nhr.comVestg.000046583130",
+            // aantalVestg_activiteit
+            5,
+            // kvkNummer v MaatschAct
+            80216269,
+            // sbiCodes,
+            new String[] {"47919", "46499", "47722", "47712", "47721"},
+            // aantalFunctionarissen
+            1)
+        // </editor-fold>
+        );
   }
 
   private static final String BESTANDTYPE = "nhr";
@@ -364,10 +392,9 @@ public class NhrToStagingToRsgbIntegrationTest extends AbstractDatabaseIntegrati
     brmo.closeBrmoFramework();
 
     CleanUtil.cleanSTAGING(staging, false);
+    CleanUtil.cleanRSGB_NHR(rsgb);
     staging.close();
     dsStaging.close();
-
-    CleanUtil.cleanRSGB_NHR(rsgb);
     rsgb.close();
     dsRsgb.close();
 

--- a/brmo-loader/src/test/resources/nhr-v3/289535.anon.xml
+++ b/brmo-loader/src/test/resources/nhr-v3/289535.anon.xml
@@ -1,0 +1,737 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Geanonimiseerd door B3Partners BV op 2025-09-09+02:00, zie commentaar in bericht.-->
+<ophalenInschrijvingResponse xmlns="http://schemas.kvk.nl/schemas/hrip/dataservice/2015/02"
+                             xmlns:ns2="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02"
+                             peilmoment="20250818103657584">
+   <meldingen>
+      <informatie>
+         <code>IPD0000</code>
+         <omschrijving>Het product is succesvol geproduceerd</omschrijving>
+         <referentie>80216269</referentie>
+      </informatie>
+   </meldingen>
+   <product>
+      <ns2:maatschappelijkeActiviteit>
+         <ns2:registratie registratieTijdstip="20200902153522133">
+            <ns2:datumAanvang>20200902</ns2:datumAanvang>
+         </ns2:registratie>
+         <ns2:kvkNummer>80216269</ns2:kvkNummer>
+         <ns2:nonMailing>
+            <ns2:code>J</ns2:code>
+            <ns2:omschrijving>Ja</ns2:omschrijving>
+            <ns2:referentieType>geenRT</ns2:referentieType>
+         </ns2:nonMailing>
+         <ns2:incidenteelUitlenenArbeidskrachten>
+            <ns2:code>N</ns2:code>
+            <ns2:omschrijving>Nee</ns2:omschrijving>
+            <ns2:referentieType>geenRT</ns2:referentieType>
+         </ns2:incidenteelUitlenenArbeidskrachten>
+         <ns2:bezoekLocatie>
+            <ns2:registratie registratieTijdstip="20200902153522133">
+               <ns2:datumAanvang>20200902</ns2:datumAanvang>
+            </ns2:registratie>
+            <ns2:afgeschermd>
+               <ns2:code>N</ns2:code>
+               <ns2:omschrijving>Nee</ns2:omschrijving>
+               <ns2:referentieType>geenRT</ns2:referentieType>
+            </ns2:afgeschermd>
+            <ns2:adres>
+               <ns2:binnenlandsAdres>
+                  <ns2:straatnaam>Bataviaplein</ns2:straatnaam>
+                  <ns2:huisnummer>62</ns2:huisnummer>
+                  <ns2:postcode>
+                     <ns2:cijfercombinatie>8242</ns2:cijfercombinatie>
+                     <ns2:lettercombinatie>PN</ns2:lettercombinatie>
+                  </ns2:postcode>
+                  <ns2:plaats>Lelystad</ns2:plaats>
+                  <ns2:bagId>
+                     <ns2:identificatieNummeraanduiding>0995200000822597</ns2:identificatieNummeraanduiding>
+                     <ns2:identificatieAdresseerbaarObject>0995010000822668</ns2:identificatieAdresseerbaarObject>
+                  </ns2:bagId>
+               </ns2:binnenlandsAdres>
+            </ns2:adres>
+            <ns2:volledigAdres>Bataviaplein 62
+8242PN Lelystad</ns2:volledigAdres>
+         </ns2:bezoekLocatie>
+         <ns2:postLocatie>
+            <ns2:registratie registratieTijdstip="20200902153522133">
+               <ns2:datumAanvang>20200902</ns2:datumAanvang>
+            </ns2:registratie>
+            <ns2:afgeschermd>
+               <ns2:code>N</ns2:code>
+               <ns2:omschrijving>Nee</ns2:omschrijving>
+               <ns2:referentieType>geenRT</ns2:referentieType>
+            </ns2:afgeschermd>
+            <ns2:adres>
+               <ns2:binnenlandsAdres>
+                  <ns2:straatnaam>Bataviaplein</ns2:straatnaam>
+                  <ns2:huisnummer>62</ns2:huisnummer>
+                  <ns2:postcode>
+                     <ns2:cijfercombinatie>8242</ns2:cijfercombinatie>
+                     <ns2:lettercombinatie>PN</ns2:lettercombinatie>
+                  </ns2:postcode>
+                  <ns2:plaats>Lelystad</ns2:plaats>
+                  <ns2:bagId>
+                     <ns2:identificatieNummeraanduiding>0995200000822597</ns2:identificatieNummeraanduiding>
+                     <ns2:identificatieAdresseerbaarObject>0995010000822668</ns2:identificatieAdresseerbaarObject>
+                  </ns2:bagId>
+               </ns2:binnenlandsAdres>
+            </ns2:adres>
+            <ns2:volledigAdres>Bataviaplein 62
+8242PN Lelystad</ns2:volledigAdres>
+         </ns2:postLocatie>
+         <ns2:naam>Radley Netherlands B.V.</ns2:naam>
+         <ns2:manifesteertZichAls>
+            <ns2:relatieRegistratie registratieTijdstip="20200902153522133">
+               <ns2:datumAanvang>20200902</ns2:datumAanvang>
+            </ns2:relatieRegistratie>
+            <ns2:onderneming>
+               <ns2:registratie registratieTijdstip="20200902153522133">
+                  <ns2:datumAanvang>20200902</ns2:datumAanvang>
+               </ns2:registratie>
+               <ns2:kvkNummer>80216269</ns2:kvkNummer>
+               <ns2:sbiActiviteit>
+                  <ns2:registratie registratieTijdstip="20200902153522133">
+                     <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:sbiCode>
+                     <ns2:code>47919</ns2:code>
+                     <ns2:omschrijving>Detailhandel via internet in een algemeen assortiment non-food</ns2:omschrijving>
+                     <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                  </ns2:sbiCode>
+                  <ns2:isHoofdactiviteit>
+                     <ns2:code>J</ns2:code>
+                     <ns2:omschrijving>Ja</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:isHoofdactiviteit>
+               </ns2:sbiActiviteit>
+               <ns2:sbiActiviteit>
+                  <ns2:registratie registratieTijdstip="20200902153522133">
+                     <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:sbiCode>
+                     <ns2:code>46499</ns2:code>
+                     <ns2:omschrijving>Groothandel in overige consumentenartikelen (rest non-food)</ns2:omschrijving>
+                     <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                  </ns2:sbiCode>
+                  <ns2:isHoofdactiviteit>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:isHoofdactiviteit>
+               </ns2:sbiActiviteit>
+               <ns2:sbiActiviteit>
+                  <ns2:registratie registratieTijdstip="20200908160726583">
+                     <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:sbiCode>
+                     <ns2:code>47722</ns2:code>
+                     <ns2:omschrijving>Winkels in lederwaren en reisartikelen</ns2:omschrijving>
+                     <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                  </ns2:sbiCode>
+                  <ns2:isHoofdactiviteit>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:isHoofdactiviteit>
+               </ns2:sbiActiviteit>
+               <ns2:sbiActiviteit>
+                  <ns2:registratie registratieTijdstip="20200908160726583">
+                     <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:sbiCode>
+                     <ns2:code>47712</ns2:code>
+                     <ns2:omschrijving>Winkels in dameskleding</ns2:omschrijving>
+                     <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                  </ns2:sbiCode>
+                  <ns2:isHoofdactiviteit>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:isHoofdactiviteit>
+               </ns2:sbiActiviteit>
+               <ns2:sbiActiviteit>
+                  <ns2:registratie registratieTijdstip="20200908160726583">
+                     <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:sbiCode>
+                     <ns2:code>47721</ns2:code>
+                     <ns2:omschrijving>Winkels in schoenen</ns2:omschrijving>
+                     <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                  </ns2:sbiCode>
+                  <ns2:isHoofdactiviteit>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:isHoofdactiviteit>
+               </ns2:sbiActiviteit>
+               <ns2:voltijdWerkzamePersonen>3</ns2:voltijdWerkzamePersonen>
+               <ns2:deeltijdWerkzamePersonen>7</ns2:deeltijdWerkzamePersonen>
+               <ns2:totaalWerkzamePersonen>10</ns2:totaalWerkzamePersonen>
+               <ns2:handeltOnder>
+                  <ns2:handelsnaam>
+                     <ns2:registratie registratieTijdstip="20200902153522133">
+                        <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:naam>Radley Netherlands B.V.</ns2:naam>
+                     <ns2:volgorde>0</ns2:volgorde>
+                  </ns2:handelsnaam>
+               </ns2:handeltOnder>
+               <ns2:wordtUitgeoefendIn>
+                  <ns2:relatieRegistratie registratieTijdstip="20200902153522133">
+                     <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                  </ns2:relatieRegistratie>
+                  <ns2:commercieleVestiging>
+                     <ns2:registratie registratieTijdstip="20200902153522133">
+                        <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:vestigingsnummer>000046583130</ns2:vestigingsnummer>
+                     <ns2:bezoekLocatie>
+                        <ns2:registratie registratieTijdstip="20200902153522133">
+                           <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:afgeschermd>
+                           <ns2:code>N</ns2:code>
+                           <ns2:omschrijving>Nee</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:afgeschermd>
+                        <ns2:adres>
+                           <ns2:binnenlandsAdres>
+                              <ns2:straatnaam>Bataviaplein</ns2:straatnaam>
+                              <ns2:huisnummer>62</ns2:huisnummer>
+                              <ns2:postcode>
+                                 <ns2:cijfercombinatie>8242</ns2:cijfercombinatie>
+                                 <ns2:lettercombinatie>PN</ns2:lettercombinatie>
+                              </ns2:postcode>
+                              <ns2:plaats>Lelystad</ns2:plaats>
+                              <ns2:bagId>
+                                 <ns2:identificatieNummeraanduiding>0995200000822597</ns2:identificatieNummeraanduiding>
+                                 <ns2:identificatieAdresseerbaarObject>0995010000822668</ns2:identificatieAdresseerbaarObject>
+                              </ns2:bagId>
+                           </ns2:binnenlandsAdres>
+                        </ns2:adres>
+                        <ns2:volledigAdres>Bataviaplein 62
+8242PN Lelystad</ns2:volledigAdres>
+                     </ns2:bezoekLocatie>
+                     <ns2:eersteHandelsnaam>Radley Netherlands B.V.</ns2:eersteHandelsnaam>
+                     <ns2:voltijdWerkzamePersonen>3</ns2:voltijdWerkzamePersonen>
+                     <ns2:deeltijdWerkzamePersonen>7</ns2:deeltijdWerkzamePersonen>
+                     <ns2:totaalWerkzamePersonen>10</ns2:totaalWerkzamePersonen>
+                     <ns2:activiteiten>
+                        <ns2:omschrijving>De detailhandel en groothandel van producten en artikelen, waaronder onder meer begrepen handtassen, lederwaren, kleding, schoeisel, accessoires, cadeaus en huishoudelijke artikelen.</ns2:omschrijving>
+                        <ns2:sbiActiviteit>
+                           <ns2:registratie registratieTijdstip="20200902153522133">
+                              <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <ns2:sbiCode>
+                              <ns2:code>47919</ns2:code>
+                              <ns2:omschrijving>Detailhandel via internet in een algemeen assortiment non-food</ns2:omschrijving>
+                              <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                           </ns2:sbiCode>
+                           <ns2:isHoofdactiviteit>
+                              <ns2:code>J</ns2:code>
+                              <ns2:omschrijving>Ja</ns2:omschrijving>
+                              <ns2:referentieType>geenRT</ns2:referentieType>
+                           </ns2:isHoofdactiviteit>
+                        </ns2:sbiActiviteit>
+                        <ns2:sbiActiviteit>
+                           <ns2:registratie registratieTijdstip="20200902153522133">
+                              <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <ns2:sbiCode>
+                              <ns2:code>46499</ns2:code>
+                              <ns2:omschrijving>Groothandel in overige consumentenartikelen (rest non-food)</ns2:omschrijving>
+                              <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                           </ns2:sbiCode>
+                           <ns2:isHoofdactiviteit>
+                              <ns2:code>N</ns2:code>
+                              <ns2:omschrijving>Nee</ns2:omschrijving>
+                              <ns2:referentieType>geenRT</ns2:referentieType>
+                           </ns2:isHoofdactiviteit>
+                        </ns2:sbiActiviteit>
+                        <ns2:sbiActiviteit>
+                           <ns2:registratie registratieTijdstip="20200908160726583">
+                              <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <ns2:sbiCode>
+                              <ns2:code>47722</ns2:code>
+                              <ns2:omschrijving>Winkels in lederwaren en reisartikelen</ns2:omschrijving>
+                              <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                           </ns2:sbiCode>
+                           <ns2:isHoofdactiviteit>
+                              <ns2:code>N</ns2:code>
+                              <ns2:omschrijving>Nee</ns2:omschrijving>
+                              <ns2:referentieType>geenRT</ns2:referentieType>
+                           </ns2:isHoofdactiviteit>
+                        </ns2:sbiActiviteit>
+                        <ns2:sbiActiviteit>
+                           <ns2:registratie registratieTijdstip="20200908160726583">
+                              <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <ns2:sbiCode>
+                              <ns2:code>47712</ns2:code>
+                              <ns2:omschrijving>Winkels in dameskleding</ns2:omschrijving>
+                              <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                           </ns2:sbiCode>
+                           <ns2:isHoofdactiviteit>
+                              <ns2:code>N</ns2:code>
+                              <ns2:omschrijving>Nee</ns2:omschrijving>
+                              <ns2:referentieType>geenRT</ns2:referentieType>
+                           </ns2:isHoofdactiviteit>
+                        </ns2:sbiActiviteit>
+                        <ns2:sbiActiviteit>
+                           <ns2:registratie registratieTijdstip="20200908160726583">
+                              <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <ns2:sbiCode>
+                              <ns2:code>47721</ns2:code>
+                              <ns2:omschrijving>Winkels in schoenen</ns2:omschrijving>
+                              <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                           </ns2:sbiCode>
+                           <ns2:isHoofdactiviteit>
+                              <ns2:code>N</ns2:code>
+                              <ns2:omschrijving>Nee</ns2:omschrijving>
+                              <ns2:referentieType>geenRT</ns2:referentieType>
+                           </ns2:isHoofdactiviteit>
+                        </ns2:sbiActiviteit>
+                        <ns2:exporteert>
+                           <ns2:code>N</ns2:code>
+                           <ns2:omschrijving>Nee</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:exporteert>
+                        <ns2:importeert>
+                           <ns2:code>J</ns2:code>
+                           <ns2:omschrijving>Ja</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:importeert>
+                     </ns2:activiteiten>
+                     <ns2:handeltOnder>
+                        <ns2:relatieRegistratie registratieTijdstip="20200902153522133">
+                           <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                        </ns2:relatieRegistratie>
+                        <ns2:handelsnaam>
+                           <ns2:registratie registratieTijdstip="20200902153522133">
+                              <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <ns2:naam>Radley Netherlands B.V.</ns2:naam>
+                           <ns2:volgorde>0</ns2:volgorde>
+                        </ns2:handelsnaam>
+                     </ns2:handeltOnder>
+                  </ns2:commercieleVestiging>
+               </ns2:wordtUitgeoefendIn>
+            </ns2:onderneming>
+         </ns2:manifesteertZichAls>
+         <ns2:wordtGeleidVanuit>
+            <ns2:commercieleVestiging>
+               <ns2:registratie registratieTijdstip="20200902153522133">
+                  <ns2:datumAanvang>20200902</ns2:datumAanvang>
+               </ns2:registratie>
+               <ns2:vestigingsnummer>000046583130</ns2:vestigingsnummer>
+               <ns2:bezoekLocatie>
+                  <ns2:registratie registratieTijdstip="20200902153522133">
+                     <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:afgeschermd>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:afgeschermd>
+                  <ns2:adres>
+                     <ns2:binnenlandsAdres>
+                        <ns2:straatnaam>Bataviaplein</ns2:straatnaam>
+                        <ns2:huisnummer>62</ns2:huisnummer>
+                        <ns2:postcode>
+                           <ns2:cijfercombinatie>8242</ns2:cijfercombinatie>
+                           <ns2:lettercombinatie>PN</ns2:lettercombinatie>
+                        </ns2:postcode>
+                        <ns2:plaats>Lelystad</ns2:plaats>
+                        <ns2:bagId>
+                           <ns2:identificatieNummeraanduiding>0995200000822597</ns2:identificatieNummeraanduiding>
+                           <ns2:identificatieAdresseerbaarObject>0995010000822668</ns2:identificatieAdresseerbaarObject>
+                        </ns2:bagId>
+                     </ns2:binnenlandsAdres>
+                  </ns2:adres>
+                  <ns2:volledigAdres>Bataviaplein 62
+8242PN Lelystad</ns2:volledigAdres>
+               </ns2:bezoekLocatie>
+               <ns2:eersteHandelsnaam>Radley Netherlands B.V.</ns2:eersteHandelsnaam>
+               <ns2:voltijdWerkzamePersonen>3</ns2:voltijdWerkzamePersonen>
+               <ns2:deeltijdWerkzamePersonen>7</ns2:deeltijdWerkzamePersonen>
+               <ns2:totaalWerkzamePersonen>10</ns2:totaalWerkzamePersonen>
+               <ns2:activiteiten>
+                  <ns2:omschrijving>De detailhandel en groothandel van producten en artikelen, waaronder onder meer begrepen handtassen, lederwaren, kleding, schoeisel, accessoires, cadeaus en huishoudelijke artikelen.</ns2:omschrijving>
+                  <ns2:sbiActiviteit>
+                     <ns2:registratie registratieTijdstip="20200902153522133">
+                        <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:sbiCode>
+                        <ns2:code>47919</ns2:code>
+                        <ns2:omschrijving>Detailhandel via internet in een algemeen assortiment non-food</ns2:omschrijving>
+                        <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                     </ns2:sbiCode>
+                     <ns2:isHoofdactiviteit>
+                        <ns2:code>J</ns2:code>
+                        <ns2:omschrijving>Ja</ns2:omschrijving>
+                        <ns2:referentieType>geenRT</ns2:referentieType>
+                     </ns2:isHoofdactiviteit>
+                  </ns2:sbiActiviteit>
+                  <ns2:sbiActiviteit>
+                     <ns2:registratie registratieTijdstip="20200902153522133">
+                        <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:sbiCode>
+                        <ns2:code>46499</ns2:code>
+                        <ns2:omschrijving>Groothandel in overige consumentenartikelen (rest non-food)</ns2:omschrijving>
+                        <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                     </ns2:sbiCode>
+                     <ns2:isHoofdactiviteit>
+                        <ns2:code>N</ns2:code>
+                        <ns2:omschrijving>Nee</ns2:omschrijving>
+                        <ns2:referentieType>geenRT</ns2:referentieType>
+                     </ns2:isHoofdactiviteit>
+                  </ns2:sbiActiviteit>
+                  <ns2:sbiActiviteit>
+                     <ns2:registratie registratieTijdstip="20200908160726583">
+                        <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:sbiCode>
+                        <ns2:code>47722</ns2:code>
+                        <ns2:omschrijving>Winkels in lederwaren en reisartikelen</ns2:omschrijving>
+                        <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                     </ns2:sbiCode>
+                     <ns2:isHoofdactiviteit>
+                        <ns2:code>N</ns2:code>
+                        <ns2:omschrijving>Nee</ns2:omschrijving>
+                        <ns2:referentieType>geenRT</ns2:referentieType>
+                     </ns2:isHoofdactiviteit>
+                  </ns2:sbiActiviteit>
+                  <ns2:sbiActiviteit>
+                     <ns2:registratie registratieTijdstip="20200908160726583">
+                        <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:sbiCode>
+                        <ns2:code>47712</ns2:code>
+                        <ns2:omschrijving>Winkels in dameskleding</ns2:omschrijving>
+                        <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                     </ns2:sbiCode>
+                     <ns2:isHoofdactiviteit>
+                        <ns2:code>N</ns2:code>
+                        <ns2:omschrijving>Nee</ns2:omschrijving>
+                        <ns2:referentieType>geenRT</ns2:referentieType>
+                     </ns2:isHoofdactiviteit>
+                  </ns2:sbiActiviteit>
+                  <ns2:sbiActiviteit>
+                     <ns2:registratie registratieTijdstip="20200908160726583">
+                        <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:sbiCode>
+                        <ns2:code>47721</ns2:code>
+                        <ns2:omschrijving>Winkels in schoenen</ns2:omschrijving>
+                        <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                     </ns2:sbiCode>
+                     <ns2:isHoofdactiviteit>
+                        <ns2:code>N</ns2:code>
+                        <ns2:omschrijving>Nee</ns2:omschrijving>
+                        <ns2:referentieType>geenRT</ns2:referentieType>
+                     </ns2:isHoofdactiviteit>
+                  </ns2:sbiActiviteit>
+                  <ns2:exporteert>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:exporteert>
+                  <ns2:importeert>
+                     <ns2:code>J</ns2:code>
+                     <ns2:omschrijving>Ja</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:importeert>
+               </ns2:activiteiten>
+               <ns2:handeltOnder>
+                  <ns2:relatieRegistratie registratieTijdstip="20200902153522133">
+                     <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                  </ns2:relatieRegistratie>
+                  <ns2:handelsnaam>
+                     <ns2:registratie registratieTijdstip="20200902153522133">
+                        <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:naam>Radley Netherlands B.V.</ns2:naam>
+                     <ns2:volgorde>0</ns2:volgorde>
+                  </ns2:handelsnaam>
+               </ns2:handeltOnder>
+            </ns2:commercieleVestiging>
+         </ns2:wordtGeleidVanuit>
+         <ns2:heeftAlsEigenaar>
+            <ns2:relatieRegistratie registratieTijdstip="20200902153522133">
+               <ns2:datumAanvang>20200902</ns2:datumAanvang>
+            </ns2:relatieRegistratie>
+            <ns2:rechtspersoon>
+               <ns2:extraElementen>
+                  <ns2:extraElement naam="datumAanvangStatuten">20200902</ns2:extraElement>
+                  <ns2:extraElement naam="datumAkteStatuten">20200902</ns2:extraElement>
+               </ns2:extraElementen>
+               <ns2:registratie registratieTijdstip="20200902153522133">
+                  <ns2:datumAanvang>20200902</ns2:datumAanvang>
+               </ns2:registratie>
+               <ns2:persoonRechtsvorm>Besloten Vennootschap</ns2:persoonRechtsvorm>
+               <ns2:volledigeNaam>Radley Netherlands B.V.</ns2:volledigeNaam>
+               <ns2:uitgebreideRechtsvorm>Besloten Vennootschap</ns2:uitgebreideRechtsvorm>
+               <ns2:heeft>
+                  <ns2:bestuursfunctie>
+                     <ns2:registratie registratieTijdstip="20200902153522133">
+                        <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:functietitel>
+                        <ns2:registratie registratieTijdstip="20200902153522133">
+                           <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:titel>Directeur</ns2:titel>
+                        <ns2:isStatutaireTitel>
+                           <ns2:code>J</ns2:code>
+                           <ns2:omschrijving>Ja</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:isStatutaireTitel>
+                     </ns2:functietitel>
+                     <ns2:door>
+                        <ns2:buitenlandseVennootschap>
+                           <ns2:persoonRechtsvorm>Overige buitenlandse rechtspersoon of vennootschap</ns2:persoonRechtsvorm>
+                           <ns2:volledigeNaam>Radley + Co. Limited</ns2:volledigeNaam>
+                           <ns2:bezoekLocatiePersoon>
+                              <ns2:registratie registratieTijdstip="20200902153522133">
+                                 <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                              </ns2:registratie>
+                              <ns2:afgeschermd>
+                                 <ns2:code>N</ns2:code>
+                                 <ns2:omschrijving>Nee</ns2:omschrijving>
+                                 <ns2:referentieType>geenRT</ns2:referentieType>
+                              </ns2:afgeschermd>
+                              <ns2:adres>
+                                 <ns2:buitenlandsAdres>
+                                    <ns2:straatHuisnummer>McBeath House, 310 Goswell Road</ns2:straatHuisnummer>
+                                    <ns2:postcodeWoonplaats>EC1V 7LW Londen</ns2:postcodeWoonplaats>
+                                    <ns2:land>
+                                       <ns2:code>6039</ns2:code>
+                                       <ns2:omschrijving>Verenigd Koninkrijk</ns2:omschrijving>
+                                       <ns2:referentieType>Land</ns2:referentieType>
+                                    </ns2:land>
+                                 </ns2:buitenlandsAdres>
+                              </ns2:adres>
+                              <ns2:volledigAdres>McBeath House, 310 Goswell Road
+EC1V 7LW Londen
+Verenigd Koninkrijk</ns2:volledigAdres>
+                           </ns2:bezoekLocatiePersoon>
+                           <ns2:buitenlandseRegistratieGegevens>
+                              <ns2:naam>Companies Registration Office (England and Wales)</ns2:naam>
+                              <ns2:plaats>Cardiff</ns2:plaats>
+                              <ns2:land>
+                                 <ns2:code>6039</ns2:code>
+                                 <ns2:omschrijving>Verenigd Koninkrijk</ns2:omschrijving>
+                                 <ns2:referentieType>Land</ns2:referentieType>
+                              </ns2:land>
+                              <ns2:inschrijfnummer>02573819</ns2:inschrijfnummer>
+                              <ns2:buitenlandseRegistratie>Companies Registration Office (England and Wales)
+Cardiff, Verenigd Koninkrijk
+Onder nummer 02573819</ns2:buitenlandseRegistratie>
+                           </ns2:buitenlandseRegistratieGegevens>
+                           <ns2:landVanVestiging>
+                              <ns2:code>6039</ns2:code>
+                              <ns2:omschrijving>Verenigd Koninkrijk</ns2:omschrijving>
+                              <ns2:referentieType>Land</ns2:referentieType>
+                           </ns2:landVanVestiging>
+                        </ns2:buitenlandseVennootschap>
+                     </ns2:door>
+                     <ns2:functie>
+                        <ns2:code>02</ns2:code>
+                        <ns2:omschrijving>Bestuurder</ns2:omschrijving>
+                        <ns2:referentieType>FunctionarisRol</ns2:referentieType>
+                     </ns2:functie>
+                     <ns2:bevoegdheid>
+                        <ns2:registratie registratieTijdstip="20200902153522133">
+                           <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:soort>
+                           <ns2:code>azb</ns2:code>
+                           <ns2:omschrijving>Alleen/zelfstandig bevoegd</ns2:omschrijving>
+                           <ns2:referentieType>SoortBevoegdheidBestuurder</ns2:referentieType>
+                        </ns2:soort>
+                        <ns2:isBevoegdMetAnderePersonen>
+                           <ns2:code>N</ns2:code>
+                           <ns2:omschrijving>Nee</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:isBevoegdMetAnderePersonen>
+                     </ns2:bevoegdheid>
+                  </ns2:bestuursfunctie>
+               </ns2:heeft>
+               <ns2:heeft>
+                  <ns2:overigeFunctionaris>
+                     <ns2:registratie registratieTijdstip="20200902153522133">
+                        <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:door>
+                        <ns2:buitenlandseVennootschap>
+                           <ns2:persoonRechtsvorm>Overige buitenlandse rechtspersoon of vennootschap</ns2:persoonRechtsvorm>
+                           <ns2:volledigeNaam>Radley + Co. Limited</ns2:volledigeNaam>
+                           <ns2:bezoekLocatiePersoon>
+                              <ns2:registratie registratieTijdstip="20200902153522133">
+                                 <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                              </ns2:registratie>
+                              <ns2:afgeschermd>
+                                 <ns2:code>N</ns2:code>
+                                 <ns2:omschrijving>Nee</ns2:omschrijving>
+                                 <ns2:referentieType>geenRT</ns2:referentieType>
+                              </ns2:afgeschermd>
+                              <ns2:adres>
+                                 <ns2:buitenlandsAdres>
+                                    <ns2:straatHuisnummer>McBeath House, 310 Goswell Road</ns2:straatHuisnummer>
+                                    <ns2:postcodeWoonplaats>EC1V 7LW Londen</ns2:postcodeWoonplaats>
+                                    <ns2:land>
+                                       <ns2:code>6039</ns2:code>
+                                       <ns2:omschrijving>Verenigd Koninkrijk</ns2:omschrijving>
+                                       <ns2:referentieType>Land</ns2:referentieType>
+                                    </ns2:land>
+                                 </ns2:buitenlandsAdres>
+                              </ns2:adres>
+                              <ns2:volledigAdres>McBeath House, 310 Goswell Road
+EC1V 7LW Londen
+Verenigd Koninkrijk</ns2:volledigAdres>
+                           </ns2:bezoekLocatiePersoon>
+                           <ns2:buitenlandseRegistratieGegevens>
+                              <ns2:naam>Companies Registration Office (England and Wales)</ns2:naam>
+                              <ns2:plaats>Cardiff</ns2:plaats>
+                              <ns2:land>
+                                 <ns2:code>6039</ns2:code>
+                                 <ns2:omschrijving>Verenigd Koninkrijk</ns2:omschrijving>
+                                 <ns2:referentieType>Land</ns2:referentieType>
+                              </ns2:land>
+                              <ns2:inschrijfnummer>02573819</ns2:inschrijfnummer>
+                              <ns2:buitenlandseRegistratie>Companies Registration Office (England and Wales)
+Cardiff, Verenigd Koninkrijk
+Onder nummer 02573819</ns2:buitenlandseRegistratie>
+                           </ns2:buitenlandseRegistratieGegevens>
+                           <ns2:landVanVestiging>
+                              <ns2:code>6039</ns2:code>
+                              <ns2:omschrijving>Verenigd Koninkrijk</ns2:omschrijving>
+                              <ns2:referentieType>Land</ns2:referentieType>
+                           </ns2:landVanVestiging>
+                        </ns2:buitenlandseVennootschap>
+                     </ns2:door>
+                     <ns2:functie>
+                        <ns2:code>08</ns2:code>
+                        <ns2:omschrijving>Enig aandeelhouder</ns2:omschrijving>
+                        <ns2:referentieType>FunctionarisRol</ns2:referentieType>
+                     </ns2:functie>
+                  </ns2:overigeFunctionaris>
+               </ns2:heeft>
+               <ns2:rsin>861591616</ns2:rsin>
+               <ns2:naamgeving>
+                  <ns2:registratie registratieTijdstip="20200902153522133">
+                     <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:naam>Radley Netherlands B.V.</ns2:naam>
+               </ns2:naamgeving>
+               <ns2:heeftGedeponeerd>
+                  <ns2:jaarstukJaarrekening>
+                     <ns2:depotId>3c233bd6:18848c3d87e:-4937</ns2:depotId>
+                     <ns2:soortDeponering>Jaarrekening (art. 394 lid 1 BW2)</ns2:soortDeponering>
+                     <ns2:status>
+                        <ns2:code>1</ns2:code>
+                        <ns2:omschrijving>Actueel</ns2:omschrijving>
+                        <ns2:referentieType>StatusDepotstuk</ns2:referentieType>
+                     </ns2:status>
+                     <ns2:datumDeponering>20230523</ns2:datumDeponering>
+                     <ns2:boekjaar>2022</ns2:boekjaar>
+                     <ns2:datumVaststelling>20230517</ns2:datumVaststelling>
+                     <ns2:vaststelling>
+                        <ns2:code>D</ns2:code>
+                        <ns2:omschrijving>Definitief</ns2:omschrijving>
+                        <ns2:referentieType>VaststellingJaarrekening</ns2:referentieType>
+                     </ns2:vaststelling>
+                     <ns2:grootte>
+                        <ns2:code>micro</ns2:code>
+                        <ns2:omschrijving>Micro</ns2:omschrijving>
+                     </ns2:grootte>
+                     <ns2:buitenlandseJaarrekening>
+                        <ns2:code>N</ns2:code>
+                        <ns2:omschrijving>Nee</ns2:omschrijving>
+                        <ns2:referentieType>geenRT</ns2:referentieType>
+                     </ns2:buitenlandseJaarrekening>
+                  </ns2:jaarstukJaarrekening>
+               </ns2:heeftGedeponeerd>
+               <ns2:rechtsvorm>
+                  <ns2:code>BV</ns2:code>
+                  <ns2:omschrijving>Besloten Vennootschap</ns2:omschrijving>
+                  <ns2:referentieType>Rechtsvorm</ns2:referentieType>
+               </ns2:rechtsvorm>
+               <ns2:statutaireZetel>Amsterdam</ns2:statutaireZetel>
+               <ns2:aanvangStatutaireZetel>20200902</ns2:aanvangStatutaireZetel>
+               <ns2:datumAkteOprichting>20200902</ns2:datumAkteOprichting>
+               <ns2:datumOprichting>20200902</ns2:datumOprichting>
+               <ns2:datumEersteInschrijvingHandelsregister>20200902</ns2:datumEersteInschrijvingHandelsregister>
+               <ns2:datumAkteStatutenwijziging>20200902</ns2:datumAkteStatutenwijziging>
+               <ns2:stelselInrichting>
+                  <ns2:code>D</ns2:code>
+                  <ns2:omschrijving>Dualistisch</ns2:omschrijving>
+                  <ns2:referentieType>StelselInrichting</ns2:referentieType>
+               </ns2:stelselInrichting>
+               <ns2:structuur>
+                  <ns2:code>GS</ns2:code>
+                  <ns2:omschrijving>Gewone structuur</ns2:omschrijving>
+                  <ns2:referentieType>RechtsvormStructuur</ns2:referentieType>
+               </ns2:structuur>
+               <ns2:geplaatstKapitaal>
+                  <ns2:registratie registratieTijdstip="20200902153522133">
+                     <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:bedrag>
+                     <ns2:waarde>100</ns2:waarde>
+                     <ns2:valuta>
+                        <ns2:code>EUR</ns2:code>
+                        <ns2:omschrijving>Euro</ns2:omschrijving>
+                        <ns2:referentieType>Valuta</ns2:referentieType>
+                     </ns2:valuta>
+                  </ns2:bedrag>
+               </ns2:geplaatstKapitaal>
+               <ns2:gestortKapitaal>
+                  <ns2:registratie registratieTijdstip="20200902153522133">
+                     <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:bedrag>
+                     <ns2:waarde>0</ns2:waarde>
+                     <ns2:valuta>
+                        <ns2:code>EUR</ns2:code>
+                        <ns2:omschrijving>Euro</ns2:omschrijving>
+                        <ns2:referentieType>Valuta</ns2:referentieType>
+                     </ns2:valuta>
+                  </ns2:bedrag>
+               </ns2:gestortKapitaal>
+               <ns2:bezoekLocatie>
+                  <ns2:registratie registratieTijdstip="20200902153522133">
+                     <ns2:datumAanvang>20200902</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:afgeschermd>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:afgeschermd>
+                  <ns2:adres>
+                     <ns2:binnenlandsAdres>
+                        <ns2:straatnaam>Bataviaplein</ns2:straatnaam>
+                        <ns2:huisnummer>62</ns2:huisnummer>
+                        <ns2:postcode>
+                           <ns2:cijfercombinatie>8242</ns2:cijfercombinatie>
+                           <ns2:lettercombinatie>PN</ns2:lettercombinatie>
+                        </ns2:postcode>
+                        <ns2:plaats>Lelystad</ns2:plaats>
+                        <ns2:bagId>
+                           <ns2:identificatieNummeraanduiding>0995200000822597</ns2:identificatieNummeraanduiding>
+                           <ns2:identificatieAdresseerbaarObject>0995010000822668</ns2:identificatieAdresseerbaarObject>
+                        </ns2:bagId>
+                     </ns2:binnenlandsAdres>
+                  </ns2:adres>
+                  <ns2:volledigAdres>Bataviaplein 62
+8242PN Lelystad</ns2:volledigAdres>
+               </ns2:bezoekLocatie>
+            </ns2:rechtspersoon>
+         </ns2:heeftAlsEigenaar>
+      </ns2:maatschappelijkeActiviteit>
+   </product>
+</ophalenInschrijvingResponse>

--- a/brmo-loader/src/test/resources/nhr-v3/289538.anon.xml
+++ b/brmo-loader/src/test/resources/nhr-v3/289538.anon.xml
@@ -1,0 +1,598 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Geanonimiseerd door B3Partners BV op 2025-09-09+02:00, zie commentaar in bericht.-->
+<ophalenInschrijvingResponse xmlns="http://schemas.kvk.nl/schemas/hrip/dataservice/2015/02"
+                             xmlns:ns2="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02"
+                             peilmoment="20250818103657584">
+   <meldingen>
+      <informatie>
+         <code>IPD0000</code>
+         <omschrijving>Het product is succesvol geproduceerd</omschrijving>
+         <referentie>63300486</referentie>
+      </informatie>
+   </meldingen>
+   <product>
+      <ns2:maatschappelijkeActiviteit>
+         <ns2:registratie registratieTijdstip="20150512155308324">
+            <ns2:datumAanvang>20150511</ns2:datumAanvang>
+         </ns2:registratie>
+         <ns2:kvkNummer>63300486</ns2:kvkNummer>
+         <ns2:nonMailing>
+            <ns2:code>J</ns2:code>
+            <ns2:omschrijving>Ja</ns2:omschrijving>
+            <ns2:referentieType>geenRT</ns2:referentieType>
+         </ns2:nonMailing>
+         <ns2:incidenteelUitlenenArbeidskrachten>
+            <ns2:code>N</ns2:code>
+            <ns2:omschrijving>Nee</ns2:omschrijving>
+            <ns2:referentieType>geenRT</ns2:referentieType>
+         </ns2:incidenteelUitlenenArbeidskrachten>
+         <ns2:bezoekLocatie>
+            <ns2:registratie registratieTijdstip="20240722123852318">
+               <ns2:datumAanvang>20240720</ns2:datumAanvang>
+            </ns2:registratie>
+            <ns2:afgeschermd>
+               <ns2:code>N</ns2:code>
+               <ns2:omschrijving>Nee</ns2:omschrijving>
+               <ns2:referentieType>geenRT</ns2:referentieType>
+            </ns2:afgeschermd>
+            <ns2:adres>
+               <ns2:binnenlandsAdres>
+                  <ns2:straatnaam>Aambeeld</ns2:straatnaam>
+                  <ns2:huisnummer>16</ns2:huisnummer>
+                  <ns2:postcode>
+                     <ns2:cijfercombinatie>8307</ns2:cijfercombinatie>
+                     <ns2:lettercombinatie>EC</ns2:lettercombinatie>
+                  </ns2:postcode>
+                  <ns2:plaats>Ens</ns2:plaats>
+                  <ns2:bagId>
+                     <ns2:identificatieNummeraanduiding>0171200000022341</ns2:identificatieNummeraanduiding>
+                     <ns2:identificatieAdresseerbaarObject>0171010000022341</ns2:identificatieAdresseerbaarObject>
+                  </ns2:bagId>
+               </ns2:binnenlandsAdres>
+            </ns2:adres>
+            <ns2:volledigAdres>Aambeeld 16
+8307EC Ens</ns2:volledigAdres>
+         </ns2:bezoekLocatie>
+         <ns2:postLocatie>
+            <ns2:registratie registratieTijdstip="20240722123852318">
+               <ns2:datumAanvang>20240720</ns2:datumAanvang>
+            </ns2:registratie>
+            <ns2:afgeschermd>
+               <ns2:code>N</ns2:code>
+               <ns2:omschrijving>Nee</ns2:omschrijving>
+               <ns2:referentieType>geenRT</ns2:referentieType>
+            </ns2:afgeschermd>
+            <ns2:adres>
+               <ns2:binnenlandsAdres>
+                  <ns2:straatnaam>Aambeeld</ns2:straatnaam>
+                  <ns2:huisnummer>16</ns2:huisnummer>
+                  <ns2:postcode>
+                     <ns2:cijfercombinatie>8307</ns2:cijfercombinatie>
+                     <ns2:lettercombinatie>EC</ns2:lettercombinatie>
+                  </ns2:postcode>
+                  <ns2:plaats>Ens</ns2:plaats>
+                  <ns2:bagId>
+                     <ns2:identificatieNummeraanduiding>0171200000022341</ns2:identificatieNummeraanduiding>
+                     <ns2:identificatieAdresseerbaarObject>0171010000022341</ns2:identificatieAdresseerbaarObject>
+                  </ns2:bagId>
+               </ns2:binnenlandsAdres>
+            </ns2:adres>
+            <ns2:volledigAdres>Aambeeld 16
+8307EC Ens</ns2:volledigAdres>
+         </ns2:postLocatie>
+         <ns2:communicatiegegevens>
+            <ns2:registratie registratieTijdstip="20150512155308324">
+               <ns2:datumAanvang>20150511</ns2:datumAanvang>
+            </ns2:registratie>
+            <ns2:communicatienummer>
+               <ns2:toegangscode>+31</ns2:toegangscode>
+               <ns2:nummer>0646317064</ns2:nummer>
+               <ns2:soort>
+                  <ns2:code>T</ns2:code>
+                  <ns2:omschrijving>Telefoon</ns2:omschrijving>
+               </ns2:soort>
+            </ns2:communicatienummer>
+         </ns2:communicatiegegevens>
+         <ns2:naam>F&amp;L Sales B.V.</ns2:naam>
+         <ns2:manifesteertZichAls>
+            <ns2:relatieRegistratie registratieTijdstip="20150512155308324">
+               <ns2:datumAanvang>20150511</ns2:datumAanvang>
+            </ns2:relatieRegistratie>
+            <ns2:onderneming>
+               <ns2:registratie registratieTijdstip="20150512155308324">
+                  <ns2:datumAanvang>20150511</ns2:datumAanvang>
+               </ns2:registratie>
+               <ns2:kvkNummer>63300486</ns2:kvkNummer>
+               <ns2:sbiActiviteit>
+                  <ns2:registratie registratieTijdstip="20150512155308324">
+                     <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:sbiCode>
+                     <ns2:code>46384</ns2:code>
+                     <ns2:omschrijving>Groothandel in bakkerijgrondstoffen</ns2:omschrijving>
+                     <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                  </ns2:sbiCode>
+                  <ns2:isHoofdactiviteit>
+                     <ns2:code>J</ns2:code>
+                     <ns2:omschrijving>Ja</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:isHoofdactiviteit>
+               </ns2:sbiActiviteit>
+               <ns2:voltijdWerkzamePersonen>1</ns2:voltijdWerkzamePersonen>
+               <ns2:deeltijdWerkzamePersonen>1</ns2:deeltijdWerkzamePersonen>
+               <ns2:totaalWerkzamePersonen>2</ns2:totaalWerkzamePersonen>
+               <ns2:handeltOnder>
+                  <ns2:handelsnaam>
+                     <ns2:registratie registratieTijdstip="20150512155308324">
+                        <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:naam>F&amp;L Sales B.V.</ns2:naam>
+                     <ns2:volgorde>0</ns2:volgorde>
+                  </ns2:handelsnaam>
+               </ns2:handeltOnder>
+               <ns2:wordtUitgeoefendIn>
+                  <ns2:relatieRegistratie registratieTijdstip="20150512155308324">
+                     <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                  </ns2:relatieRegistratie>
+                  <ns2:commercieleVestiging>
+                     <ns2:registratie registratieTijdstip="20150512155308324">
+                        <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:vestigingsnummer>000032230524</ns2:vestigingsnummer>
+                     <ns2:bezoekLocatie>
+                        <ns2:registratie registratieTijdstip="20240722123852318">
+                           <ns2:datumAanvang>20240720</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:afgeschermd>
+                           <ns2:code>N</ns2:code>
+                           <ns2:omschrijving>Nee</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:afgeschermd>
+                        <ns2:adres>
+                           <ns2:binnenlandsAdres>
+                              <ns2:straatnaam>Aambeeld</ns2:straatnaam>
+                              <ns2:huisnummer>16</ns2:huisnummer>
+                              <ns2:postcode>
+                                 <ns2:cijfercombinatie>8307</ns2:cijfercombinatie>
+                                 <ns2:lettercombinatie>EC</ns2:lettercombinatie>
+                              </ns2:postcode>
+                              <ns2:plaats>Ens</ns2:plaats>
+                              <ns2:bagId>
+                                 <ns2:identificatieNummeraanduiding>0171200000022341</ns2:identificatieNummeraanduiding>
+                                 <ns2:identificatieAdresseerbaarObject>0171010000022341</ns2:identificatieAdresseerbaarObject>
+                              </ns2:bagId>
+                           </ns2:binnenlandsAdres>
+                        </ns2:adres>
+                        <ns2:volledigAdres>Aambeeld 16
+8307EC Ens</ns2:volledigAdres>
+                     </ns2:bezoekLocatie>
+                     <ns2:communicatiegegevens>
+                        <ns2:registratie registratieTijdstip="20150512155308324">
+                           <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:communicatienummer>
+                           <ns2:toegangscode>+31</ns2:toegangscode>
+                           <ns2:nummer>0646317064</ns2:nummer>
+                           <ns2:soort>
+                              <ns2:code>T</ns2:code>
+                              <ns2:omschrijving>Telefoon</ns2:omschrijving>
+                           </ns2:soort>
+                        </ns2:communicatienummer>
+                     </ns2:communicatiegegevens>
+                     <ns2:eersteHandelsnaam>F&amp;L Sales B.V.</ns2:eersteHandelsnaam>
+                     <ns2:voltijdWerkzamePersonen>1</ns2:voltijdWerkzamePersonen>
+                     <ns2:deeltijdWerkzamePersonen>1</ns2:deeltijdWerkzamePersonen>
+                     <ns2:totaalWerkzamePersonen>2</ns2:totaalWerkzamePersonen>
+                     <ns2:activiteiten>
+                        <ns2:omschrijving>Het aankopen en verkopen van brood- en banketproducten en andere voedingswaren, het stimuleren, bemiddelen en uitbreiden van verkoop van brood- en banketproducten en andere voedingswaren voor en door bedrijven, alles in de ruimste zin van het woord.</ns2:omschrijving>
+                        <ns2:sbiActiviteit>
+                           <ns2:registratie registratieTijdstip="20150512155308324">
+                              <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <ns2:sbiCode>
+                              <ns2:code>46384</ns2:code>
+                              <ns2:omschrijving>Groothandel in bakkerijgrondstoffen</ns2:omschrijving>
+                              <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                           </ns2:sbiCode>
+                           <ns2:isHoofdactiviteit>
+                              <ns2:code>J</ns2:code>
+                              <ns2:omschrijving>Ja</ns2:omschrijving>
+                              <ns2:referentieType>geenRT</ns2:referentieType>
+                           </ns2:isHoofdactiviteit>
+                        </ns2:sbiActiviteit>
+                        <ns2:exporteert>
+                           <ns2:code>J</ns2:code>
+                           <ns2:omschrijving>Ja</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:exporteert>
+                        <ns2:importeert>
+                           <ns2:code>J</ns2:code>
+                           <ns2:omschrijving>Ja</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:importeert>
+                     </ns2:activiteiten>
+                     <ns2:handeltOnder>
+                        <ns2:relatieRegistratie registratieTijdstip="20150512155308324">
+                           <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                        </ns2:relatieRegistratie>
+                        <ns2:handelsnaam>
+                           <ns2:registratie registratieTijdstip="20150512155308324">
+                              <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <ns2:naam>F&amp;L Sales B.V.</ns2:naam>
+                           <ns2:volgorde>0</ns2:volgorde>
+                        </ns2:handelsnaam>
+                     </ns2:handeltOnder>
+                  </ns2:commercieleVestiging>
+               </ns2:wordtUitgeoefendIn>
+            </ns2:onderneming>
+         </ns2:manifesteertZichAls>
+         <ns2:wordtGeleidVanuit>
+            <ns2:commercieleVestiging>
+               <ns2:registratie registratieTijdstip="20150512155308324">
+                  <ns2:datumAanvang>20150511</ns2:datumAanvang>
+               </ns2:registratie>
+               <ns2:vestigingsnummer>000032230524</ns2:vestigingsnummer>
+               <ns2:bezoekLocatie>
+                  <ns2:registratie registratieTijdstip="20240722123852318">
+                     <ns2:datumAanvang>20240720</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:afgeschermd>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:afgeschermd>
+                  <ns2:adres>
+                     <ns2:binnenlandsAdres>
+                        <ns2:straatnaam>Aambeeld</ns2:straatnaam>
+                        <ns2:huisnummer>16</ns2:huisnummer>
+                        <ns2:postcode>
+                           <ns2:cijfercombinatie>8307</ns2:cijfercombinatie>
+                           <ns2:lettercombinatie>EC</ns2:lettercombinatie>
+                        </ns2:postcode>
+                        <ns2:plaats>Ens</ns2:plaats>
+                        <ns2:bagId>
+                           <ns2:identificatieNummeraanduiding>0171200000022341</ns2:identificatieNummeraanduiding>
+                           <ns2:identificatieAdresseerbaarObject>0171010000022341</ns2:identificatieAdresseerbaarObject>
+                        </ns2:bagId>
+                     </ns2:binnenlandsAdres>
+                  </ns2:adres>
+                  <ns2:volledigAdres>Aambeeld 16
+8307EC Ens</ns2:volledigAdres>
+               </ns2:bezoekLocatie>
+               <ns2:communicatiegegevens>
+                  <ns2:registratie registratieTijdstip="20150512155308324">
+                     <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:communicatienummer>
+                     <ns2:toegangscode>+31</ns2:toegangscode>
+                     <ns2:nummer>0646317064</ns2:nummer>
+                     <ns2:soort>
+                        <ns2:code>T</ns2:code>
+                        <ns2:omschrijving>Telefoon</ns2:omschrijving>
+                     </ns2:soort>
+                  </ns2:communicatienummer>
+               </ns2:communicatiegegevens>
+               <ns2:eersteHandelsnaam>F&amp;L Sales B.V.</ns2:eersteHandelsnaam>
+               <ns2:voltijdWerkzamePersonen>1</ns2:voltijdWerkzamePersonen>
+               <ns2:deeltijdWerkzamePersonen>1</ns2:deeltijdWerkzamePersonen>
+               <ns2:totaalWerkzamePersonen>2</ns2:totaalWerkzamePersonen>
+               <ns2:activiteiten>
+                  <ns2:omschrijving>Het aankopen en verkopen van brood- en banketproducten en andere voedingswaren, het stimuleren, bemiddelen en uitbreiden van verkoop van brood- en banketproducten en andere voedingswaren voor en door bedrijven, alles in de ruimste zin van het woord.</ns2:omschrijving>
+                  <ns2:sbiActiviteit>
+                     <ns2:registratie registratieTijdstip="20150512155308324">
+                        <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:sbiCode>
+                        <ns2:code>46384</ns2:code>
+                        <ns2:omschrijving>Groothandel in bakkerijgrondstoffen</ns2:omschrijving>
+                        <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                     </ns2:sbiCode>
+                     <ns2:isHoofdactiviteit>
+                        <ns2:code>J</ns2:code>
+                        <ns2:omschrijving>Ja</ns2:omschrijving>
+                        <ns2:referentieType>geenRT</ns2:referentieType>
+                     </ns2:isHoofdactiviteit>
+                  </ns2:sbiActiviteit>
+                  <ns2:exporteert>
+                     <ns2:code>J</ns2:code>
+                     <ns2:omschrijving>Ja</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:exporteert>
+                  <ns2:importeert>
+                     <ns2:code>J</ns2:code>
+                     <ns2:omschrijving>Ja</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:importeert>
+               </ns2:activiteiten>
+               <ns2:handeltOnder>
+                  <ns2:relatieRegistratie registratieTijdstip="20150512155308324">
+                     <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                  </ns2:relatieRegistratie>
+                  <ns2:handelsnaam>
+                     <ns2:registratie registratieTijdstip="20150512155308324">
+                        <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:naam>F&amp;L Sales B.V.</ns2:naam>
+                     <ns2:volgorde>0</ns2:volgorde>
+                  </ns2:handelsnaam>
+               </ns2:handeltOnder>
+            </ns2:commercieleVestiging>
+         </ns2:wordtGeleidVanuit>
+         <ns2:heeftAlsEigenaar>
+            <ns2:relatieRegistratie registratieTijdstip="20150512155308324">
+               <ns2:datumAanvang>20150511</ns2:datumAanvang>
+            </ns2:relatieRegistratie>
+            <ns2:rechtspersoon>
+               <ns2:extraElementen>
+                  <ns2:extraElement naam="datumAanvangStatuten">20150511</ns2:extraElement>
+                  <ns2:extraElement naam="datumAkteStatuten">20150511</ns2:extraElement>
+               </ns2:extraElementen>
+               <ns2:registratie registratieTijdstip="20150512155308324">
+                  <ns2:datumAanvang>20150511</ns2:datumAanvang>
+               </ns2:registratie>
+               <ns2:persoonRechtsvorm>Besloten Vennootschap</ns2:persoonRechtsvorm>
+               <ns2:volledigeNaam>F&amp;L Sales B.V.</ns2:volledigeNaam>
+               <ns2:uitgebreideRechtsvorm>Besloten Vennootschap</ns2:uitgebreideRechtsvorm>
+               <ns2:heeft>
+                  <ns2:bestuursfunctie>
+                     <ns2:registratie registratieTijdstip="20150512155308324">
+                        <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:functietitel>
+                        <ns2:registratie registratieTijdstip="20150512155308324">
+                           <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:titel>Algemeen directeur</ns2:titel>
+                        <ns2:isStatutaireTitel>
+                           <ns2:code>J</ns2:code>
+                           <ns2:omschrijving>Ja</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:isStatutaireTitel>
+                     </ns2:functietitel>
+                     <ns2:door>
+                        <ns2:natuurlijkPersoon>
+                           <ns2:extraElementen>
+<!--Anonimisatie 'ns2:extraElement': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:extraElement naam="achternaam">523300f</ns2:extraElement>
+                           </ns2:extraElementen>
+                           <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+<!--Anonimisatie 'ns2:datumAanvang': datum is met behoud van vorm vervangen door een hash van de oorspronkelijke datum.--><ns2:datumAanvang>20210127</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <!--Anonimisatie 'ns2:volledigeNaam': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:volledigeNaam>640ef52281 1d7258 ada0741a b8a6fe3</ns2:volledigeNaam>
+                           <ns2:bezoekLocatiePersoon>
+                              <ns2:registratie registratieTijdstip="20240715061039837"/>
+                              <ns2:afgeschermd>
+                                 <ns2:code>N</ns2:code>
+                                 <ns2:omschrijving>Nee</ns2:omschrijving>
+                                 <ns2:referentieType>geenRT</ns2:referentieType>
+                              </ns2:afgeschermd>
+                              <ns2:adres>
+                                 <ns2:binnenlandsAdres>
+                                    <ns2:straatnaam>Aambeeld</ns2:straatnaam>
+                                    <ns2:huisnummer>16</ns2:huisnummer>
+                                    <ns2:postcode>
+                                       <ns2:cijfercombinatie>8307</ns2:cijfercombinatie>
+                                       <ns2:lettercombinatie>EC</ns2:lettercombinatie>
+                                    </ns2:postcode>
+                                    <ns2:plaats>Ens</ns2:plaats>
+                                    <ns2:bagId>
+                                       <ns2:identificatieNummeraanduiding>0171200000022341</ns2:identificatieNummeraanduiding>
+                                       <ns2:identificatieAdresseerbaarObject>0171010000022341</ns2:identificatieAdresseerbaarObject>
+                                    </ns2:bagId>
+                                 </ns2:binnenlandsAdres>
+                              </ns2:adres>
+                              <ns2:volledigAdres>Aambeeld 16
+8307EC Ens</ns2:volledigAdres>
+                           </ns2:bezoekLocatiePersoon>
+                           <!--Anonimisatie 'ns2:bsn': getal is met behoud van vorm vervangen door een hash van van het oorspronkelijke getal.--><ns2:bsn>226360306</ns2:bsn>
+                           <!--Anonimisatie 'ns2:geslachtsnaam': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:geslachtsnaam>523300f</ns2:geslachtsnaam>
+                           <!--Anonimisatie 'ns2:voornamen': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:voornamen>c3d98f6b60 313d18 dc981358</ns2:voornamen>
+                           <ns2:geslachtsaanduiding>
+                              <ns2:code>m</ns2:code>
+                              <ns2:omschrijving>Mannelijk</ns2:omschrijving>
+                              <ns2:referentieType>Geslacht</ns2:referentieType>
+                           </ns2:geslachtsaanduiding>
+                           <!--Anonimisatie 'ns2:geboorteplaats': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:geboorteplaats>47a7e16</ns2:geboorteplaats>
+                           <ns2:geboorteland>
+                              <ns2:code>6030</ns2:code>
+                              <ns2:omschrijving>Nederland</ns2:omschrijving>
+                              <ns2:referentieType>Land</ns2:referentieType>
+                           </ns2:geboorteland>
+                           <!--Anonimisatie 'ns2:geboortedatum': datum is met behoud van vorm vervangen door een hash van de oorspronkelijke datum.--><ns2:geboortedatum>20210127</ns2:geboortedatum>
+                        </ns2:natuurlijkPersoon>
+                     </ns2:door>
+                     <ns2:functie>
+                        <ns2:code>02</ns2:code>
+                        <ns2:omschrijving>Bestuurder</ns2:omschrijving>
+                        <ns2:referentieType>FunctionarisRol</ns2:referentieType>
+                     </ns2:functie>
+                     <ns2:bevoegdheid>
+                        <ns2:registratie registratieTijdstip="20150512155308324">
+                           <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:soort>
+                           <ns2:code>azb</ns2:code>
+                           <ns2:omschrijving>Alleen/zelfstandig bevoegd</ns2:omschrijving>
+                           <ns2:referentieType>SoortBevoegdheidBestuurder</ns2:referentieType>
+                        </ns2:soort>
+                        <ns2:isBevoegdMetAnderePersonen>
+                           <ns2:code>N</ns2:code>
+                           <ns2:omschrijving>Nee</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:isBevoegdMetAnderePersonen>
+                     </ns2:bevoegdheid>
+                  </ns2:bestuursfunctie>
+               </ns2:heeft>
+               <ns2:heeft>
+                  <ns2:overigeFunctionaris>
+                     <ns2:registratie registratieTijdstip="20250731112258783">
+                        <ns2:datumAanvang>20250731</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:door>
+                        <ns2:buitenlandseVennootschap>
+                           <ns2:persoonRechtsvorm>Overige buitenlandse rechtspersoon of vennootschap</ns2:persoonRechtsvorm>
+                           <ns2:volledigeNaam>UAB "MANTINGA GROUP"</ns2:volledigeNaam>
+                           <ns2:bezoekLocatiePersoon>
+                              <ns2:registratie registratieTijdstip="20250731112258783">
+                                 <ns2:datumAanvang>20250731</ns2:datumAanvang>
+                              </ns2:registratie>
+                              <ns2:afgeschermd>
+                                 <ns2:code>N</ns2:code>
+                                 <ns2:omschrijving>Nee</ns2:omschrijving>
+                                 <ns2:referentieType>geenRT</ns2:referentieType>
+                              </ns2:afgeschermd>
+                              <ns2:adres>
+                                 <ns2:buitenlandsAdres>
+                                    <ns2:straatHuisnummer>Stoties g. 51</ns2:straatHuisnummer>
+                                    <ns2:postcodeWoonplaats>LT-68261 Marijampolė</ns2:postcodeWoonplaats>
+                                    <ns2:land>
+                                       <ns2:code>7066</ns2:code>
+                                       <ns2:omschrijving>Litouwen</ns2:omschrijving>
+                                       <ns2:referentieType>Land</ns2:referentieType>
+                                    </ns2:land>
+                                 </ns2:buitenlandsAdres>
+                              </ns2:adres>
+                              <ns2:volledigAdres>Stoties g. 51
+LT-68261 Marijampolė
+Litouwen</ns2:volledigAdres>
+                           </ns2:bezoekLocatiePersoon>
+                           <ns2:buitenlandseRegistratieGegevens>
+                              <ns2:naam>Juridinių asmenų registras</ns2:naam>
+                              <ns2:land>
+                                 <ns2:code>7066</ns2:code>
+                                 <ns2:omschrijving>Litouwen</ns2:omschrijving>
+                                 <ns2:referentieType>Land</ns2:referentieType>
+                              </ns2:land>
+                              <ns2:inschrijfnummer>305572684</ns2:inschrijfnummer>
+                              <ns2:buitenlandseRegistratie>Juridinių asmenų registras
+Litouwen
+Onder nummer 305572684</ns2:buitenlandseRegistratie>
+                           </ns2:buitenlandseRegistratieGegevens>
+                           <ns2:landVanVestiging>
+                              <ns2:code>7066</ns2:code>
+                              <ns2:omschrijving>Litouwen</ns2:omschrijving>
+                              <ns2:referentieType>Land</ns2:referentieType>
+                           </ns2:landVanVestiging>
+                        </ns2:buitenlandseVennootschap>
+                     </ns2:door>
+                     <ns2:functie>
+                        <ns2:code>08</ns2:code>
+                        <ns2:omschrijving>Enig aandeelhouder</ns2:omschrijving>
+                        <ns2:referentieType>FunctionarisRol</ns2:referentieType>
+                     </ns2:functie>
+                  </ns2:overigeFunctionaris>
+               </ns2:heeft>
+               <ns2:rsin>855175904</ns2:rsin>
+               <ns2:naamgeving>
+                  <ns2:registratie registratieTijdstip="20150512155308324">
+                     <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:naam>F&amp;L Sales B.V.</ns2:naam>
+               </ns2:naamgeving>
+               <ns2:heeftGedeponeerd>
+                  <ns2:jaarstukJaarrekening>
+                     <ns2:depotId>7c3c8da4:195ad72b3cb:420</ns2:depotId>
+                     <ns2:soortDeponering>Jaarrekening (art. 394 lid 1 BW2)</ns2:soortDeponering>
+                     <ns2:status>
+                        <ns2:code>1</ns2:code>
+                        <ns2:omschrijving>Actueel</ns2:omschrijving>
+                        <ns2:referentieType>StatusDepotstuk</ns2:referentieType>
+                     </ns2:status>
+                     <ns2:datumDeponering>20250319</ns2:datumDeponering>
+                     <ns2:boekjaar>2024</ns2:boekjaar>
+                     <ns2:datumVaststelling>20250318</ns2:datumVaststelling>
+                     <ns2:vaststelling>
+                        <ns2:code>D</ns2:code>
+                        <ns2:omschrijving>Definitief</ns2:omschrijving>
+                        <ns2:referentieType>VaststellingJaarrekening</ns2:referentieType>
+                     </ns2:vaststelling>
+                     <ns2:grootte>
+                        <ns2:code>klein</ns2:code>
+                        <ns2:omschrijving>Klein</ns2:omschrijving>
+                     </ns2:grootte>
+                     <ns2:buitenlandseJaarrekening>
+                        <ns2:code>N</ns2:code>
+                        <ns2:omschrijving>Nee</ns2:omschrijving>
+                        <ns2:referentieType>geenRT</ns2:referentieType>
+                     </ns2:buitenlandseJaarrekening>
+                  </ns2:jaarstukJaarrekening>
+               </ns2:heeftGedeponeerd>
+               <ns2:rechtsvorm>
+                  <ns2:code>BV</ns2:code>
+                  <ns2:omschrijving>Besloten Vennootschap</ns2:omschrijving>
+                  <ns2:referentieType>Rechtsvorm</ns2:referentieType>
+               </ns2:rechtsvorm>
+               <ns2:statutaireZetel>Dalfsen</ns2:statutaireZetel>
+               <ns2:aanvangStatutaireZetel>20150511</ns2:aanvangStatutaireZetel>
+               <ns2:datumAkteOprichting>20150511</ns2:datumAkteOprichting>
+               <ns2:datumOprichting>20150511</ns2:datumOprichting>
+               <ns2:datumEersteInschrijvingHandelsregister>20150512</ns2:datumEersteInschrijvingHandelsregister>
+               <ns2:datumAkteStatutenwijziging>20150511</ns2:datumAkteStatutenwijziging>
+               <ns2:stelselInrichting>
+                  <ns2:code>D</ns2:code>
+                  <ns2:omschrijving>Dualistisch</ns2:omschrijving>
+                  <ns2:referentieType>StelselInrichting</ns2:referentieType>
+               </ns2:stelselInrichting>
+               <ns2:structuur>
+                  <ns2:code>GS</ns2:code>
+                  <ns2:omschrijving>Gewone structuur</ns2:omschrijving>
+                  <ns2:referentieType>RechtsvormStructuur</ns2:referentieType>
+               </ns2:structuur>
+               <ns2:geplaatstKapitaal>
+                  <ns2:registratie registratieTijdstip="20150512155308324">
+                     <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:bedrag>
+                     <ns2:waarde>10</ns2:waarde>
+                     <ns2:valuta>
+                        <ns2:code>EUR</ns2:code>
+                        <ns2:omschrijving>Euro</ns2:omschrijving>
+                        <ns2:referentieType>Valuta</ns2:referentieType>
+                     </ns2:valuta>
+                  </ns2:bedrag>
+               </ns2:geplaatstKapitaal>
+               <ns2:gestortKapitaal>
+                  <ns2:registratie registratieTijdstip="20150512155308324">
+                     <ns2:datumAanvang>20150511</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:bedrag>
+                     <ns2:waarde>10</ns2:waarde>
+                     <ns2:valuta>
+                        <ns2:code>EUR</ns2:code>
+                        <ns2:omschrijving>Euro</ns2:omschrijving>
+                        <ns2:referentieType>Valuta</ns2:referentieType>
+                     </ns2:valuta>
+                  </ns2:bedrag>
+               </ns2:gestortKapitaal>
+               <ns2:bezoekLocatie>
+                  <ns2:registratie registratieTijdstip="20240722123852318">
+                     <ns2:datumAanvang>20240720</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:afgeschermd>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:afgeschermd>
+                  <ns2:adres>
+                     <ns2:binnenlandsAdres>
+                        <ns2:straatnaam>Aambeeld</ns2:straatnaam>
+                        <ns2:huisnummer>16</ns2:huisnummer>
+                        <ns2:postcode>
+                           <ns2:cijfercombinatie>8307</ns2:cijfercombinatie>
+                           <ns2:lettercombinatie>EC</ns2:lettercombinatie>
+                        </ns2:postcode>
+                        <ns2:plaats>Ens</ns2:plaats>
+                        <ns2:bagId>
+                           <ns2:identificatieNummeraanduiding>0171200000022341</ns2:identificatieNummeraanduiding>
+                           <ns2:identificatieAdresseerbaarObject>0171010000022341</ns2:identificatieAdresseerbaarObject>
+                        </ns2:bagId>
+                     </ns2:binnenlandsAdres>
+                  </ns2:adres>
+                  <ns2:volledigAdres>Aambeeld 16
+8307EC Ens</ns2:volledigAdres>
+               </ns2:bezoekLocatie>
+            </ns2:rechtspersoon>
+         </ns2:heeftAlsEigenaar>
+      </ns2:maatschappelijkeActiviteit>
+   </product>
+</ophalenInschrijvingResponse>

--- a/brmo-loader/src/test/resources/nhr-v3/289541.anon.xml
+++ b/brmo-loader/src/test/resources/nhr-v3/289541.anon.xml
@@ -1,0 +1,591 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Geanonimiseerd door B3Partners BV op 2025-09-09+02:00, zie commentaar in bericht.-->
+<ophalenInschrijvingResponse xmlns="http://schemas.kvk.nl/schemas/hrip/dataservice/2015/02"
+                             xmlns:ns2="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02"
+                             peilmoment="20250818103657584">
+   <meldingen>
+      <informatie>
+         <code>IPD0000</code>
+         <omschrijving>Het product is succesvol geproduceerd</omschrijving>
+         <referentie>39052953</referentie>
+      </informatie>
+   </meldingen>
+   <product>
+      <ns2:maatschappelijkeActiviteit>
+         <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+            <ns2:datumAanvang>19550701</ns2:datumAanvang>
+         </ns2:registratie>
+         <ns2:kvkNummer>39052953</ns2:kvkNummer>
+         <ns2:nonMailing>
+            <ns2:code>N</ns2:code>
+            <ns2:omschrijving>Nee</ns2:omschrijving>
+            <ns2:referentieType>geenRT</ns2:referentieType>
+         </ns2:nonMailing>
+         <ns2:incidenteelUitlenenArbeidskrachten>
+            <ns2:code>N</ns2:code>
+            <ns2:omschrijving>Nee</ns2:omschrijving>
+            <ns2:referentieType>geenRT</ns2:referentieType>
+         </ns2:incidenteelUitlenenArbeidskrachten>
+         <ns2:bezoekLocatie>
+            <ns2:registratie registratieTijdstip="20211201081841176">
+               <ns2:datumAanvang>20211201</ns2:datumAanvang>
+            </ns2:registratie>
+            <ns2:afgeschermd>
+               <ns2:code>N</ns2:code>
+               <ns2:omschrijving>Nee</ns2:omschrijving>
+               <ns2:referentieType>geenRT</ns2:referentieType>
+            </ns2:afgeschermd>
+            <ns2:adres>
+               <ns2:binnenlandsAdres>
+                  <ns2:straatnaam>Edvard Munchweg</ns2:straatnaam>
+                  <ns2:huisnummer>29</ns2:huisnummer>
+                  <ns2:postcode>
+                     <ns2:cijfercombinatie>1328</ns2:cijfercombinatie>
+                     <ns2:lettercombinatie>MA</ns2:lettercombinatie>
+                  </ns2:postcode>
+                  <ns2:plaats>Almere</ns2:plaats>
+                  <ns2:bagId>
+                     <ns2:identificatieNummeraanduiding>0034200000075865</ns2:identificatieNummeraanduiding>
+                     <ns2:identificatieAdresseerbaarObject>0034010000076871</ns2:identificatieAdresseerbaarObject>
+                  </ns2:bagId>
+               </ns2:binnenlandsAdres>
+            </ns2:adres>
+            <ns2:volledigAdres>Edvard Munchweg 29
+1328MA Almere</ns2:volledigAdres>
+         </ns2:bezoekLocatie>
+         <ns2:postLocatie>
+            <ns2:registratie registratieTijdstip="20211201081841176">
+               <ns2:datumAanvang>20211201</ns2:datumAanvang>
+            </ns2:registratie>
+            <ns2:afgeschermd>
+               <ns2:code>N</ns2:code>
+               <ns2:omschrijving>Nee</ns2:omschrijving>
+               <ns2:referentieType>geenRT</ns2:referentieType>
+            </ns2:afgeschermd>
+            <ns2:adres>
+               <ns2:binnenlandsAdres>
+                  <ns2:straatnaam>Edvard Munchweg</ns2:straatnaam>
+                  <ns2:huisnummer>29</ns2:huisnummer>
+                  <ns2:postcode>
+                     <ns2:cijfercombinatie>1328</ns2:cijfercombinatie>
+                     <ns2:lettercombinatie>MA</ns2:lettercombinatie>
+                  </ns2:postcode>
+                  <ns2:plaats>Almere</ns2:plaats>
+                  <ns2:bagId>
+                     <ns2:identificatieNummeraanduiding>0034200000075865</ns2:identificatieNummeraanduiding>
+                     <ns2:identificatieAdresseerbaarObject>0034010000076871</ns2:identificatieAdresseerbaarObject>
+                  </ns2:bagId>
+               </ns2:binnenlandsAdres>
+            </ns2:adres>
+            <ns2:volledigAdres>Edvard Munchweg 29
+1328MA Almere</ns2:volledigAdres>
+         </ns2:postLocatie>
+         <ns2:communicatiegegevens>
+            <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+               <ns2:datumAanvang>19550701</ns2:datumAanvang>
+            </ns2:registratie>
+            <ns2:communicatienummer>
+               <ns2:toegangscode>+31</ns2:toegangscode>
+               <ns2:nummer>0365365483</ns2:nummer>
+               <ns2:soort>
+                  <ns2:code>T</ns2:code>
+                  <ns2:omschrijving>Telefoon</ns2:omschrijving>
+               </ns2:soort>
+            </ns2:communicatienummer>
+            <ns2:emailAdres>info@arntz-nl.com</ns2:emailAdres>
+         </ns2:communicatiegegevens>
+         <ns2:naam>ARNTZ Nederland B.V.</ns2:naam>
+         <ns2:manifesteertZichAls>
+            <ns2:relatieRegistratie registratieTijdstipNoValue="vastgesteldOnbekend">
+               <ns2:datumAanvang>19720911</ns2:datumAanvang>
+            </ns2:relatieRegistratie>
+            <ns2:onderneming>
+               <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                  <ns2:datumAanvang>19550701</ns2:datumAanvang>
+               </ns2:registratie>
+               <ns2:kvkNummer>39052953</ns2:kvkNummer>
+               <ns2:sbiActiviteit>
+                  <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                     <ns2:datumAanvang>19550701</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:sbiCode>
+                     <ns2:code>4662</ns2:code>
+                     <ns2:omschrijving>Groothandel in gereedschapswerktuigen</ns2:omschrijving>
+                     <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                  </ns2:sbiCode>
+                  <ns2:isHoofdactiviteit>
+                     <ns2:code>J</ns2:code>
+                     <ns2:omschrijving>Ja</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:isHoofdactiviteit>
+               </ns2:sbiActiviteit>
+               <ns2:voltijdWerkzamePersonen>21</ns2:voltijdWerkzamePersonen>
+               <ns2:deeltijdWerkzamePersonen>1</ns2:deeltijdWerkzamePersonen>
+               <ns2:totaalWerkzamePersonen>22</ns2:totaalWerkzamePersonen>
+               <ns2:handeltOnder>
+                  <ns2:handelsnaam>
+                     <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                        <ns2:datumAanvang>20001002</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:naam>ARNTZ Nederland B.V.</ns2:naam>
+                     <ns2:volgorde>0</ns2:volgorde>
+                  </ns2:handelsnaam>
+               </ns2:handeltOnder>
+               <ns2:wordtUitgeoefendIn>
+                  <ns2:relatieRegistratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                     <ns2:datumAanvang>19720911</ns2:datumAanvang>
+                  </ns2:relatieRegistratie>
+                  <ns2:commercieleVestiging>
+                     <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                        <ns2:datumAanvang>19550701</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:vestigingsnummer>000018129943</ns2:vestigingsnummer>
+                     <ns2:bezoekLocatie>
+                        <ns2:registratie registratieTijdstip="20211201081841176">
+                           <ns2:datumAanvang>20211201</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:afgeschermd>
+                           <ns2:code>N</ns2:code>
+                           <ns2:omschrijving>Nee</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:afgeschermd>
+                        <ns2:adres>
+                           <ns2:binnenlandsAdres>
+                              <ns2:straatnaam>Edvard Munchweg</ns2:straatnaam>
+                              <ns2:huisnummer>29</ns2:huisnummer>
+                              <ns2:postcode>
+                                 <ns2:cijfercombinatie>1328</ns2:cijfercombinatie>
+                                 <ns2:lettercombinatie>MA</ns2:lettercombinatie>
+                              </ns2:postcode>
+                              <ns2:plaats>Almere</ns2:plaats>
+                              <ns2:bagId>
+                                 <ns2:identificatieNummeraanduiding>0034200000075865</ns2:identificatieNummeraanduiding>
+                                 <ns2:identificatieAdresseerbaarObject>0034010000076871</ns2:identificatieAdresseerbaarObject>
+                              </ns2:bagId>
+                           </ns2:binnenlandsAdres>
+                        </ns2:adres>
+                        <ns2:volledigAdres>Edvard Munchweg 29
+1328MA Almere</ns2:volledigAdres>
+                     </ns2:bezoekLocatie>
+                     <ns2:communicatiegegevens>
+                        <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                           <ns2:datumAanvang>19550701</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:communicatienummer>
+                           <ns2:toegangscode>+31</ns2:toegangscode>
+                           <ns2:nummer>0365365483</ns2:nummer>
+                           <ns2:soort>
+                              <ns2:code>T</ns2:code>
+                              <ns2:omschrijving>Telefoon</ns2:omschrijving>
+                           </ns2:soort>
+                        </ns2:communicatienummer>
+                        <ns2:emailAdres>info@arntz-nl.com</ns2:emailAdres>
+                     </ns2:communicatiegegevens>
+                     <ns2:eersteHandelsnaam>ARNTZ Nederland B.V.</ns2:eersteHandelsnaam>
+                     <ns2:voltijdWerkzamePersonen>21</ns2:voltijdWerkzamePersonen>
+                     <ns2:deeltijdWerkzamePersonen>1</ns2:deeltijdWerkzamePersonen>
+                     <ns2:totaalWerkzamePersonen>22</ns2:totaalWerkzamePersonen>
+                     <ns2:activiteiten>
+                        <ns2:omschrijving>(groot) handel/reparatie van zagen, frezen en aanverwante artikelen.</ns2:omschrijving>
+                        <ns2:sbiActiviteit>
+                           <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                              <ns2:datumAanvang>19550701</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <ns2:sbiCode>
+                              <ns2:code>4662</ns2:code>
+                              <ns2:omschrijving>Groothandel in gereedschapswerktuigen</ns2:omschrijving>
+                              <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                           </ns2:sbiCode>
+                           <ns2:isHoofdactiviteit>
+                              <ns2:code>J</ns2:code>
+                              <ns2:omschrijving>Ja</ns2:omschrijving>
+                              <ns2:referentieType>geenRT</ns2:referentieType>
+                           </ns2:isHoofdactiviteit>
+                        </ns2:sbiActiviteit>
+                        <ns2:exporteert>
+                           <ns2:code>J</ns2:code>
+                           <ns2:omschrijving>Ja</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:exporteert>
+                        <ns2:importeert>
+                           <ns2:code>J</ns2:code>
+                           <ns2:omschrijving>Ja</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:importeert>
+                     </ns2:activiteiten>
+                     <ns2:handeltOnder>
+                        <ns2:relatieRegistratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                           <ns2:datumAanvang>20001002</ns2:datumAanvang>
+                        </ns2:relatieRegistratie>
+                        <ns2:handelsnaam>
+                           <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                              <ns2:datumAanvang>20001002</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <ns2:naam>ARNTZ Nederland B.V.</ns2:naam>
+                           <ns2:volgorde>0</ns2:volgorde>
+                        </ns2:handelsnaam>
+                     </ns2:handeltOnder>
+                  </ns2:commercieleVestiging>
+               </ns2:wordtUitgeoefendIn>
+            </ns2:onderneming>
+         </ns2:manifesteertZichAls>
+         <ns2:wordtGeleidVanuit>
+            <ns2:commercieleVestiging>
+               <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                  <ns2:datumAanvang>19550701</ns2:datumAanvang>
+               </ns2:registratie>
+               <ns2:vestigingsnummer>000018129943</ns2:vestigingsnummer>
+               <ns2:bezoekLocatie>
+                  <ns2:registratie registratieTijdstip="20211201081841176">
+                     <ns2:datumAanvang>20211201</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:afgeschermd>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:afgeschermd>
+                  <ns2:adres>
+                     <ns2:binnenlandsAdres>
+                        <ns2:straatnaam>Edvard Munchweg</ns2:straatnaam>
+                        <ns2:huisnummer>29</ns2:huisnummer>
+                        <ns2:postcode>
+                           <ns2:cijfercombinatie>1328</ns2:cijfercombinatie>
+                           <ns2:lettercombinatie>MA</ns2:lettercombinatie>
+                        </ns2:postcode>
+                        <ns2:plaats>Almere</ns2:plaats>
+                        <ns2:bagId>
+                           <ns2:identificatieNummeraanduiding>0034200000075865</ns2:identificatieNummeraanduiding>
+                           <ns2:identificatieAdresseerbaarObject>0034010000076871</ns2:identificatieAdresseerbaarObject>
+                        </ns2:bagId>
+                     </ns2:binnenlandsAdres>
+                  </ns2:adres>
+                  <ns2:volledigAdres>Edvard Munchweg 29
+1328MA Almere</ns2:volledigAdres>
+               </ns2:bezoekLocatie>
+               <ns2:communicatiegegevens>
+                  <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                     <ns2:datumAanvang>19550701</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:communicatienummer>
+                     <ns2:toegangscode>+31</ns2:toegangscode>
+                     <ns2:nummer>0365365483</ns2:nummer>
+                     <ns2:soort>
+                        <ns2:code>T</ns2:code>
+                        <ns2:omschrijving>Telefoon</ns2:omschrijving>
+                     </ns2:soort>
+                  </ns2:communicatienummer>
+                  <ns2:emailAdres>info@arntz-nl.com</ns2:emailAdres>
+               </ns2:communicatiegegevens>
+               <ns2:eersteHandelsnaam>ARNTZ Nederland B.V.</ns2:eersteHandelsnaam>
+               <ns2:voltijdWerkzamePersonen>21</ns2:voltijdWerkzamePersonen>
+               <ns2:deeltijdWerkzamePersonen>1</ns2:deeltijdWerkzamePersonen>
+               <ns2:totaalWerkzamePersonen>22</ns2:totaalWerkzamePersonen>
+               <ns2:activiteiten>
+                  <ns2:omschrijving>(groot) handel/reparatie van zagen, frezen en aanverwante artikelen.</ns2:omschrijving>
+                  <ns2:sbiActiviteit>
+                     <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                        <ns2:datumAanvang>19550701</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:sbiCode>
+                        <ns2:code>4662</ns2:code>
+                        <ns2:omschrijving>Groothandel in gereedschapswerktuigen</ns2:omschrijving>
+                        <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                     </ns2:sbiCode>
+                     <ns2:isHoofdactiviteit>
+                        <ns2:code>J</ns2:code>
+                        <ns2:omschrijving>Ja</ns2:omschrijving>
+                        <ns2:referentieType>geenRT</ns2:referentieType>
+                     </ns2:isHoofdactiviteit>
+                  </ns2:sbiActiviteit>
+                  <ns2:exporteert>
+                     <ns2:code>J</ns2:code>
+                     <ns2:omschrijving>Ja</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:exporteert>
+                  <ns2:importeert>
+                     <ns2:code>J</ns2:code>
+                     <ns2:omschrijving>Ja</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:importeert>
+               </ns2:activiteiten>
+               <ns2:handeltOnder>
+                  <ns2:relatieRegistratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                     <ns2:datumAanvang>20001002</ns2:datumAanvang>
+                  </ns2:relatieRegistratie>
+                  <ns2:handelsnaam>
+                     <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                        <ns2:datumAanvang>20001002</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:naam>ARNTZ Nederland B.V.</ns2:naam>
+                     <ns2:volgorde>0</ns2:volgorde>
+                  </ns2:handelsnaam>
+               </ns2:handeltOnder>
+            </ns2:commercieleVestiging>
+         </ns2:wordtGeleidVanuit>
+         <ns2:heeftAlsEigenaar>
+            <ns2:relatieRegistratie registratieTijdstipNoValue="vastgesteldOnbekend">
+               <ns2:datumAanvang>19550701</ns2:datumAanvang>
+            </ns2:relatieRegistratie>
+            <ns2:rechtspersoon>
+               <ns2:extraElementen>
+                  <ns2:extraElement naam="datumAanvangStatuten">20001002</ns2:extraElement>
+                  <ns2:extraElement naam="datumAkteStatuten">20001002</ns2:extraElement>
+               </ns2:extraElementen>
+               <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                  <ns2:datumAanvang>19550701</ns2:datumAanvang>
+               </ns2:registratie>
+               <ns2:persoonRechtsvorm>Besloten Vennootschap</ns2:persoonRechtsvorm>
+               <ns2:volledigeNaam>ARNTZ Nederland B.V.</ns2:volledigeNaam>
+               <ns2:uitgebreideRechtsvorm>Besloten Vennootschap</ns2:uitgebreideRechtsvorm>
+               <ns2:heeft>
+                  <ns2:bestuursfunctie>
+                     <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                        <ns2:datumAanvang>19991221</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:functietitel>
+                        <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                           <ns2:datumAanvang>19991221</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:titel>Directeur</ns2:titel>
+                        <ns2:isStatutaireTitel>
+                           <ns2:code>J</ns2:code>
+                           <ns2:omschrijving>Ja</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:isStatutaireTitel>
+                     </ns2:functietitel>
+                     <ns2:door>
+                        <ns2:natuurlijkPersoon>
+                           <ns2:extraElementen>
+<!--Anonimisatie 'ns2:extraElement': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:extraElement naam="achternaam">dc9ea</ns2:extraElement>
+                           </ns2:extraElementen>
+                           <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+<!--Anonimisatie 'ns2:datumAanvang': datum is met behoud van vorm vervangen door een hash van de oorspronkelijke datum.--><ns2:datumAanvang>19670801</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <!--Anonimisatie 'ns2:volledigeNaam': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:volledigeNaam>5d3 29f2e5c 5cd5c</ns2:volledigeNaam>
+                           <ns2:bezoekLocatiePersoon>
+                              <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend"/>
+                              <ns2:afgeschermd>
+                                 <ns2:code>N</ns2:code>
+                                 <ns2:omschrijving>Nee</ns2:omschrijving>
+                                 <ns2:referentieType>geenRT</ns2:referentieType>
+                              </ns2:afgeschermd>
+                              <ns2:adres>
+                                 <ns2:buitenlandsAdres>
+                                    <ns2:straatHuisnummer>Brüderstrasse 53</ns2:straatHuisnummer>
+                                    <ns2:postcodeWoonplaats>D42853 Remscheid</ns2:postcodeWoonplaats>
+                                    <ns2:land>
+                                       <ns2:code>9089</ns2:code>
+                                       <ns2:omschrijving>Bondsrepubliek Duitsland</ns2:omschrijving>
+                                       <ns2:referentieType>Land</ns2:referentieType>
+                                    </ns2:land>
+                                 </ns2:buitenlandsAdres>
+                              </ns2:adres>
+                              <ns2:volledigAdres>Brüderstrasse 53
+D42853 Remscheid
+Bondsrepubliek Duitsland</ns2:volledigAdres>
+                           </ns2:bezoekLocatiePersoon>
+                           <!--Anonimisatie 'ns2:geslachtsnaam': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:geslachtsnaam>dc9ea</ns2:geslachtsnaam>
+                           <!--Anonimisatie 'ns2:voornamen': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:voornamen>d7c 3913ac6</ns2:voornamen>
+                           <ns2:geslachtsaanduiding>
+                              <ns2:code>o</ns2:code>
+                              <ns2:omschrijving>Onbekend</ns2:omschrijving>
+                              <ns2:referentieType>Geslacht</ns2:referentieType>
+                           </ns2:geslachtsaanduiding>
+                           <!--Anonimisatie 'ns2:geboorteplaats': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:geboorteplaats>2f31df10d</ns2:geboorteplaats>
+                           <ns2:geboorteland>
+                              <ns2:code>6029</ns2:code>
+                              <ns2:omschrijving>Duitsland</ns2:omschrijving>
+                              <ns2:referentieType>Land</ns2:referentieType>
+                           </ns2:geboorteland>
+                           <!--Anonimisatie 'ns2:geboortedatum': datum is met behoud van vorm vervangen door een hash van de oorspronkelijke datum.--><ns2:geboortedatum>19670801</ns2:geboortedatum>
+                        </ns2:natuurlijkPersoon>
+                     </ns2:door>
+                     <ns2:functie>
+                        <ns2:code>02</ns2:code>
+                        <ns2:omschrijving>Bestuurder</ns2:omschrijving>
+                        <ns2:referentieType>FunctionarisRol</ns2:referentieType>
+                     </ns2:functie>
+                     <ns2:bevoegdheid>
+                        <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                           <ns2:datumAanvang>19991221</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:soort>
+                           <ns2:code>azb</ns2:code>
+                           <ns2:omschrijving>Alleen/zelfstandig bevoegd</ns2:omschrijving>
+                           <ns2:referentieType>SoortBevoegdheidBestuurder</ns2:referentieType>
+                        </ns2:soort>
+                        <ns2:isBevoegdMetAnderePersonen>
+                           <ns2:code>N</ns2:code>
+                           <ns2:omschrijving>Nee</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:isBevoegdMetAnderePersonen>
+                     </ns2:bevoegdheid>
+                  </ns2:bestuursfunctie>
+               </ns2:heeft>
+               <ns2:heeft>
+                  <ns2:overigeFunctionaris>
+                     <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                        <ns2:datumAanvang>20100108</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:door>
+                        <ns2:buitenlandseVennootschap>
+                           <ns2:persoonRechtsvorm>Overige buitenlandse rechtspersoon of vennootschap</ns2:persoonRechtsvorm>
+                           <ns2:volledigeNaam>Jan Wilhelm Arntz GmbH + Co.KG</ns2:volledigeNaam>
+                           <ns2:bezoekLocatiePersoon>
+                              <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend"/>
+                              <ns2:afgeschermd>
+                                 <ns2:code>N</ns2:code>
+                                 <ns2:omschrijving>Nee</ns2:omschrijving>
+                                 <ns2:referentieType>geenRT</ns2:referentieType>
+                              </ns2:afgeschermd>
+                              <ns2:adres>
+                                 <ns2:buitenlandsAdres>
+                                    <ns2:straatHuisnummer>Brüderstrasse 53</ns2:straatHuisnummer>
+                                    <ns2:postcodeWoonplaats>42853 Remscheid</ns2:postcodeWoonplaats>
+                                    <ns2:land>
+                                       <ns2:code>9089</ns2:code>
+                                       <ns2:omschrijving>Bondsrepubliek Duitsland</ns2:omschrijving>
+                                       <ns2:referentieType>Land</ns2:referentieType>
+                                    </ns2:land>
+                                 </ns2:buitenlandsAdres>
+                              </ns2:adres>
+                              <ns2:volledigAdres>Brüderstrasse 53
+42853 Remscheid
+Bondsrepubliek Duitsland</ns2:volledigAdres>
+                           </ns2:bezoekLocatiePersoon>
+                           <ns2:buitenlandseRegistratieGegevens>
+                              <ns2:naam>Wuppertal - Handelsregister</ns2:naam>
+                              <ns2:plaats>Wuppertal</ns2:plaats>
+                              <ns2:land>
+                                 <ns2:code>9089</ns2:code>
+                                 <ns2:omschrijving>Bondsrepubliek Duitsland</ns2:omschrijving>
+                                 <ns2:referentieType>Land</ns2:referentieType>
+                              </ns2:land>
+                              <ns2:inschrijfnummer>HRA 22905</ns2:inschrijfnummer>
+                              <ns2:buitenlandseRegistratie>Wuppertal - Handelsregister
+Wuppertal, Bondsrepubliek Duitsland
+Onder nummer HRA 22905</ns2:buitenlandseRegistratie>
+                           </ns2:buitenlandseRegistratieGegevens>
+                           <ns2:landVanVestiging>
+                              <ns2:code>9089</ns2:code>
+                              <ns2:omschrijving>Bondsrepubliek Duitsland</ns2:omschrijving>
+                              <ns2:referentieType>Land</ns2:referentieType>
+                           </ns2:landVanVestiging>
+                        </ns2:buitenlandseVennootschap>
+                     </ns2:door>
+                     <ns2:functie>
+                        <ns2:code>08</ns2:code>
+                        <ns2:omschrijving>Enig aandeelhouder</ns2:omschrijving>
+                        <ns2:referentieType>FunctionarisRol</ns2:referentieType>
+                     </ns2:functie>
+                  </ns2:overigeFunctionaris>
+               </ns2:heeft>
+               <ns2:rsin>001066845</ns2:rsin>
+               <ns2:naamgeving>
+                  <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+                     <ns2:datumAanvang>20001002</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:naam>ARNTZ Nederland B.V.</ns2:naam>
+               </ns2:naamgeving>
+               <ns2:heeftGedeponeerd>
+                  <ns2:jaarstukJaarrekening>
+                     <ns2:depotId>244627:179e584e372:-4d78</ns2:depotId>
+                     <ns2:soortDeponering>Jaarrekening (art. 394 lid 1 BW2)</ns2:soortDeponering>
+                     <ns2:status>
+                        <ns2:code>1</ns2:code>
+                        <ns2:omschrijving>Actueel</ns2:omschrijving>
+                        <ns2:referentieType>StatusDepotstuk</ns2:referentieType>
+                     </ns2:status>
+                     <ns2:datumDeponering>20210607</ns2:datumDeponering>
+                     <ns2:boekjaar>2020</ns2:boekjaar>
+                     <ns2:datumVaststelling>20210520</ns2:datumVaststelling>
+                     <ns2:vaststelling>
+                        <ns2:code>D</ns2:code>
+                        <ns2:omschrijving>Definitief</ns2:omschrijving>
+                        <ns2:referentieType>VaststellingJaarrekening</ns2:referentieType>
+                     </ns2:vaststelling>
+                     <ns2:grootte>
+                        <ns2:code>klein</ns2:code>
+                        <ns2:omschrijving>Klein</ns2:omschrijving>
+                     </ns2:grootte>
+                     <ns2:buitenlandseJaarrekening>
+                        <ns2:code>N</ns2:code>
+                        <ns2:omschrijving>Nee</ns2:omschrijving>
+                        <ns2:referentieType>geenRT</ns2:referentieType>
+                     </ns2:buitenlandseJaarrekening>
+                  </ns2:jaarstukJaarrekening>
+               </ns2:heeftGedeponeerd>
+               <ns2:rechtsvorm>
+                  <ns2:code>BV</ns2:code>
+                  <ns2:omschrijving>Besloten Vennootschap</ns2:omschrijving>
+                  <ns2:referentieType>Rechtsvorm</ns2:referentieType>
+               </ns2:rechtsvorm>
+               <ns2:statutaireZetel>Almere</ns2:statutaireZetel>
+               <ns2:aanvangStatutaireZetel>19550701</ns2:aanvangStatutaireZetel>
+               <ns2:datumAkteOprichting>19550701</ns2:datumAkteOprichting>
+               <ns2:datumEersteInschrijvingHandelsregister>19551121</ns2:datumEersteInschrijvingHandelsregister>
+               <ns2:datumAkteStatutenwijziging>20001002</ns2:datumAkteStatutenwijziging>
+               <ns2:stelselInrichting>
+                  <ns2:code>D</ns2:code>
+                  <ns2:omschrijving>Dualistisch</ns2:omschrijving>
+                  <ns2:referentieType>StelselInrichting</ns2:referentieType>
+               </ns2:stelselInrichting>
+               <ns2:structuur>
+                  <ns2:code>GS</ns2:code>
+                  <ns2:omschrijving>Gewone structuur</ns2:omschrijving>
+                  <ns2:referentieType>RechtsvormStructuur</ns2:referentieType>
+               </ns2:structuur>
+               <ns2:geplaatstKapitaal>
+                  <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend"/>
+                  <ns2:bedrag>
+                     <ns2:waarde>113445.05</ns2:waarde>
+                     <ns2:valuta>
+                        <ns2:code>EUR</ns2:code>
+                        <ns2:omschrijving>Euro</ns2:omschrijving>
+                        <ns2:referentieType>Valuta</ns2:referentieType>
+                     </ns2:valuta>
+                  </ns2:bedrag>
+               </ns2:geplaatstKapitaal>
+               <ns2:gestortKapitaal>
+                  <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend"/>
+                  <ns2:bedrag>
+                     <ns2:waarde>113445.05</ns2:waarde>
+                     <ns2:valuta>
+                        <ns2:code>EUR</ns2:code>
+                        <ns2:omschrijving>Euro</ns2:omschrijving>
+                        <ns2:referentieType>Valuta</ns2:referentieType>
+                     </ns2:valuta>
+                  </ns2:bedrag>
+               </ns2:gestortKapitaal>
+               <ns2:bezoekLocatie>
+                  <ns2:registratie registratieTijdstip="20211201081841176">
+                     <ns2:datumAanvang>20211201</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:afgeschermd>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:afgeschermd>
+                  <ns2:adres>
+                     <ns2:binnenlandsAdres>
+                        <ns2:straatnaam>Edvard Munchweg</ns2:straatnaam>
+                        <ns2:huisnummer>29</ns2:huisnummer>
+                        <ns2:postcode>
+                           <ns2:cijfercombinatie>1328</ns2:cijfercombinatie>
+                           <ns2:lettercombinatie>MA</ns2:lettercombinatie>
+                        </ns2:postcode>
+                        <ns2:plaats>Almere</ns2:plaats>
+                        <ns2:bagId>
+                           <ns2:identificatieNummeraanduiding>0034200000075865</ns2:identificatieNummeraanduiding>
+                           <ns2:identificatieAdresseerbaarObject>0034010000076871</ns2:identificatieAdresseerbaarObject>
+                        </ns2:bagId>
+                     </ns2:binnenlandsAdres>
+                  </ns2:adres>
+                  <ns2:volledigAdres>Edvard Munchweg 29
+1328MA Almere</ns2:volledigAdres>
+               </ns2:bezoekLocatie>
+            </ns2:rechtspersoon>
+         </ns2:heeftAlsEigenaar>
+      </ns2:maatschappelijkeActiviteit>
+   </product>
+</ophalenInschrijvingResponse>

--- a/brmo-loader/src/test/resources/nhr-v3/289544.anon.xml
+++ b/brmo-loader/src/test/resources/nhr-v3/289544.anon.xml
@@ -1,0 +1,755 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Geanonimiseerd door B3Partners BV op 2025-09-09+02:00, zie commentaar in bericht.-->
+<ophalenInschrijvingResponse xmlns="http://schemas.kvk.nl/schemas/hrip/dataservice/2015/02"
+                             xmlns:ns2="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02"
+                             peilmoment="20250818103657584">
+   <meldingen>
+      <informatie>
+         <code>IPD0000</code>
+         <omschrijving>Het product is succesvol geproduceerd</omschrijving>
+         <referentie>93152825</referentie>
+      </informatie>
+   </meldingen>
+   <product>
+      <ns2:maatschappelijkeActiviteit>
+         <ns2:registratie registratieTijdstip="20240304162304948">
+            <ns2:datumAanvang>20240304</ns2:datumAanvang>
+         </ns2:registratie>
+         <ns2:kvkNummer>93152825</ns2:kvkNummer>
+         <ns2:nonMailing>
+            <ns2:code>J</ns2:code>
+            <ns2:omschrijving>Ja</ns2:omschrijving>
+            <ns2:referentieType>geenRT</ns2:referentieType>
+         </ns2:nonMailing>
+         <ns2:incidenteelUitlenenArbeidskrachten>
+            <ns2:code>N</ns2:code>
+            <ns2:omschrijving>Nee</ns2:omschrijving>
+            <ns2:referentieType>geenRT</ns2:referentieType>
+         </ns2:incidenteelUitlenenArbeidskrachten>
+         <ns2:bezoekLocatie>
+            <ns2:registratie registratieTijdstip="20240304162304948">
+               <ns2:datumAanvang>20240304</ns2:datumAanvang>
+            </ns2:registratie>
+            <ns2:afgeschermd>
+               <ns2:code>N</ns2:code>
+               <ns2:omschrijving>Nee</ns2:omschrijving>
+               <ns2:referentieType>geenRT</ns2:referentieType>
+            </ns2:afgeschermd>
+            <ns2:adres>
+               <ns2:binnenlandsAdres>
+                  <ns2:straatnaam>Buster Keatonstraat</ns2:straatnaam>
+                  <ns2:huisnummer>9</ns2:huisnummer>
+                  <ns2:postcode>
+                     <ns2:cijfercombinatie>1325</ns2:cijfercombinatie>
+                     <ns2:lettercombinatie>CJ</ns2:lettercombinatie>
+                  </ns2:postcode>
+                  <ns2:plaats>Almere</ns2:plaats>
+                  <ns2:bagId>
+                     <ns2:identificatieNummeraanduiding>0034200000041060</ns2:identificatieNummeraanduiding>
+                     <ns2:identificatieAdresseerbaarObject>0034010000067741</ns2:identificatieAdresseerbaarObject>
+                  </ns2:bagId>
+               </ns2:binnenlandsAdres>
+            </ns2:adres>
+            <ns2:volledigAdres>Buster Keatonstraat 9
+1325CJ Almere</ns2:volledigAdres>
+         </ns2:bezoekLocatie>
+         <ns2:postLocatie>
+            <ns2:registratie registratieTijdstip="20240304162304948">
+               <ns2:datumAanvang>20240304</ns2:datumAanvang>
+            </ns2:registratie>
+            <ns2:afgeschermd>
+               <ns2:code>N</ns2:code>
+               <ns2:omschrijving>Nee</ns2:omschrijving>
+               <ns2:referentieType>geenRT</ns2:referentieType>
+            </ns2:afgeschermd>
+            <ns2:adres>
+               <ns2:binnenlandsAdres>
+                  <ns2:straatnaam>Buster Keatonstraat</ns2:straatnaam>
+                  <ns2:huisnummer>9</ns2:huisnummer>
+                  <ns2:postcode>
+                     <ns2:cijfercombinatie>1325</ns2:cijfercombinatie>
+                     <ns2:lettercombinatie>CJ</ns2:lettercombinatie>
+                  </ns2:postcode>
+                  <ns2:plaats>Almere</ns2:plaats>
+                  <ns2:bagId>
+                     <ns2:identificatieNummeraanduiding>0034200000041060</ns2:identificatieNummeraanduiding>
+                     <ns2:identificatieAdresseerbaarObject>0034010000067741</ns2:identificatieAdresseerbaarObject>
+                  </ns2:bagId>
+               </ns2:binnenlandsAdres>
+            </ns2:adres>
+            <ns2:volledigAdres>Buster Keatonstraat 9
+1325CJ Almere</ns2:volledigAdres>
+         </ns2:postLocatie>
+         <ns2:naam>KESER Industrial Solutions B.V.</ns2:naam>
+         <ns2:manifesteertZichAls>
+            <ns2:relatieRegistratie registratieTijdstip="20240304162304948">
+               <ns2:datumAanvang>20240304</ns2:datumAanvang>
+            </ns2:relatieRegistratie>
+            <ns2:onderneming>
+               <ns2:registratie registratieTijdstip="20240304162304948">
+                  <ns2:datumAanvang>20240304</ns2:datumAanvang>
+               </ns2:registratie>
+               <ns2:kvkNummer>93152825</ns2:kvkNummer>
+               <ns2:sbiActiviteit>
+                  <ns2:registratie registratieTijdstip="20240304162304948">
+                     <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:sbiCode>
+                     <ns2:code>7112</ns2:code>
+                     <ns2:omschrijving>Ingenieurs en overig technisch ontwerp en advies</ns2:omschrijving>
+                     <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                  </ns2:sbiCode>
+                  <ns2:isHoofdactiviteit>
+                     <ns2:code>J</ns2:code>
+                     <ns2:omschrijving>Ja</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:isHoofdactiviteit>
+               </ns2:sbiActiviteit>
+               <ns2:sbiActiviteit>
+                  <ns2:registratie registratieTijdstip="20240304162304948">
+                     <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:sbiCode>
+                     <ns2:code>4120</ns2:code>
+                     <ns2:omschrijving>Algemene burgerlijke en utiliteitsbouw</ns2:omschrijving>
+                     <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                  </ns2:sbiCode>
+                  <ns2:isHoofdactiviteit>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:isHoofdactiviteit>
+               </ns2:sbiActiviteit>
+               <ns2:sbiActiviteit>
+                  <ns2:registratie registratieTijdstip="20240304162304948">
+                     <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:sbiCode>
+                     <ns2:code>2511</ns2:code>
+                     <ns2:omschrijving>Vervaardiging van metalen constructiewerken en delen daarvan</ns2:omschrijving>
+                     <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                  </ns2:sbiCode>
+                  <ns2:isHoofdactiviteit>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:isHoofdactiviteit>
+               </ns2:sbiActiviteit>
+               <ns2:voltijdWerkzamePersonen>0</ns2:voltijdWerkzamePersonen>
+               <ns2:deeltijdWerkzamePersonen>0</ns2:deeltijdWerkzamePersonen>
+               <ns2:totaalWerkzamePersonen>0</ns2:totaalWerkzamePersonen>
+               <ns2:handeltOnder>
+                  <ns2:handelsnaam>
+                     <ns2:registratie registratieTijdstip="20240304162304948">
+                        <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:naam>KESER Industrial Solutions B.V.</ns2:naam>
+                     <ns2:volgorde>0</ns2:volgorde>
+                  </ns2:handelsnaam>
+               </ns2:handeltOnder>
+               <ns2:wordtUitgeoefendIn>
+                  <ns2:relatieRegistratie registratieTijdstip="20240304162304948">
+                     <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                  </ns2:relatieRegistratie>
+                  <ns2:commercieleVestiging>
+                     <ns2:registratie registratieTijdstip="20240304162304948">
+                        <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:vestigingsnummer>000058716262</ns2:vestigingsnummer>
+                     <ns2:bezoekLocatie>
+                        <ns2:registratie registratieTijdstip="20240304162304948">
+                           <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:afgeschermd>
+                           <ns2:code>N</ns2:code>
+                           <ns2:omschrijving>Nee</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:afgeschermd>
+                        <ns2:adres>
+                           <ns2:binnenlandsAdres>
+                              <ns2:straatnaam>Buster Keatonstraat</ns2:straatnaam>
+                              <ns2:huisnummer>9</ns2:huisnummer>
+                              <ns2:postcode>
+                                 <ns2:cijfercombinatie>1325</ns2:cijfercombinatie>
+                                 <ns2:lettercombinatie>CJ</ns2:lettercombinatie>
+                              </ns2:postcode>
+                              <ns2:plaats>Almere</ns2:plaats>
+                              <ns2:bagId>
+                                 <ns2:identificatieNummeraanduiding>0034200000041060</ns2:identificatieNummeraanduiding>
+                                 <ns2:identificatieAdresseerbaarObject>0034010000067741</ns2:identificatieAdresseerbaarObject>
+                              </ns2:bagId>
+                           </ns2:binnenlandsAdres>
+                        </ns2:adres>
+                        <ns2:volledigAdres>Buster Keatonstraat 9
+1325CJ Almere</ns2:volledigAdres>
+                     </ns2:bezoekLocatie>
+                     <ns2:eersteHandelsnaam>KESER Industrial Solutions B.V.</ns2:eersteHandelsnaam>
+                     <ns2:voltijdWerkzamePersonen>0</ns2:voltijdWerkzamePersonen>
+                     <ns2:deeltijdWerkzamePersonen>0</ns2:deeltijdWerkzamePersonen>
+                     <ns2:totaalWerkzamePersonen>0</ns2:totaalWerkzamePersonen>
+                     <ns2:activiteiten>
+                        <ns2:omschrijving>Het leveren van diensten op het gebied van installatie, supervisie, advies, ontwerp en materiaallevering van industriële bekledingen, alsmede het uitvoeren van industriële en civiele bouwwerken, mechanische montagewerken en staalwerken.</ns2:omschrijving>
+                        <ns2:sbiActiviteit>
+                           <ns2:registratie registratieTijdstip="20240304162304948">
+                              <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <ns2:sbiCode>
+                              <ns2:code>7112</ns2:code>
+                              <ns2:omschrijving>Ingenieurs en overig technisch ontwerp en advies</ns2:omschrijving>
+                              <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                           </ns2:sbiCode>
+                           <ns2:isHoofdactiviteit>
+                              <ns2:code>J</ns2:code>
+                              <ns2:omschrijving>Ja</ns2:omschrijving>
+                              <ns2:referentieType>geenRT</ns2:referentieType>
+                           </ns2:isHoofdactiviteit>
+                        </ns2:sbiActiviteit>
+                        <ns2:sbiActiviteit>
+                           <ns2:registratie registratieTijdstip="20240304162304948">
+                              <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <ns2:sbiCode>
+                              <ns2:code>4120</ns2:code>
+                              <ns2:omschrijving>Algemene burgerlijke en utiliteitsbouw</ns2:omschrijving>
+                              <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                           </ns2:sbiCode>
+                           <ns2:isHoofdactiviteit>
+                              <ns2:code>N</ns2:code>
+                              <ns2:omschrijving>Nee</ns2:omschrijving>
+                              <ns2:referentieType>geenRT</ns2:referentieType>
+                           </ns2:isHoofdactiviteit>
+                        </ns2:sbiActiviteit>
+                        <ns2:sbiActiviteit>
+                           <ns2:registratie registratieTijdstip="20240304162304948">
+                              <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <ns2:sbiCode>
+                              <ns2:code>2511</ns2:code>
+                              <ns2:omschrijving>Vervaardiging van metalen constructiewerken en delen daarvan</ns2:omschrijving>
+                              <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                           </ns2:sbiCode>
+                           <ns2:isHoofdactiviteit>
+                              <ns2:code>N</ns2:code>
+                              <ns2:omschrijving>Nee</ns2:omschrijving>
+                              <ns2:referentieType>geenRT</ns2:referentieType>
+                           </ns2:isHoofdactiviteit>
+                        </ns2:sbiActiviteit>
+                        <ns2:exporteert>
+                           <ns2:code>N</ns2:code>
+                           <ns2:omschrijving>Nee</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:exporteert>
+                        <ns2:importeert>
+                           <ns2:code>N</ns2:code>
+                           <ns2:omschrijving>Nee</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:importeert>
+                     </ns2:activiteiten>
+                     <ns2:handeltOnder>
+                        <ns2:relatieRegistratie registratieTijdstip="20240304162304948">
+                           <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                        </ns2:relatieRegistratie>
+                        <ns2:handelsnaam>
+                           <ns2:registratie registratieTijdstip="20240304162304948">
+                              <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <ns2:naam>KESER Industrial Solutions B.V.</ns2:naam>
+                           <ns2:volgorde>0</ns2:volgorde>
+                        </ns2:handelsnaam>
+                     </ns2:handeltOnder>
+                  </ns2:commercieleVestiging>
+               </ns2:wordtUitgeoefendIn>
+            </ns2:onderneming>
+         </ns2:manifesteertZichAls>
+         <ns2:wordtGeleidVanuit>
+            <ns2:commercieleVestiging>
+               <ns2:registratie registratieTijdstip="20240304162304948">
+                  <ns2:datumAanvang>20240304</ns2:datumAanvang>
+               </ns2:registratie>
+               <ns2:vestigingsnummer>000058716262</ns2:vestigingsnummer>
+               <ns2:bezoekLocatie>
+                  <ns2:registratie registratieTijdstip="20240304162304948">
+                     <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:afgeschermd>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:afgeschermd>
+                  <ns2:adres>
+                     <ns2:binnenlandsAdres>
+                        <ns2:straatnaam>Buster Keatonstraat</ns2:straatnaam>
+                        <ns2:huisnummer>9</ns2:huisnummer>
+                        <ns2:postcode>
+                           <ns2:cijfercombinatie>1325</ns2:cijfercombinatie>
+                           <ns2:lettercombinatie>CJ</ns2:lettercombinatie>
+                        </ns2:postcode>
+                        <ns2:plaats>Almere</ns2:plaats>
+                        <ns2:bagId>
+                           <ns2:identificatieNummeraanduiding>0034200000041060</ns2:identificatieNummeraanduiding>
+                           <ns2:identificatieAdresseerbaarObject>0034010000067741</ns2:identificatieAdresseerbaarObject>
+                        </ns2:bagId>
+                     </ns2:binnenlandsAdres>
+                  </ns2:adres>
+                  <ns2:volledigAdres>Buster Keatonstraat 9
+1325CJ Almere</ns2:volledigAdres>
+               </ns2:bezoekLocatie>
+               <ns2:eersteHandelsnaam>KESER Industrial Solutions B.V.</ns2:eersteHandelsnaam>
+               <ns2:voltijdWerkzamePersonen>0</ns2:voltijdWerkzamePersonen>
+               <ns2:deeltijdWerkzamePersonen>0</ns2:deeltijdWerkzamePersonen>
+               <ns2:totaalWerkzamePersonen>0</ns2:totaalWerkzamePersonen>
+               <ns2:activiteiten>
+                  <ns2:omschrijving>Het leveren van diensten op het gebied van installatie, supervisie, advies, ontwerp en materiaallevering van industriële bekledingen, alsmede het uitvoeren van industriële en civiele bouwwerken, mechanische montagewerken en staalwerken.</ns2:omschrijving>
+                  <ns2:sbiActiviteit>
+                     <ns2:registratie registratieTijdstip="20240304162304948">
+                        <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:sbiCode>
+                        <ns2:code>7112</ns2:code>
+                        <ns2:omschrijving>Ingenieurs en overig technisch ontwerp en advies</ns2:omschrijving>
+                        <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                     </ns2:sbiCode>
+                     <ns2:isHoofdactiviteit>
+                        <ns2:code>J</ns2:code>
+                        <ns2:omschrijving>Ja</ns2:omschrijving>
+                        <ns2:referentieType>geenRT</ns2:referentieType>
+                     </ns2:isHoofdactiviteit>
+                  </ns2:sbiActiviteit>
+                  <ns2:sbiActiviteit>
+                     <ns2:registratie registratieTijdstip="20240304162304948">
+                        <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:sbiCode>
+                        <ns2:code>4120</ns2:code>
+                        <ns2:omschrijving>Algemene burgerlijke en utiliteitsbouw</ns2:omschrijving>
+                        <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                     </ns2:sbiCode>
+                     <ns2:isHoofdactiviteit>
+                        <ns2:code>N</ns2:code>
+                        <ns2:omschrijving>Nee</ns2:omschrijving>
+                        <ns2:referentieType>geenRT</ns2:referentieType>
+                     </ns2:isHoofdactiviteit>
+                  </ns2:sbiActiviteit>
+                  <ns2:sbiActiviteit>
+                     <ns2:registratie registratieTijdstip="20240304162304948">
+                        <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:sbiCode>
+                        <ns2:code>2511</ns2:code>
+                        <ns2:omschrijving>Vervaardiging van metalen constructiewerken en delen daarvan</ns2:omschrijving>
+                        <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                     </ns2:sbiCode>
+                     <ns2:isHoofdactiviteit>
+                        <ns2:code>N</ns2:code>
+                        <ns2:omschrijving>Nee</ns2:omschrijving>
+                        <ns2:referentieType>geenRT</ns2:referentieType>
+                     </ns2:isHoofdactiviteit>
+                  </ns2:sbiActiviteit>
+                  <ns2:exporteert>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:exporteert>
+                  <ns2:importeert>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:importeert>
+               </ns2:activiteiten>
+               <ns2:handeltOnder>
+                  <ns2:relatieRegistratie registratieTijdstip="20240304162304948">
+                     <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                  </ns2:relatieRegistratie>
+                  <ns2:handelsnaam>
+                     <ns2:registratie registratieTijdstip="20240304162304948">
+                        <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:naam>KESER Industrial Solutions B.V.</ns2:naam>
+                     <ns2:volgorde>0</ns2:volgorde>
+                  </ns2:handelsnaam>
+               </ns2:handeltOnder>
+            </ns2:commercieleVestiging>
+         </ns2:wordtGeleidVanuit>
+         <ns2:heeftAlsEigenaar>
+            <ns2:relatieRegistratie registratieTijdstip="20240304162304948">
+               <ns2:datumAanvang>20240304</ns2:datumAanvang>
+            </ns2:relatieRegistratie>
+            <ns2:rechtspersoon>
+               <ns2:extraElementen>
+                  <ns2:extraElement naam="datumAanvangStatuten">20240304</ns2:extraElement>
+                  <ns2:extraElement naam="datumAkteStatuten">20240304</ns2:extraElement>
+               </ns2:extraElementen>
+               <ns2:registratie registratieTijdstip="20240304162304948">
+                  <ns2:datumAanvang>20240304</ns2:datumAanvang>
+               </ns2:registratie>
+               <ns2:persoonRechtsvorm>Besloten Vennootschap</ns2:persoonRechtsvorm>
+               <ns2:volledigeNaam>KESER Industrial Solutions B.V.</ns2:volledigeNaam>
+               <ns2:uitgebreideRechtsvorm>Besloten Vennootschap</ns2:uitgebreideRechtsvorm>
+               <ns2:heeft>
+                  <ns2:bestuursfunctie>
+                     <ns2:registratie registratieTijdstip="20240304162304948">
+                        <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:door>
+                        <ns2:natuurlijkPersoon>
+                           <ns2:extraElementen>
+<!--Anonimisatie 'ns2:extraElement': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:extraElement naam="achternaam">6ac96</ns2:extraElement>
+                           </ns2:extraElementen>
+                           <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+<!--Anonimisatie 'ns2:datumAanvang': datum is met behoud van vorm vervangen door een hash van de oorspronkelijke datum.--><ns2:datumAanvang>19481109</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <!--Anonimisatie 'ns2:volledigeNaam': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:volledigeNaam>2e5f27 ba3fb</ns2:volledigeNaam>
+                           <ns2:bezoekLocatiePersoon>
+                              <ns2:registratie registratieTijdstip="20240304162304948"/>
+                              <ns2:afgeschermd>
+                                 <ns2:code>N</ns2:code>
+                                 <ns2:omschrijving>Nee</ns2:omschrijving>
+                                 <ns2:referentieType>geenRT</ns2:referentieType>
+                              </ns2:afgeschermd>
+                              <ns2:adres>
+                                 <ns2:buitenlandsAdres>
+                                    <ns2:straatHuisnummer>Sinanoba Mahallesi, Bektaș Çikmazi Sokak No: 5D</ns2:straatHuisnummer>
+                                    <ns2:postcodeWoonplaats>Büyükçekmece, Istanbul</ns2:postcodeWoonplaats>
+                                    <ns2:land>
+                                       <ns2:code>6043</ns2:code>
+                                       <ns2:omschrijving>Turkije</ns2:omschrijving>
+                                       <ns2:referentieType>Land</ns2:referentieType>
+                                    </ns2:land>
+                                 </ns2:buitenlandsAdres>
+                              </ns2:adres>
+                              <ns2:volledigAdres>Sinanoba Mahallesi, Bektaș Çikmazi Sokak No: 5D
+Büyükçekmece, Istanbul
+Turkije</ns2:volledigAdres>
+                           </ns2:bezoekLocatiePersoon>
+                           <!--Anonimisatie 'ns2:geslachtsnaam': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:geslachtsnaam>6ac96</ns2:geslachtsnaam>
+                           <!--Anonimisatie 'ns2:voornamen': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:voornamen>f36baa</ns2:voornamen>
+                           <ns2:geslachtsaanduiding>
+                              <ns2:code>m</ns2:code>
+                              <ns2:omschrijving>Mannelijk</ns2:omschrijving>
+                              <ns2:referentieType>Geslacht</ns2:referentieType>
+                           </ns2:geslachtsaanduiding>
+                           <!--Anonimisatie 'ns2:geboorteplaats': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:geboorteplaats>2ec2594</ns2:geboorteplaats>
+                           <ns2:geboorteland>
+                              <ns2:code>6043</ns2:code>
+                              <ns2:omschrijving>Turkije</ns2:omschrijving>
+                              <ns2:referentieType>Land</ns2:referentieType>
+                           </ns2:geboorteland>
+                           <!--Anonimisatie 'ns2:geboortedatum': datum is met behoud van vorm vervangen door een hash van de oorspronkelijke datum.--><ns2:geboortedatum>19481109</ns2:geboortedatum>
+                        </ns2:natuurlijkPersoon>
+                     </ns2:door>
+                     <ns2:functie>
+                        <ns2:code>02</ns2:code>
+                        <ns2:omschrijving>Bestuurder</ns2:omschrijving>
+                        <ns2:referentieType>FunctionarisRol</ns2:referentieType>
+                     </ns2:functie>
+                     <ns2:bevoegdheid>
+                        <ns2:registratie registratieTijdstip="20240304162304948">
+                           <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:soort>
+                           <ns2:code>azb</ns2:code>
+                           <ns2:omschrijving>Alleen/zelfstandig bevoegd</ns2:omschrijving>
+                           <ns2:referentieType>SoortBevoegdheidBestuurder</ns2:referentieType>
+                        </ns2:soort>
+                        <ns2:isBevoegdMetAnderePersonen>
+                           <ns2:code>N</ns2:code>
+                           <ns2:omschrijving>Nee</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:isBevoegdMetAnderePersonen>
+                     </ns2:bevoegdheid>
+                  </ns2:bestuursfunctie>
+               </ns2:heeft>
+               <ns2:heeft>
+                  <ns2:bestuursfunctie>
+                     <ns2:registratie registratieTijdstip="20240304162304948">
+                        <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:door>
+                        <ns2:natuurlijkPersoon>
+                           <ns2:extraElementen>
+<!--Anonimisatie 'ns2:extraElement': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:extraElement naam="achternaam">6ac96</ns2:extraElement>
+                           </ns2:extraElementen>
+                           <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+<!--Anonimisatie 'ns2:datumAanvang': datum is met behoud van vorm vervangen door een hash van de oorspronkelijke datum.--><ns2:datumAanvang>20230204</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <!--Anonimisatie 'ns2:volledigeNaam': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:volledigeNaam>ae584 bd0a de969</ns2:volledigeNaam>
+                           <ns2:bezoekLocatiePersoon>
+                              <ns2:registratie registratieTijdstip="20240304162304948"/>
+                              <ns2:afgeschermd>
+                                 <ns2:code>N</ns2:code>
+                                 <ns2:omschrijving>Nee</ns2:omschrijving>
+                                 <ns2:referentieType>geenRT</ns2:referentieType>
+                              </ns2:afgeschermd>
+                              <ns2:adres>
+                                 <ns2:buitenlandsAdres>
+                                    <ns2:straatHuisnummer>Erenköy Mahallesi, Azim Sokak Murat Apt. No:4, Iç Kapi No:2</ns2:straatHuisnummer>
+                                    <ns2:postcodeWoonplaats>Kadiköy, Istanbul</ns2:postcodeWoonplaats>
+                                    <ns2:land>
+                                       <ns2:code>6043</ns2:code>
+                                       <ns2:omschrijving>Turkije</ns2:omschrijving>
+                                       <ns2:referentieType>Land</ns2:referentieType>
+                                    </ns2:land>
+                                 </ns2:buitenlandsAdres>
+                              </ns2:adres>
+                              <ns2:volledigAdres>Erenköy Mahallesi, Azim Sokak Murat Apt. No:4, Iç Kapi No:2
+Kadiköy, Istanbul
+Turkije</ns2:volledigAdres>
+                           </ns2:bezoekLocatiePersoon>
+                           <!--Anonimisatie 'ns2:geslachtsnaam': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:geslachtsnaam>6ac96</ns2:geslachtsnaam>
+                           <!--Anonimisatie 'ns2:voornamen': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:voornamen>17e0a c50b</ns2:voornamen>
+                           <ns2:geslachtsaanduiding>
+                              <ns2:code>v</ns2:code>
+                              <ns2:omschrijving>Vrouwelijk</ns2:omschrijving>
+                              <ns2:referentieType>Geslacht</ns2:referentieType>
+                           </ns2:geslachtsaanduiding>
+                           <!--Anonimisatie 'ns2:geboorteplaats': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:geboorteplaats>d3bb13ec893ada</ns2:geboorteplaats>
+                           <ns2:geboorteland>
+                              <ns2:code>6043</ns2:code>
+                              <ns2:omschrijving>Turkije</ns2:omschrijving>
+                              <ns2:referentieType>Land</ns2:referentieType>
+                           </ns2:geboorteland>
+                           <!--Anonimisatie 'ns2:geboortedatum': datum is met behoud van vorm vervangen door een hash van de oorspronkelijke datum.--><ns2:geboortedatum>20230204</ns2:geboortedatum>
+                        </ns2:natuurlijkPersoon>
+                     </ns2:door>
+                     <ns2:functie>
+                        <ns2:code>02</ns2:code>
+                        <ns2:omschrijving>Bestuurder</ns2:omschrijving>
+                        <ns2:referentieType>FunctionarisRol</ns2:referentieType>
+                     </ns2:functie>
+                     <ns2:bevoegdheid>
+                        <ns2:registratie registratieTijdstip="20240304162304948">
+                           <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:soort>
+                           <ns2:code>azb</ns2:code>
+                           <ns2:omschrijving>Alleen/zelfstandig bevoegd</ns2:omschrijving>
+                           <ns2:referentieType>SoortBevoegdheidBestuurder</ns2:referentieType>
+                        </ns2:soort>
+                        <ns2:isBevoegdMetAnderePersonen>
+                           <ns2:code>N</ns2:code>
+                           <ns2:omschrijving>Nee</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:isBevoegdMetAnderePersonen>
+                     </ns2:bevoegdheid>
+                  </ns2:bestuursfunctie>
+               </ns2:heeft>
+               <ns2:heeft>
+                  <ns2:bestuursfunctie>
+                     <ns2:registratie registratieTijdstip="20240304162304948">
+                        <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:door>
+                        <ns2:natuurlijkPersoon>
+                           <ns2:extraElementen>
+<!--Anonimisatie 'ns2:extraElement': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:extraElement naam="achternaam">6ac96</ns2:extraElement>
+                           </ns2:extraElementen>
+                           <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+<!--Anonimisatie 'ns2:datumAanvang': datum is met behoud van vorm vervangen door een hash van de oorspronkelijke datum.--><ns2:datumAanvang>19830710</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <!--Anonimisatie 'ns2:volledigeNaam': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:volledigeNaam>d752e 0dde57c c8193</ns2:volledigeNaam>
+                           <ns2:bezoekLocatiePersoon>
+                              <ns2:registratie registratieTijdstip="20240304162304948"/>
+                              <ns2:afgeschermd>
+                                 <ns2:code>N</ns2:code>
+                                 <ns2:omschrijving>Nee</ns2:omschrijving>
+                                 <ns2:referentieType>geenRT</ns2:referentieType>
+                              </ns2:afgeschermd>
+                              <ns2:adres>
+                                 <ns2:buitenlandsAdres>
+                                    <ns2:straatHuisnummer>Sinanoba Mahallesi, Bektaș Çikmazi Sokak No: 5D</ns2:straatHuisnummer>
+                                    <ns2:postcodeWoonplaats>Büyükçekmece, Istanbul</ns2:postcodeWoonplaats>
+                                    <ns2:land>
+                                       <ns2:code>6043</ns2:code>
+                                       <ns2:omschrijving>Turkije</ns2:omschrijving>
+                                       <ns2:referentieType>Land</ns2:referentieType>
+                                    </ns2:land>
+                                 </ns2:buitenlandsAdres>
+                              </ns2:adres>
+                              <ns2:volledigAdres>Sinanoba Mahallesi, Bektaș Çikmazi Sokak No: 5D
+Büyükçekmece, Istanbul
+Turkije</ns2:volledigAdres>
+                           </ns2:bezoekLocatiePersoon>
+                           <!--Anonimisatie 'ns2:geslachtsnaam': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:geslachtsnaam>6ac96</ns2:geslachtsnaam>
+                           <!--Anonimisatie 'ns2:voornamen': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:voornamen>04404 e824806</ns2:voornamen>
+                           <ns2:geslachtsaanduiding>
+                              <ns2:code>m</ns2:code>
+                              <ns2:omschrijving>Mannelijk</ns2:omschrijving>
+                              <ns2:referentieType>Geslacht</ns2:referentieType>
+                           </ns2:geslachtsaanduiding>
+                           <!--Anonimisatie 'ns2:geboorteplaats': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:geboorteplaats>7f572646cd</ns2:geboorteplaats>
+                           <ns2:geboorteland>
+                              <ns2:code>6043</ns2:code>
+                              <ns2:omschrijving>Turkije</ns2:omschrijving>
+                              <ns2:referentieType>Land</ns2:referentieType>
+                           </ns2:geboorteland>
+                           <!--Anonimisatie 'ns2:geboortedatum': datum is met behoud van vorm vervangen door een hash van de oorspronkelijke datum.--><ns2:geboortedatum>19830710</ns2:geboortedatum>
+                        </ns2:natuurlijkPersoon>
+                     </ns2:door>
+                     <ns2:functie>
+                        <ns2:code>02</ns2:code>
+                        <ns2:omschrijving>Bestuurder</ns2:omschrijving>
+                        <ns2:referentieType>FunctionarisRol</ns2:referentieType>
+                     </ns2:functie>
+                     <ns2:bevoegdheid>
+                        <ns2:registratie registratieTijdstip="20240304162304948">
+                           <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:soort>
+                           <ns2:code>azb</ns2:code>
+                           <ns2:omschrijving>Alleen/zelfstandig bevoegd</ns2:omschrijving>
+                           <ns2:referentieType>SoortBevoegdheidBestuurder</ns2:referentieType>
+                        </ns2:soort>
+                        <ns2:isBevoegdMetAnderePersonen>
+                           <ns2:code>N</ns2:code>
+                           <ns2:omschrijving>Nee</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:isBevoegdMetAnderePersonen>
+                     </ns2:bevoegdheid>
+                  </ns2:bestuursfunctie>
+               </ns2:heeft>
+               <ns2:heeft>
+                  <ns2:overigeFunctionaris>
+                     <ns2:registratie registratieTijdstip="20240304162304948">
+                        <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:door>
+                        <ns2:buitenlandseVennootschap>
+                           <ns2:persoonRechtsvorm>Overige buitenlandse rechtspersoon of vennootschap</ns2:persoonRechtsvorm>
+                           <ns2:volledigeNaam>KESER Makina İmalat Montaj Sanayi ve Ticaret Limited Șirketi</ns2:volledigeNaam>
+                           <ns2:bezoekLocatiePersoon>
+                              <ns2:registratie registratieTijdstip="20240304162304948">
+                                 <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                              </ns2:registratie>
+                              <ns2:afgeschermd>
+                                 <ns2:code>N</ns2:code>
+                                 <ns2:omschrijving>Nee</ns2:omschrijving>
+                                 <ns2:referentieType>geenRT</ns2:referentieType>
+                              </ns2:afgeschermd>
+                              <ns2:adres>
+                                 <ns2:buitenlandsAdres>
+                                    <ns2:straatHuisnummer>19 Mayıs Mahallesi, Atatürk Caddesi, Saydağ Sokak No:4/A</ns2:straatHuisnummer>
+                                    <ns2:postcodeWoonplaats>34500 Büyükçekmece, Istanbul</ns2:postcodeWoonplaats>
+                                    <ns2:land>
+                                       <ns2:code>6043</ns2:code>
+                                       <ns2:omschrijving>Turkije</ns2:omschrijving>
+                                       <ns2:referentieType>Land</ns2:referentieType>
+                                    </ns2:land>
+                                 </ns2:buitenlandsAdres>
+                              </ns2:adres>
+                              <ns2:volledigAdres>19 Mayıs Mahallesi, Atatürk Caddesi, Saydağ Sokak No:4/A
+34500 Büyükçekmece, Istanbul
+Turkije</ns2:volledigAdres>
+                           </ns2:bezoekLocatiePersoon>
+                           <ns2:buitenlandseRegistratieGegevens>
+                              <ns2:naam>Regionale Administraties Handelsregister</ns2:naam>
+                              <ns2:plaats>İstanbul Ticaret Odası</ns2:plaats>
+                              <ns2:land>
+                                 <ns2:code>6043</ns2:code>
+                                 <ns2:omschrijving>Turkije</ns2:omschrijving>
+                                 <ns2:referentieType>Land</ns2:referentieType>
+                              </ns2:land>
+                              <ns2:inschrijfnummer>385218-0</ns2:inschrijfnummer>
+                              <ns2:buitenlandseRegistratie>Regionale Administraties Handelsregister
+İstanbul Ticaret Odası, Turkije
+Onder nummer 385218-0</ns2:buitenlandseRegistratie>
+                           </ns2:buitenlandseRegistratieGegevens>
+                           <ns2:landVanVestiging>
+                              <ns2:code>6043</ns2:code>
+                              <ns2:omschrijving>Turkije</ns2:omschrijving>
+                              <ns2:referentieType>Land</ns2:referentieType>
+                           </ns2:landVanVestiging>
+                        </ns2:buitenlandseVennootschap>
+                     </ns2:door>
+                     <ns2:functie>
+                        <ns2:code>08</ns2:code>
+                        <ns2:omschrijving>Enig aandeelhouder</ns2:omschrijving>
+                        <ns2:referentieType>FunctionarisRol</ns2:referentieType>
+                     </ns2:functie>
+                  </ns2:overigeFunctionaris>
+               </ns2:heeft>
+               <ns2:rsin>866295045</ns2:rsin>
+               <ns2:naamgeving>
+                  <ns2:registratie registratieTijdstip="20240304162304948">
+                     <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:naam>KESER Industrial Solutions B.V.</ns2:naam>
+               </ns2:naamgeving>
+               <ns2:rechtsvorm>
+                  <ns2:code>BV</ns2:code>
+                  <ns2:omschrijving>Besloten Vennootschap</ns2:omschrijving>
+                  <ns2:referentieType>Rechtsvorm</ns2:referentieType>
+               </ns2:rechtsvorm>
+               <ns2:statutaireZetel>Rotterdam</ns2:statutaireZetel>
+               <ns2:aanvangStatutaireZetel>20240304</ns2:aanvangStatutaireZetel>
+               <ns2:datumAkteOprichting>20240304</ns2:datumAkteOprichting>
+               <ns2:datumOprichting>20240304</ns2:datumOprichting>
+               <ns2:datumEersteInschrijvingHandelsregister>20240304</ns2:datumEersteInschrijvingHandelsregister>
+               <ns2:datumAkteStatutenwijziging>20240304</ns2:datumAkteStatutenwijziging>
+               <ns2:stelselInrichting>
+                  <ns2:code>D</ns2:code>
+                  <ns2:omschrijving>Dualistisch</ns2:omschrijving>
+                  <ns2:referentieType>StelselInrichting</ns2:referentieType>
+               </ns2:stelselInrichting>
+               <ns2:structuur>
+                  <ns2:code>GS</ns2:code>
+                  <ns2:omschrijving>Gewone structuur</ns2:omschrijving>
+                  <ns2:referentieType>RechtsvormStructuur</ns2:referentieType>
+               </ns2:structuur>
+               <ns2:geplaatstKapitaal>
+                  <ns2:registratie registratieTijdstip="20240304162304948">
+                     <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:bedrag>
+                     <ns2:waarde>100</ns2:waarde>
+                     <ns2:valuta>
+                        <ns2:code>EUR</ns2:code>
+                        <ns2:omschrijving>Euro</ns2:omschrijving>
+                        <ns2:referentieType>Valuta</ns2:referentieType>
+                     </ns2:valuta>
+                  </ns2:bedrag>
+               </ns2:geplaatstKapitaal>
+               <ns2:gestortKapitaal>
+                  <ns2:registratie registratieTijdstip="20240304162304948">
+                     <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:bedrag>
+                     <ns2:waarde>0</ns2:waarde>
+                     <ns2:valuta>
+                        <ns2:code>EUR</ns2:code>
+                        <ns2:omschrijving>Euro</ns2:omschrijving>
+                        <ns2:referentieType>Valuta</ns2:referentieType>
+                     </ns2:valuta>
+                  </ns2:bedrag>
+               </ns2:gestortKapitaal>
+               <ns2:bezoekLocatie>
+                  <ns2:registratie registratieTijdstip="20240304162304948">
+                     <ns2:datumAanvang>20240304</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:afgeschermd>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:afgeschermd>
+                  <ns2:adres>
+                     <ns2:binnenlandsAdres>
+                        <ns2:straatnaam>Buster Keatonstraat</ns2:straatnaam>
+                        <ns2:huisnummer>9</ns2:huisnummer>
+                        <ns2:postcode>
+                           <ns2:cijfercombinatie>1325</ns2:cijfercombinatie>
+                           <ns2:lettercombinatie>CJ</ns2:lettercombinatie>
+                        </ns2:postcode>
+                        <ns2:plaats>Almere</ns2:plaats>
+                        <ns2:bagId>
+                           <ns2:identificatieNummeraanduiding>0034200000041060</ns2:identificatieNummeraanduiding>
+                           <ns2:identificatieAdresseerbaarObject>0034010000067741</ns2:identificatieAdresseerbaarObject>
+                        </ns2:bagId>
+                     </ns2:binnenlandsAdres>
+                  </ns2:adres>
+                  <ns2:volledigAdres>Buster Keatonstraat 9
+1325CJ Almere</ns2:volledigAdres>
+               </ns2:bezoekLocatie>
+            </ns2:rechtspersoon>
+         </ns2:heeftAlsEigenaar>
+      </ns2:maatschappelijkeActiviteit>
+   </product>
+</ophalenInschrijvingResponse>

--- a/brmo-loader/src/test/resources/nhr-v3/289547.anon.xml
+++ b/brmo-loader/src/test/resources/nhr-v3/289547.anon.xml
@@ -1,0 +1,509 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Geanonimiseerd door B3Partners BV op 2025-09-09+02:00, zie commentaar in bericht.-->
+<ophalenInschrijvingResponse xmlns="http://schemas.kvk.nl/schemas/hrip/dataservice/2015/02"
+                             xmlns:ns2="http://schemas.kvk.nl/schemas/hrip/catalogus/2015/02"
+                             peilmoment="20250818103657584">
+   <meldingen>
+      <informatie>
+         <code>IPD0000</code>
+         <omschrijving>Het product is succesvol geproduceerd</omschrijving>
+         <referentie>97113131</referentie>
+      </informatie>
+   </meldingen>
+   <product>
+      <ns2:maatschappelijkeActiviteit>
+         <ns2:registratie registratieTijdstip="20250425153458627">
+            <ns2:datumAanvang>20250319</ns2:datumAanvang>
+         </ns2:registratie>
+         <ns2:kvkNummer>97113131</ns2:kvkNummer>
+         <ns2:nonMailing>
+            <ns2:code>J</ns2:code>
+            <ns2:omschrijving>Ja</ns2:omschrijving>
+            <ns2:referentieType>geenRT</ns2:referentieType>
+         </ns2:nonMailing>
+         <ns2:incidenteelUitlenenArbeidskrachten>
+            <ns2:code>N</ns2:code>
+            <ns2:omschrijving>Nee</ns2:omschrijving>
+            <ns2:referentieType>geenRT</ns2:referentieType>
+         </ns2:incidenteelUitlenenArbeidskrachten>
+         <ns2:bezoekLocatie>
+            <ns2:registratie registratieTijdstip="20250425153458627">
+               <ns2:datumAanvang>20250319</ns2:datumAanvang>
+            </ns2:registratie>
+            <ns2:afgeschermd>
+               <ns2:code>N</ns2:code>
+               <ns2:omschrijving>Nee</ns2:omschrijving>
+               <ns2:referentieType>geenRT</ns2:referentieType>
+            </ns2:afgeschermd>
+            <ns2:adres>
+               <ns2:binnenlandsAdres>
+                  <ns2:straatnaam>Brancusistraat</ns2:straatnaam>
+                  <ns2:huisnummer>27</ns2:huisnummer>
+                  <ns2:postcode>
+                     <ns2:cijfercombinatie>1328</ns2:cijfercombinatie>
+                     <ns2:lettercombinatie>ND</ns2:lettercombinatie>
+                  </ns2:postcode>
+                  <ns2:plaats>Almere</ns2:plaats>
+                  <ns2:bagId>
+                     <ns2:identificatieNummeraanduiding>0034200000070603</ns2:identificatieNummeraanduiding>
+                     <ns2:identificatieAdresseerbaarObject>0034010000028825</ns2:identificatieAdresseerbaarObject>
+                  </ns2:bagId>
+               </ns2:binnenlandsAdres>
+            </ns2:adres>
+            <ns2:volledigAdres>Brancusistraat 27
+1328ND Almere</ns2:volledigAdres>
+         </ns2:bezoekLocatie>
+         <ns2:postLocatie>
+            <ns2:registratie registratieTijdstip="20250425153458627">
+               <ns2:datumAanvang>20250319</ns2:datumAanvang>
+            </ns2:registratie>
+            <ns2:afgeschermd>
+               <ns2:code>N</ns2:code>
+               <ns2:omschrijving>Nee</ns2:omschrijving>
+               <ns2:referentieType>geenRT</ns2:referentieType>
+            </ns2:afgeschermd>
+            <ns2:adres>
+               <ns2:binnenlandsAdres>
+                  <ns2:straatnaam>Brancusistraat</ns2:straatnaam>
+                  <ns2:huisnummer>27</ns2:huisnummer>
+                  <ns2:postcode>
+                     <ns2:cijfercombinatie>1328</ns2:cijfercombinatie>
+                     <ns2:lettercombinatie>ND</ns2:lettercombinatie>
+                  </ns2:postcode>
+                  <ns2:plaats>Almere</ns2:plaats>
+                  <ns2:bagId>
+                     <ns2:identificatieNummeraanduiding>0034200000070603</ns2:identificatieNummeraanduiding>
+                     <ns2:identificatieAdresseerbaarObject>0034010000028825</ns2:identificatieAdresseerbaarObject>
+                  </ns2:bagId>
+               </ns2:binnenlandsAdres>
+            </ns2:adres>
+            <ns2:volledigAdres>Brancusistraat 27
+1328ND Almere</ns2:volledigAdres>
+         </ns2:postLocatie>
+         <ns2:communicatiegegevens>
+            <ns2:registratie registratieTijdstip="20250425153458627">
+               <ns2:datumAanvang>20250319</ns2:datumAanvang>
+            </ns2:registratie>
+            <ns2:communicatienummer>
+               <ns2:toegangscode>+31</ns2:toegangscode>
+               <ns2:nummer>0621917214</ns2:nummer>
+               <ns2:soort>
+                  <ns2:code>T</ns2:code>
+                  <ns2:omschrijving>Telefoon</ns2:omschrijving>
+               </ns2:soort>
+            </ns2:communicatienummer>
+            <ns2:emailAdres>nelson@atmathews.com</ns2:emailAdres>
+            <ns2:domeinNaam>www.atmathews.com</ns2:domeinNaam>
+         </ns2:communicatiegegevens>
+         <ns2:naam>OMG@Mathews Ltd</ns2:naam>
+         <ns2:manifesteertZichAls>
+            <ns2:relatieRegistratie registratieTijdstip="20250425153458627">
+               <ns2:datumAanvang>20250319</ns2:datumAanvang>
+            </ns2:relatieRegistratie>
+            <ns2:onderneming>
+               <ns2:registratie registratieTijdstip="20250425153458627">
+                  <ns2:datumAanvang>20250319</ns2:datumAanvang>
+               </ns2:registratie>
+               <ns2:kvkNummer>97113131</ns2:kvkNummer>
+               <ns2:sbiActiviteit>
+                  <ns2:registratie registratieTijdstip="20250425153458627">
+                     <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:sbiCode>
+                     <ns2:code>4637</ns2:code>
+                     <ns2:omschrijving>Groothandel in koffie, thee, cacao en specerijen (geen ruwe)</ns2:omschrijving>
+                     <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                  </ns2:sbiCode>
+                  <ns2:isHoofdactiviteit>
+                     <ns2:code>J</ns2:code>
+                     <ns2:omschrijving>Ja</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:isHoofdactiviteit>
+               </ns2:sbiActiviteit>
+               <ns2:voltijdWerkzamePersonen>1</ns2:voltijdWerkzamePersonen>
+               <ns2:deeltijdWerkzamePersonen>0</ns2:deeltijdWerkzamePersonen>
+               <ns2:totaalWerkzamePersonen>1</ns2:totaalWerkzamePersonen>
+               <ns2:handeltOnder>
+                  <ns2:handelsnaam>
+                     <ns2:registratie registratieTijdstip="20250425153458627">
+                        <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:naam>OMG@Mathews Ltd</ns2:naam>
+                     <ns2:volgorde>0</ns2:volgorde>
+                  </ns2:handelsnaam>
+               </ns2:handeltOnder>
+               <ns2:wordtUitgeoefendIn>
+                  <ns2:relatieRegistratie registratieTijdstip="20250425153458627">
+                     <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                  </ns2:relatieRegistratie>
+                  <ns2:commercieleVestiging>
+                     <ns2:registratie registratieTijdstip="20250425153458627">
+                        <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:vestigingsnummer>000062377655</ns2:vestigingsnummer>
+                     <ns2:bezoekLocatie>
+                        <ns2:registratie registratieTijdstip="20250425153458627">
+                           <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:afgeschermd>
+                           <ns2:code>N</ns2:code>
+                           <ns2:omschrijving>Nee</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:afgeschermd>
+                        <ns2:adres>
+                           <ns2:binnenlandsAdres>
+                              <ns2:straatnaam>Brancusistraat</ns2:straatnaam>
+                              <ns2:huisnummer>27</ns2:huisnummer>
+                              <ns2:postcode>
+                                 <ns2:cijfercombinatie>1328</ns2:cijfercombinatie>
+                                 <ns2:lettercombinatie>ND</ns2:lettercombinatie>
+                              </ns2:postcode>
+                              <ns2:plaats>Almere</ns2:plaats>
+                              <ns2:bagId>
+                                 <ns2:identificatieNummeraanduiding>0034200000070603</ns2:identificatieNummeraanduiding>
+                                 <ns2:identificatieAdresseerbaarObject>0034010000028825</ns2:identificatieAdresseerbaarObject>
+                              </ns2:bagId>
+                           </ns2:binnenlandsAdres>
+                        </ns2:adres>
+                        <ns2:volledigAdres>Brancusistraat 27
+1328ND Almere</ns2:volledigAdres>
+                     </ns2:bezoekLocatie>
+                     <ns2:communicatiegegevens>
+                        <ns2:registratie registratieTijdstip="20250425153458627">
+                           <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:communicatienummer>
+                           <ns2:toegangscode>+31</ns2:toegangscode>
+                           <ns2:nummer>0621917214</ns2:nummer>
+                           <ns2:soort>
+                              <ns2:code>T</ns2:code>
+                              <ns2:omschrijving>Telefoon</ns2:omschrijving>
+                           </ns2:soort>
+                        </ns2:communicatienummer>
+                        <ns2:emailAdres>nelson@atmathews.com</ns2:emailAdres>
+                        <ns2:domeinNaam>www.atmathews.com</ns2:domeinNaam>
+                     </ns2:communicatiegegevens>
+                     <ns2:eersteHandelsnaam>OMG@Mathews Ltd</ns2:eersteHandelsnaam>
+                     <ns2:voltijdWerkzamePersonen>1</ns2:voltijdWerkzamePersonen>
+                     <ns2:deeltijdWerkzamePersonen>0</ns2:deeltijdWerkzamePersonen>
+                     <ns2:totaalWerkzamePersonen>1</ns2:totaalWerkzamePersonen>
+                     <ns2:activiteiten>
+                        <ns2:omschrijving>Groothandel, daaronder begrepen de im- en export, in thee en specerijen.</ns2:omschrijving>
+                        <ns2:sbiActiviteit>
+                           <ns2:registratie registratieTijdstip="20250425153458627">
+                              <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <ns2:sbiCode>
+                              <ns2:code>4637</ns2:code>
+                              <ns2:omschrijving>Groothandel in koffie, thee, cacao en specerijen (geen ruwe)</ns2:omschrijving>
+                              <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                           </ns2:sbiCode>
+                           <ns2:isHoofdactiviteit>
+                              <ns2:code>J</ns2:code>
+                              <ns2:omschrijving>Ja</ns2:omschrijving>
+                              <ns2:referentieType>geenRT</ns2:referentieType>
+                           </ns2:isHoofdactiviteit>
+                        </ns2:sbiActiviteit>
+                        <ns2:exporteert>
+                           <ns2:code>J</ns2:code>
+                           <ns2:omschrijving>Ja</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:exporteert>
+                        <ns2:importeert>
+                           <ns2:code>J</ns2:code>
+                           <ns2:omschrijving>Ja</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:importeert>
+                     </ns2:activiteiten>
+                     <ns2:handeltOnder>
+                        <ns2:relatieRegistratie registratieTijdstip="20250425153458627">
+                           <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                        </ns2:relatieRegistratie>
+                        <ns2:handelsnaam>
+                           <ns2:registratie registratieTijdstip="20250425153458627">
+                              <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <ns2:naam>OMG@Mathews Ltd</ns2:naam>
+                           <ns2:volgorde>0</ns2:volgorde>
+                        </ns2:handelsnaam>
+                     </ns2:handeltOnder>
+                  </ns2:commercieleVestiging>
+               </ns2:wordtUitgeoefendIn>
+            </ns2:onderneming>
+         </ns2:manifesteertZichAls>
+         <ns2:wordtGeleidVanuit>
+            <ns2:commercieleVestiging>
+               <ns2:registratie registratieTijdstip="20250425153458627">
+                  <ns2:datumAanvang>20250319</ns2:datumAanvang>
+               </ns2:registratie>
+               <ns2:vestigingsnummer>000062377655</ns2:vestigingsnummer>
+               <ns2:bezoekLocatie>
+                  <ns2:registratie registratieTijdstip="20250425153458627">
+                     <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:afgeschermd>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:afgeschermd>
+                  <ns2:adres>
+                     <ns2:binnenlandsAdres>
+                        <ns2:straatnaam>Brancusistraat</ns2:straatnaam>
+                        <ns2:huisnummer>27</ns2:huisnummer>
+                        <ns2:postcode>
+                           <ns2:cijfercombinatie>1328</ns2:cijfercombinatie>
+                           <ns2:lettercombinatie>ND</ns2:lettercombinatie>
+                        </ns2:postcode>
+                        <ns2:plaats>Almere</ns2:plaats>
+                        <ns2:bagId>
+                           <ns2:identificatieNummeraanduiding>0034200000070603</ns2:identificatieNummeraanduiding>
+                           <ns2:identificatieAdresseerbaarObject>0034010000028825</ns2:identificatieAdresseerbaarObject>
+                        </ns2:bagId>
+                     </ns2:binnenlandsAdres>
+                  </ns2:adres>
+                  <ns2:volledigAdres>Brancusistraat 27
+1328ND Almere</ns2:volledigAdres>
+               </ns2:bezoekLocatie>
+               <ns2:communicatiegegevens>
+                  <ns2:registratie registratieTijdstip="20250425153458627">
+                     <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:communicatienummer>
+                     <ns2:toegangscode>+31</ns2:toegangscode>
+                     <ns2:nummer>0621917214</ns2:nummer>
+                     <ns2:soort>
+                        <ns2:code>T</ns2:code>
+                        <ns2:omschrijving>Telefoon</ns2:omschrijving>
+                     </ns2:soort>
+                  </ns2:communicatienummer>
+                  <ns2:emailAdres>nelson@atmathews.com</ns2:emailAdres>
+                  <ns2:domeinNaam>www.atmathews.com</ns2:domeinNaam>
+               </ns2:communicatiegegevens>
+               <ns2:eersteHandelsnaam>OMG@Mathews Ltd</ns2:eersteHandelsnaam>
+               <ns2:voltijdWerkzamePersonen>1</ns2:voltijdWerkzamePersonen>
+               <ns2:deeltijdWerkzamePersonen>0</ns2:deeltijdWerkzamePersonen>
+               <ns2:totaalWerkzamePersonen>1</ns2:totaalWerkzamePersonen>
+               <ns2:activiteiten>
+                  <ns2:omschrijving>Groothandel, daaronder begrepen de im- en export, in thee en specerijen.</ns2:omschrijving>
+                  <ns2:sbiActiviteit>
+                     <ns2:registratie registratieTijdstip="20250425153458627">
+                        <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:sbiCode>
+                        <ns2:code>4637</ns2:code>
+                        <ns2:omschrijving>Groothandel in koffie, thee, cacao en specerijen (geen ruwe)</ns2:omschrijving>
+                        <ns2:referentieType>ActiviteitCode</ns2:referentieType>
+                     </ns2:sbiCode>
+                     <ns2:isHoofdactiviteit>
+                        <ns2:code>J</ns2:code>
+                        <ns2:omschrijving>Ja</ns2:omschrijving>
+                        <ns2:referentieType>geenRT</ns2:referentieType>
+                     </ns2:isHoofdactiviteit>
+                  </ns2:sbiActiviteit>
+                  <ns2:exporteert>
+                     <ns2:code>J</ns2:code>
+                     <ns2:omschrijving>Ja</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:exporteert>
+                  <ns2:importeert>
+                     <ns2:code>J</ns2:code>
+                     <ns2:omschrijving>Ja</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:importeert>
+               </ns2:activiteiten>
+               <ns2:handeltOnder>
+                  <ns2:relatieRegistratie registratieTijdstip="20250425153458627">
+                     <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                  </ns2:relatieRegistratie>
+                  <ns2:handelsnaam>
+                     <ns2:registratie registratieTijdstip="20250425153458627">
+                        <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:naam>OMG@Mathews Ltd</ns2:naam>
+                     <ns2:volgorde>0</ns2:volgorde>
+                  </ns2:handelsnaam>
+               </ns2:handeltOnder>
+            </ns2:commercieleVestiging>
+         </ns2:wordtGeleidVanuit>
+         <ns2:heeftAlsEigenaar>
+            <ns2:relatieRegistratie registratieTijdstip="20250425153458627">
+               <ns2:datumAanvang>20250319</ns2:datumAanvang>
+            </ns2:relatieRegistratie>
+            <ns2:buitenlandseVennootschap>
+               <ns2:registratie registratieTijdstip="20250425153458627"/>
+               <ns2:persoonRechtsvorm>Kapitaalvennootschap buiten EER</ns2:persoonRechtsvorm>
+               <ns2:volledigeNaam>OMG@Mathews Ltd</ns2:volledigeNaam>
+               <ns2:uitgebreideRechtsvorm>Private limited company (Verenigd Koninkrijk); volgens opgave een formeel buitenlandse vennootschap</ns2:uitgebreideRechtsvorm>
+               <ns2:heeft>
+                  <ns2:bestuursfunctie>
+                     <ns2:registratie registratieTijdstip="20250425153458627">
+                        <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                     </ns2:registratie>
+                     <ns2:functietitel>
+                        <ns2:registratie registratieTijdstip="20250425153458627">
+                           <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:titel>Director</ns2:titel>
+                        <ns2:isStatutaireTitel>
+                           <ns2:code>N</ns2:code>
+                           <ns2:omschrijving>Nee</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:isStatutaireTitel>
+                     </ns2:functietitel>
+                     <ns2:door>
+                        <ns2:natuurlijkPersoon>
+                           <ns2:extraElementen>
+<!--Anonimisatie 'ns2:extraElement': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:extraElement naam="achternaam">eb65d1</ns2:extraElement>
+                           </ns2:extraElementen>
+                           <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend">
+<!--Anonimisatie 'ns2:datumAanvang': datum is met behoud van vorm vervangen door een hash van de oorspronkelijke datum.--><ns2:datumAanvang>19440429</ns2:datumAanvang>
+                           </ns2:registratie>
+                           <!--Anonimisatie 'ns2:volledigeNaam': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:volledigeNaam>8158e1 80cda29 77307680 9ec898</ns2:volledigeNaam>
+                           <ns2:bezoekLocatiePersoon>
+                              <ns2:registratie registratieTijdstipNoValue="vastgesteldOnbekend"/>
+                              <ns2:afgeschermd>
+                                 <ns2:code>N</ns2:code>
+                                 <ns2:omschrijving>Nee</ns2:omschrijving>
+                                 <ns2:referentieType>geenRT</ns2:referentieType>
+                              </ns2:afgeschermd>
+                              <ns2:adres>
+                                 <ns2:binnenlandsAdres>
+                                    <ns2:straatnaam>Brancusistraat</ns2:straatnaam>
+                                    <ns2:huisnummer>27</ns2:huisnummer>
+                                    <ns2:postcode>
+                                       <ns2:cijfercombinatie>1328</ns2:cijfercombinatie>
+                                       <ns2:lettercombinatie>ND</ns2:lettercombinatie>
+                                    </ns2:postcode>
+                                    <ns2:plaats>Almere</ns2:plaats>
+                                    <ns2:bagId>
+                                       <ns2:identificatieNummeraanduiding>0034200000070603</ns2:identificatieNummeraanduiding>
+                                       <ns2:identificatieAdresseerbaarObject>0034010000028825</ns2:identificatieAdresseerbaarObject>
+                                    </ns2:bagId>
+                                 </ns2:binnenlandsAdres>
+                              </ns2:adres>
+                              <ns2:volledigAdres>Brancusistraat 27
+1328ND Almere</ns2:volledigAdres>
+                           </ns2:bezoekLocatiePersoon>
+                           <!--Anonimisatie 'ns2:bsn': getal is met behoud van vorm vervangen door een hash van van het oorspronkelijke getal.--><ns2:bsn>608236862</ns2:bsn>
+                           <!--Anonimisatie 'ns2:geslachtsnaam': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:geslachtsnaam>eb65d1</ns2:geslachtsnaam>
+                           <!--Anonimisatie 'ns2:voornamen': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:voornamen>0a24a4 7524718 15fa1ab3</ns2:voornamen>
+                           <ns2:geslachtsaanduiding>
+                              <ns2:code>m</ns2:code>
+                              <ns2:omschrijving>Mannelijk</ns2:omschrijving>
+                              <ns2:referentieType>Geslacht</ns2:referentieType>
+                           </ns2:geslachtsaanduiding>
+                           <!--Anonimisatie 'ns2:geboorteplaats': waarde is vervangen door een hash van de oorspronkelijke waarde met dezelfde lengte.--><ns2:geboorteplaats>0013c01fe</ns2:geboorteplaats>
+                           <ns2:geboorteland>
+                              <ns2:code>6030</ns2:code>
+                              <ns2:omschrijving>Nederland</ns2:omschrijving>
+                              <ns2:referentieType>Land</ns2:referentieType>
+                           </ns2:geboorteland>
+                           <!--Anonimisatie 'ns2:geboortedatum': datum is met behoud van vorm vervangen door een hash van de oorspronkelijke datum.--><ns2:geboortedatum>19440429</ns2:geboortedatum>
+                        </ns2:natuurlijkPersoon>
+                     </ns2:door>
+                     <ns2:functie>
+                        <ns2:code>02</ns2:code>
+                        <ns2:omschrijving>Bestuurder</ns2:omschrijving>
+                        <ns2:referentieType>FunctionarisRol</ns2:referentieType>
+                     </ns2:functie>
+                     <ns2:bevoegdheid>
+                        <ns2:registratie registratieTijdstip="20250425153458627">
+                           <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                        </ns2:registratie>
+                        <ns2:soort>
+                           <ns2:code>azb</ns2:code>
+                           <ns2:omschrijving>Alleen/zelfstandig bevoegd</ns2:omschrijving>
+                           <ns2:referentieType>SoortBevoegdheidBestuurder</ns2:referentieType>
+                        </ns2:soort>
+                        <ns2:isBevoegdMetAnderePersonen>
+                           <ns2:code>N</ns2:code>
+                           <ns2:omschrijving>Nee</ns2:omschrijving>
+                           <ns2:referentieType>geenRT</ns2:referentieType>
+                        </ns2:isBevoegdMetAnderePersonen>
+                     </ns2:bevoegdheid>
+                  </ns2:bestuursfunctie>
+               </ns2:heeft>
+               <ns2:rsin>867915602</ns2:rsin>
+               <ns2:naamgeving>
+                  <ns2:registratie registratieTijdstip="20250425153458627"/>
+                  <ns2:naam>OMG@Mathews Ltd</ns2:naam>
+               </ns2:naamgeving>
+               <ns2:buitenlandseRegistratieGegevens>
+                  <ns2:naam>Companies Registration Office (England and Wales)</ns2:naam>
+                  <ns2:plaats>Cardiff</ns2:plaats>
+                  <ns2:land>
+                     <ns2:code>6039</ns2:code>
+                     <ns2:omschrijving>Verenigd Koninkrijk</ns2:omschrijving>
+                     <ns2:referentieType>Land</ns2:referentieType>
+                  </ns2:land>
+                  <ns2:inschrijfnummer>16328228</ns2:inschrijfnummer>
+                  <ns2:buitenlandseRegistratie>Companies Registration Office (England and Wales)
+Cardiff, Verenigd Koninkrijk
+Onder nummer 16328228</ns2:buitenlandseRegistratie>
+               </ns2:buitenlandseRegistratieGegevens>
+               <ns2:landVanOprichting>
+                  <ns2:code>6039</ns2:code>
+                  <ns2:omschrijving>Verenigd Koninkrijk</ns2:omschrijving>
+                  <ns2:referentieType>Land</ns2:referentieType>
+               </ns2:landVanOprichting>
+               <ns2:landVanVestiging>
+                  <ns2:code>6039</ns2:code>
+                  <ns2:omschrijving>Verenigd Koninkrijk</ns2:omschrijving>
+                  <ns2:referentieType>Land</ns2:referentieType>
+               </ns2:landVanVestiging>
+               <ns2:geplaatstKapitaal>
+                  <ns2:registratie registratieTijdstip="20250425153458627"/>
+                  <ns2:bedrag>
+                     <ns2:waarde>1</ns2:waarde>
+                     <ns2:valuta>
+                        <ns2:code>EUR</ns2:code>
+                        <ns2:omschrijving>Euro</ns2:omschrijving>
+                        <ns2:referentieType>Valuta</ns2:referentieType>
+                     </ns2:valuta>
+                  </ns2:bedrag>
+               </ns2:geplaatstKapitaal>
+               <ns2:buitenlandseVennootschapGegevens>
+                  <ns2:registratie registratieTijdstip="20250425153458627"/>
+                  <ns2:omschrijvingRechtsvorm>Private limited company</ns2:omschrijvingRechtsvorm>
+                  <ns2:datumEersteInschrijvingBuitenland>20250319</ns2:datumEersteInschrijvingBuitenland>
+                  <ns2:zetel>Doncaster</ns2:zetel>
+                  <ns2:rechtsvormcategorie>
+                     <ns2:code>0002</ns2:code>
+                     <ns2:omschrijving>Kapitaalvennootschap buiten EER</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:rechtsvormcategorie>
+                  <ns2:datumFormeelBuitenlandsSinds>20250319</ns2:datumFormeelBuitenlandsSinds>
+                  <ns2:datumAkteOprichting>20250319</ns2:datumAkteOprichting>
+               </ns2:buitenlandseVennootschapGegevens>
+               <ns2:bezoekLocatie>
+                  <ns2:registratie registratieTijdstip="20250425153458627">
+                     <ns2:datumAanvang>20250319</ns2:datumAanvang>
+                  </ns2:registratie>
+                  <ns2:afgeschermd>
+                     <ns2:code>N</ns2:code>
+                     <ns2:omschrijving>Nee</ns2:omschrijving>
+                     <ns2:referentieType>geenRT</ns2:referentieType>
+                  </ns2:afgeschermd>
+                  <ns2:adres>
+                     <ns2:binnenlandsAdres>
+                        <ns2:straatnaam>Brancusistraat</ns2:straatnaam>
+                        <ns2:huisnummer>27</ns2:huisnummer>
+                        <ns2:postcode>
+                           <ns2:cijfercombinatie>1328</ns2:cijfercombinatie>
+                           <ns2:lettercombinatie>ND</ns2:lettercombinatie>
+                        </ns2:postcode>
+                        <ns2:plaats>Almere</ns2:plaats>
+                        <ns2:bagId>
+                           <ns2:identificatieNummeraanduiding>0034200000070603</ns2:identificatieNummeraanduiding>
+                           <ns2:identificatieAdresseerbaarObject>0034010000028825</ns2:identificatieAdresseerbaarObject>
+                        </ns2:bagId>
+                     </ns2:binnenlandsAdres>
+                  </ns2:adres>
+                  <ns2:volledigAdres>Brancusistraat 27
+1328ND Almere</ns2:volledigAdres>
+               </ns2:bezoekLocatie>
+            </ns2:buitenlandseVennootschap>
+         </ns2:heeftAlsEigenaar>
+      </ns2:maatschappelijkeActiviteit>
+   </product>
+</ophalenInschrijvingResponse>


### PR DESCRIPTION
- [x] maak verwerking van buitenlands bedrijf met `+` in de naam mogelijk
- [x] maak verwerking van buitenlands bedrijf met `"` in de naam mogelijk
- [x] maak verwerking van buitenlands bedrijf met `Ș` in de naam mogelijk
- [x] maak verwerking van buitenlands bedrijf met `@` en/of `?` in de naam mogelijk

resolves [BRMO-419]

[BRMO-419]: https://b3partners.atlassian.net/browse/BRMO-419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ