### PR TITLE
[BRMO-431] Voeg nieuwe G4 root certificaten toe in de GDS2 truststore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,7 +380,7 @@
             <dependency>
                 <groupId>nl.b3p</groupId>
                 <artifactId>kadaster-gds2</artifactId>
-                <version>4.1</version>
+                <version>4.2</version>
             </dependency>
             <!-- J2EE dependencies en stripes -->
             <dependency>


### PR DESCRIPTION
Update kadaster-gds2 lib met daarin de nieuwe G4 root certificaten, zie: https://github.com/B3Partners/kadaster-gds2/releases#release-kadaster-gds2-4.2